### PR TITLE
Add MCP server `token_api_thegraph_com`

### DIFF
--- a/servers/token_api_thegraph_com/.npmignore
+++ b/servers/token_api_thegraph_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/token_api_thegraph_com/README.md
+++ b/servers/token_api_thegraph_com/README.md
@@ -1,0 +1,60 @@
+# @open-mcp/token_api_thegraph_com
+
+## MCP client config
+
+Add the following to `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "token_api_thegraph_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/token_api_thegraph_com"],
+      "env": {
+        "API_KEY": "..."
+      }
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `API_KEY`
+
+## Tools
+
+### getbalancesevmbyaddress
+
+### gettransfersevmbyaddress
+
+### getholdersevmbycontract
+
+### gettokensevmbycontract
+
+### getohlcpricesevmbycontract
+
+### gethealth
+
+### getversion
+
+### getnetworks
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/token_api_thegraph_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/token_api_thegraph_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`

--- a/servers/token_api_thegraph_com/package.json
+++ b/servers/token_api_thegraph_com/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/token_api_thegraph_com",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "token_api_thegraph_com": "./build/index.js"
+  },
+  "files": [
+    "build"
+  ],
+  "scripts": {
+    "clean": "rm -rf build",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 build/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.9",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/token_api_thegraph_com/src/constants.ts
+++ b/servers/token_api_thegraph_com/src/constants.ts
@@ -1,0 +1,12 @@
+export const SERVER_NAME = "token_api_thegraph_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./operations/getbalancesevmbyaddress.js",
+  "./operations/gettransfersevmbyaddress.js",
+  "./operations/getholdersevmbycontract.js",
+  "./operations/gettokensevmbycontract.js",
+  "./operations/getohlcpricesevmbycontract.js",
+  "./operations/gethealth.js",
+  "./operations/getversion.js",
+  "./operations/getnetworks.js"
+]

--- a/servers/token_api_thegraph_com/src/index.ts
+++ b/servers/token_api_thegraph_com/src/index.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+  } = operation
+
+  if (
+    !baseUrl ||
+    !opPath ||
+    !method ||
+    !toolName ||
+    // !toolDescription ||
+    !inputParams
+  ) {
+    throw new Error(
+      `Required imports from '${operationFileRelativePath}' are undefined`
+    )
+  }
+
+  if (baseUrl.endsWith("/")) {
+    throw new Error("baseUrl should not end with trailing slash")
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (params) => {
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        typeof value === "object" ? JSON.stringify(value) : value.toString()
+      )
+    }
+
+    const url = new URL(`${baseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(
+        key,
+        typeof value === "undefined"
+          ? ""
+          : typeof value === "object"
+          ? JSON.stringify(value)
+          : value.toString()
+      )
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+async function main() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error in main():", error)
+  process.exit(1)
+})

--- a/servers/token_api_thegraph_com/src/lib.ts
+++ b/servers/token_api_thegraph_com/src/lib.ts
@@ -1,0 +1,23 @@
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}

--- a/servers/token_api_thegraph_com/src/operations/acceptinvite.ts
+++ b/servers/token_api_thegraph_com/src/operations/acceptinvite.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `acceptinvite`
+export const toolDescription = `Accept invite`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/invites/token/{inviteToken}/accept`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "inviteToken": z.string().describe("The public token for the invite. This token is shared with the invitee.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/acceptrequest.ts
+++ b/servers/token_api_thegraph_com/src/operations/acceptrequest.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `acceptrequest`
+export const toolDescription = `Accept request`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/v2024-07-01/access/{resourceType}/{resourceId}/requests/{requestId}/accept`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "requestId": z.string().describe("The ID of the request.") }).optional(), "body": z.object({ "roleNames": z.array(z.string()).optional() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/adddefaultroletousers.ts
+++ b/servers/token_api_thegraph_com/src/operations/adddefaultroletousers.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `adddefaultroletousers`
+export const toolDescription = `Apply organization default role to all users.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/organization/{resourceId}/users/roles/default`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/addroletouser.ts
+++ b/servers/token_api_thegraph_com/src/operations/addroletouser.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `addroletouser`
+export const toolDescription = `Add a role to a user.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/users/{sanityUserId}/roles/{roleName}`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "sanityUserId": z.string().describe("The User ID"), "roleName": z.string().describe("The role name.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/checkuserpermissions.ts
+++ b/servers/token_api_thegraph_com/src/operations/checkuserpermissions.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `checkuserpermissions`
+export const toolDescription = `Check if current user has specified permissions`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/user-permissions/me/check`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "permissions": z.array(z.string()).describe("An array of permissions to check") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/createinvite.ts
+++ b/servers/token_api_thegraph_com/src/operations/createinvite.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createinvite`
+export const toolDescription = `Create invite`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/invites`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "body": z.object({ "email": z.string(), "role": z.string() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/createpermission.ts
+++ b/servers/token_api_thegraph_com/src/operations/createpermission.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createpermission`
+export const toolDescription = `Create a permission.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/permissions`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "body": z.object({ "type": z.enum(["sanity.document.filter","sanity.document.filter.mode","sanity.organization","sanity.organization.legal","sanity.organization.members","sanity.organization.projects","sanity.organization.roles","sanity.organization.sso","sanity.organization.tokens","sanity.project","sanity.project.cors","sanity.project.datasets","sanity.project.graphql","sanity.project.members","sanity.project.roles","sanity.project.tags","sanity.project.tokens","sanity.project.usage","sanity.project.webhooks"]).describe("The resource for the permission."), "name": z.string().describe("The name of the permission resource. A unique identifier for a permission."), "title": z.string().describe("A human-readable title of the permission resource. This is used for display purposes."), "description": z.string().describe("The description of the permission resource."), "config": z.record(z.any()).describe("Some permissions allow for additional configuration when used with document permissions. Accepts a groq filter or a dataset name.").optional() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/createrequest.ts
+++ b/servers/token_api_thegraph_com/src/operations/createrequest.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createrequest`
+export const toolDescription = `Create a new Request`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/v2024-07-01/access/{resourceType}/{resourceId}/requests`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "body": z.object({ "note": z.string().optional(), "requestUrl": z.string().describe("Optional URL to redirect the user to after their request has been accepted. Do not include PII or other confidential information.\n").optional(), "requestedRole": z.string().describe("Optional role requested by the user. The approver can assign a different role, but this is just a suggestion. If the role does not exist, the request will still be created and no validation on the role will be done.\n").optional(), "type": z.enum(["access","role"]).describe("The type of request.").optional() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/createrobot.ts
+++ b/servers/token_api_thegraph_com/src/operations/createrobot.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createrobot`
+export const toolDescription = `Create robot and associated token`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/robots`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "body": z.object({ "label": z.string().describe("A human-readable label for the robot."), "memberships": z.array(z.object({ "addedAt": z.string().datetime({ offset: true }).optional(), "resourceType": z.string(), "resourceId": z.string(), "roleNames": z.array(z.string()), "lastSeenAt": z.string().datetime({ offset: true }).nullable().optional(), "resourceUserId": z.string().nullable().describe("An alternative ID for the user in the resource. Only present for project memberships. That is, a user can be assigned to multiple projects, and each project will have a different resourceUserId to reference the same user.").optional() })) }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/createrole.ts
+++ b/servers/token_api_thegraph_com/src/operations/createrole.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createrole`
+export const toolDescription = `Create a role`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/roles`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "body": z.object({ "title": z.string().min(1).max(100), "name": z.string().regex(new RegExp("^[a-z0-9-_]+$")), "description": z.string(), "appliesToUsers": z.boolean(), "appliesToRobots": z.boolean(), "permissions": z.array(z.object({ "name": z.string().describe("The name of the permission.").optional(), "action": z.enum(["create","read","update","manage","history","editHistory"]).optional(), "params": z.record(z.any()).describe("The parameters for the permission. This is a key-value map of the permission's configuration.").optional() })) }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/declinerequest.ts
+++ b/servers/token_api_thegraph_com/src/operations/declinerequest.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `declinerequest`
+export const toolDescription = `Decline request`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/v2024-07-01/access/{resourceType}/{resourceId}/requests/{requestId}/decline`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "requestId": z.string().describe("The ID of the request.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/deletepermission.ts
+++ b/servers/token_api_thegraph_com/src/operations/deletepermission.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deletepermission`
+export const toolDescription = `Delete a permission`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/permissions/{permissionName}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "permissionName": z.string().describe("The name of the permission. This is a unique identifier for the permission.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/deleterobot.ts
+++ b/servers/token_api_thegraph_com/src/operations/deleterobot.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deleterobot`
+export const toolDescription = `Delete robot and associated token`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/robots/{robotId}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "robotId": z.string().describe("The robot's unique identifier.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/deleterole.ts
+++ b/servers/token_api_thegraph_com/src/operations/deleterole.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deleterole`
+export const toolDescription = `Delete a role`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/roles/{roleName}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "roleName": z.string().describe("The role name.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getbalancesevmbyaddress.ts
+++ b/servers/token_api_thegraph_com/src/operations/getbalancesevmbyaddress.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getbalancesevmbyaddress`
+export const toolDescription = `Token Balances by Wallet Address`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/balances/evm/{address}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query") }).optional(), "query": z.object({ "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "contract": z.string().optional(), "limit": z.number().int().gte(1).lte(500).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/gethealth.ts
+++ b/servers/token_api_thegraph_com/src/operations/gethealth.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `gethealth`
+export const toolDescription = `Get health status of the API`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/health`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({}).shape

--- a/servers/token_api_thegraph_com/src/operations/getholdersevmbycontract.ts
+++ b/servers/token_api_thegraph_com/src/operations/getholdersevmbycontract.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getholdersevmbycontract`
+export const toolDescription = `Token Holders by Contract Address`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/holders/evm/{contract}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query") }).optional(), "query": z.object({ "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "order_by": z.enum(["asc","desc"]).describe("The order in which to return the results: Ascending (asc) or Descending (desc)."), "limit": z.number().int().gte(1).lte(500).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getinvitebytoken.ts
+++ b/servers/token_api_thegraph_com/src/operations/getinvitebytoken.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getinvitebytoken`
+export const toolDescription = `Get invite`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/invites/token/{inviteToken}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "inviteToken": z.string().describe("The public token for the invite. This token is shared with the invitee.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getinvites.ts
+++ b/servers/token_api_thegraph_com/src/operations/getinvites.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getinvites`
+export const toolDescription = `Get invites`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/invites`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "status": z.array(z.enum(["pending","accepted","revoked"])).describe("Filter invites by status.").optional(), "includeChildren": z.boolean().describe("Whether to include children resources in the response. Only applies to `organization` resources.").optional(), "nextCursor": z.string().describe("The cursor for pagination. Use the nextCursor from the previous response to get the next page.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The number of items to return per page.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getmypermissions.ts
+++ b/servers/token_api_thegraph_com/src/operations/getmypermissions.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getmypermissions`
+export const toolDescription = `Get current user permissions.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/permissions/me`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "query": z.object({ "nextCursor": z.string().describe("The cursor for pagination. Use the nextCursor from the previous response to get the next page.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The number of items to return per page.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getmyrequests.ts
+++ b/servers/token_api_thegraph_com/src/operations/getmyrequests.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getmyrequests`
+export const toolDescription = `List all request for current user`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/v2024-07-01/access/requests/me`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({}).shape

--- a/servers/token_api_thegraph_com/src/operations/getnetworks.ts
+++ b/servers/token_api_thegraph_com/src/operations/getnetworks.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `getnetworks`
+export const toolDescription = `Get supported networks of the API`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/networks`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({}).shape

--- a/servers/token_api_thegraph_com/src/operations/getohlcpricesevmbycontract.ts
+++ b/servers/token_api_thegraph_com/src/operations/getohlcpricesevmbycontract.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getohlcpricesevmbycontract`
+export const toolDescription = `Token OHLCV prices by Contract Address`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/ohlc/prices/evm/{contract}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query") }).optional(), "query": z.object({ "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "interval": z.enum(["1h","4h","1d","1w"]).describe("The interval for which to aggregate price data (hourly, 4-hours, daily or weekly)."), "startTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(), "endTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getpermission.ts
+++ b/servers/token_api_thegraph_com/src/operations/getpermission.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getpermission`
+export const toolDescription = `Get a permission`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/permissions/{permissionName}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "permissionName": z.string().describe("The name of the permission. This is a unique identifier for the permission.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getpermissions.ts
+++ b/servers/token_api_thegraph_com/src/operations/getpermissions.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getpermissions`
+export const toolDescription = `Get Permissions.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/permissions`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "nextCursor": z.string().describe("The cursor for pagination. Use the nextCursor from the previous response to get the next page.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The number of items to return per page.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getrequests.ts
+++ b/servers/token_api_thegraph_com/src/operations/getrequests.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getrequests`
+export const toolDescription = `List all requests for given project/organization.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/v2024-07-01/access/{resourceType}/{resourceId}/requests`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "includeChildren": z.boolean().describe("Whether to include children resources in the response. Only applies to `organization` resources.").optional() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getrobot.ts
+++ b/servers/token_api_thegraph_com/src/operations/getrobot.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getrobot`
+export const toolDescription = `Get robot metadata`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/robots/{robotId}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "robotId": z.string().describe("The robot's unique identifier.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getrobots.ts
+++ b/servers/token_api_thegraph_com/src/operations/getrobots.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getrobots`
+export const toolDescription = `Get robots with access to this resource`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/robots`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "includeChildren": z.boolean().describe("Whether to include children resources in the response. Only applies to `organization` resources.").optional(), "nextCursor": z.string().describe("The cursor for pagination. Use the nextCursor from the previous response to get the next page.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The number of items to return per page.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getrole.ts
+++ b/servers/token_api_thegraph_com/src/operations/getrole.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getrole`
+export const toolDescription = `Get a role`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/roles/{roleName}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "roleName": z.string().describe("The role name.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getroles.ts
+++ b/servers/token_api_thegraph_com/src/operations/getroles.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getroles`
+export const toolDescription = `List roles assignable to a user on this resource.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/roles`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "includeChildren": z.boolean().describe("Whether to include children resources in the response. Only applies to `organization` resources.").optional(), "nextCursor": z.string().describe("The cursor for pagination. Use the nextCursor from the previous response to get the next page.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The number of items to return per page."), "includeImpliedRoles": z.boolean().describe("Whether to include implied roles in the response.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/gettokensevmbycontract.ts
+++ b/servers/token_api_thegraph_com/src/operations/gettokensevmbycontract.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `gettokensevmbycontract`
+export const toolDescription = `Token Metadata by Contract`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/tokens/evm/{contract}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query") }).optional(), "query": z.object({ "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/gettransfersevmbyaddress.ts
+++ b/servers/token_api_thegraph_com/src/operations/gettransfersevmbyaddress.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `gettransfersevmbyaddress`
+export const toolDescription = `Token Transfers by Wallet Address`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/transfers/evm/{address}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query") }).optional(), "query": z.object({ "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "age": z.number().int().gte(1).lte(180).describe("Indicates how many days have passed since the data's creation or insertion."), "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("Filter by contract address").optional(), "limit": z.number().int().gte(1).lte(500).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getuser.ts
+++ b/servers/token_api_thegraph_com/src/operations/getuser.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getuser`
+export const toolDescription = `Get user and roles.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/users/{sanityUserId}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "sanityUserId": z.string().describe("The User ID") }).optional(), "query": z.object({ "includeImpliedRoles": z.boolean().describe("Whether to include implied roles in the response.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getuserpermissions.ts
+++ b/servers/token_api_thegraph_com/src/operations/getuserpermissions.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getuserpermissions`
+export const toolDescription = `List permissions for a user`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/users/{sanityUserId}/permissions`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "sanityUserId": z.string().describe("The User ID") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getusers.ts
+++ b/servers/token_api_thegraph_com/src/operations/getusers.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getusers`
+export const toolDescription = `List all users of a resource and their assigned roles.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/users`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type.") }).optional(), "query": z.object({ "nextCursor": z.string().describe("The cursor for pagination. Use the nextCursor from the previous response to get the next page.").optional(), "limit": z.number().int().gte(1).lte(500).describe("The number of items to return per page."), "includeImpliedRoles": z.boolean().describe("Whether to include implied roles in the response.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/getversion.ts
+++ b/servers/token_api_thegraph_com/src/operations/getversion.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `getversion`
+export const toolDescription = `Get the version of the API`
+export const baseUrl = `https://token-api.thegraph.com`
+export const path = `/version`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({}).shape

--- a/servers/token_api_thegraph_com/src/operations/removerolefromuser.ts
+++ b/servers/token_api_thegraph_com/src/operations/removerolefromuser.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `removerolefromuser`
+export const toolDescription = `Remove a role from a user in a resource.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/users/{sanityUserId}/roles/{roleName}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "sanityUserId": z.string().describe("The User ID"), "roleName": z.string().describe("The role name.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/removeuser.ts
+++ b/servers/token_api_thegraph_com/src/operations/removeuser.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `removeuser`
+export const toolDescription = `Remove a user from a resource.`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/users/{sanityUserId}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "sanityUserId": z.string().describe("The User ID") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/revokeinvite.ts
+++ b/servers/token_api_thegraph_com/src/operations/revokeinvite.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `revokeinvite`
+export const toolDescription = `Revoke invite`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/invites/{inviteId}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "inviteId": z.string().describe("The invite's unique identifier.") }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/updatepermission.ts
+++ b/servers/token_api_thegraph_com/src/operations/updatepermission.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `updatepermission`
+export const toolDescription = `Update a permission`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/permissions/{permissionName}`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "permissionName": z.string().describe("The name of the permission. This is a unique identifier for the permission.") }).optional(), "body": z.object({ "type": z.enum(["sanity.document.filter","sanity.document.filter.mode","sanity.organization","sanity.organization.legal","sanity.organization.members","sanity.organization.projects","sanity.organization.roles","sanity.organization.sso","sanity.organization.tokens","sanity.project","sanity.project.cors","sanity.project.datasets","sanity.project.graphql","sanity.project.members","sanity.project.roles","sanity.project.tags","sanity.project.tokens","sanity.project.usage","sanity.project.webhooks"]).describe("The resource for the permission."), "name": z.string().describe("The name of the permission resource. A unique identifier for a permission."), "title": z.string().describe("A human-readable title of the permission resource. This is used for display purposes."), "description": z.string().describe("The description of the permission resource."), "config": z.record(z.any()).describe("Some permissions allow for additional configuration when used with document permissions. Accepts a groq filter or a dataset name.").optional() }).optional() }).shape

--- a/servers/token_api_thegraph_com/src/operations/updaterole.ts
+++ b/servers/token_api_thegraph_com/src/operations/updaterole.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `updaterole`
+export const toolDescription = `Update a role`
+export const baseUrl = `https://api.sanity.io`
+export const path = `/vX/access/{resourceType}/{resourceId}/roles/{roleName}`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "resourceType": z.enum(["organization","project"]).describe("Resources are entities that can be managed and accessed through the\nAccess API.\n"), "resourceId": z.string().describe("The resource ID to scope the access request to. Must be a valid ID for the resource type."), "roleName": z.string().describe("The role name.") }).optional(), "body": z.object({ "title": z.string().min(1).max(100), "name": z.string().regex(new RegExp("^[a-z0-9-_]+$")), "description": z.string(), "appliesToUsers": z.boolean(), "appliesToRobots": z.boolean(), "permissions": z.array(z.object({ "name": z.string().describe("The name of the permission.").optional(), "action": z.enum(["create","read","update","manage","history","editHistory"]).optional(), "params": z.record(z.any()).describe("The parameters for the permission. This is a key-value map of the permission's configuration.").optional() })) }).optional() }).shape

--- a/servers/token_api_thegraph_com/tsconfig.json
+++ b/servers/token_api_thegraph_com/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `token_api_thegraph_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/token_api_thegraph_com`, which you’ll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "token_api_thegraph_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/token_api_thegraph_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won’t work as expected, but we’re working fast and confident that most edge cases will be ironed out soon.