### PR TITLE
Add MCP server `api_totoy_ai_v1`

### DIFF
--- a/servers/api_totoy_ai_v1/.npmignore
+++ b/servers/api_totoy_ai_v1/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_totoy_ai_v1/README.md
+++ b/servers/api_totoy_ai_v1/README.md
@@ -1,0 +1,94 @@
+# @open-mcp/api_totoy_ai_v1
+
+## MCP client config
+
+Add the following to `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "api_totoy_ai_v1": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_totoy_ai_v1"],
+      "env": {
+        "API_KEY": "..."
+      }
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+
+## Tools
+
+### createexplanation
+
+### createknowledgebase
+
+### listknowledgebases
+
+### getknowledgebase
+
+### modifyknowledgebase
+
+### deleteknowledgebase
+
+### chatwithknowledgebase
+
+### addknowledgebasesources
+
+### listknowledgebasesources
+
+### getknowledgebasesource
+
+### deleteknowledgebasesource
+
+### createsource
+
+### listsources
+
+### getsource
+
+### modifysource
+
+### deletesource
+
+### getsourcecontent
+
+### createproject
+
+### listprojects
+
+### getproject
+
+### modifyproject
+
+### deleteproject
+
+### getorganization
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_totoy_ai_v1
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/api_totoy_ai_v1`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`

--- a/servers/api_totoy_ai_v1/package.json
+++ b/servers/api_totoy_ai_v1/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/api_totoy_ai_v1",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "api_totoy_ai_v1": "./build/index.js"
+  },
+  "files": [
+    "build"
+  ],
+  "scripts": {
+    "clean": "rm -rf build",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 build/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.9",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/api_totoy_ai_v1/src/constants.ts
+++ b/servers/api_totoy_ai_v1/src/constants.ts
@@ -1,0 +1,27 @@
+export const SERVER_NAME = "api_totoy_ai_v1"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./operations/createexplanation.js",
+  "./operations/createknowledgebase.js",
+  "./operations/listknowledgebases.js",
+  "./operations/getknowledgebase.js",
+  "./operations/modifyknowledgebase.js",
+  "./operations/deleteknowledgebase.js",
+  "./operations/chatwithknowledgebase.js",
+  "./operations/addknowledgebasesources.js",
+  "./operations/listknowledgebasesources.js",
+  "./operations/getknowledgebasesource.js",
+  "./operations/deleteknowledgebasesource.js",
+  "./operations/createsource.js",
+  "./operations/listsources.js",
+  "./operations/getsource.js",
+  "./operations/modifysource.js",
+  "./operations/deletesource.js",
+  "./operations/getsourcecontent.js",
+  "./operations/createproject.js",
+  "./operations/listprojects.js",
+  "./operations/getproject.js",
+  "./operations/modifyproject.js",
+  "./operations/deleteproject.js",
+  "./operations/getorganization.js"
+]

--- a/servers/api_totoy_ai_v1/src/index.ts
+++ b/servers/api_totoy_ai_v1/src/index.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (params) => {
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        typeof value === "object" ? JSON.stringify(value) : value.toString()
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(
+        key,
+        typeof value === "undefined"
+          ? ""
+          : typeof value === "object"
+          ? JSON.stringify(value)
+          : value.toString()
+      )
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+async function main() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error in main():", error)
+  process.exit(1)
+})

--- a/servers/api_totoy_ai_v1/src/lib.ts
+++ b/servers/api_totoy_ai_v1/src/lib.ts
@@ -1,0 +1,23 @@
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}

--- a/servers/api_totoy_ai_v1/src/operations/addknowledgebasesources.ts
+++ b/servers/api_totoy_ai_v1/src/operations/addknowledgebasesources.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `addknowledgebasesources`
+export const toolDescription = `Adds Sources to a Knowledge Base.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}/sources`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`.") }).optional(), "body": z.object({ "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("A `source_id` of a `Source` to add as a `Knowledge Base Source`. Only `Sources` that have the same `project_id` as the `Knowledge Base` can be added as `Knowledge Base Sources`.") }).strict().optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/chatwithknowledgebase.ts
+++ b/servers/api_totoy_ai_v1/src/operations/chatwithknowledgebase.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `chatwithknowledgebase`
+export const toolDescription = `Creates a Knowledge Base Chat Response for the given Messages.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}/chat`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`.") }).optional(), "body": z.object({ "output_language": z.enum(["ar","bs","cs","de","es","en","fa","fr","hr","hu","it","pl","ro","sk","sl","sr","tl","tr","uk"]).describe("The ISO 639-1 code for the language in which the `Explanation` should be generated.\nSupported Languages:\n- ar: Arabic\n- bs: Bosnian\n- cs: Czech\n- de: German\n- es: Spanish\n- en: English\n- fa: Farsi\n- fr: French\n- hr: Croatian\n- hu: Hungarian\n- it: Italian\n- pl: Polish\n- ro: Romanian\n- sk: Slovak\n- sl: Slovenian\n- sr: Serbian\n- tl: Tagalog\n- tr: Turkish\n- uk: Ukrainian\n"), "language_level": z.enum(["simple","plain","detailed"]).describe("One of three language levels for the generated text:\n1. Simple Language: Answers are short and simple, using easy words and a clear structure.\n2. Plain Language: Answers are short and the assistant explains complicated terms.\n3. Detailed Language: Answers are not simplified and the assistant answers in detail.\n"), "messages": z.array(z.object({ "role": z.enum(["user","assistant"]).describe("The entity that produced the message. One of `user` or `assistant`."), "content": z.string().max(16000).describe("The content of the message. The maximum length is 16,000 characters."), "references": z.array(z.object({ "text": z.string().max(8).describe("String in the message content that needs to be replaced."), "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("What `Source` the generated answer depended on."), "page_number": z.number().int().gte(1).lte(1000).nullable().describe("The page number in the `Source` the generated answer depended on. Only applicable for documents.").optional(), "backlink": z.string().max(512).describe("The backlink of the `Source`, so it can be called from the client.").optional(), "custom_metadata": z.record(z.any()).describe("Custom optional metadata for a `Source` provided by a client. Up to 10 key-value pairs.").optional() }).strict().describe("Represents a reference to a `Source` that was used to generate the answer.\nThe reference is used to provide backlinks to the original source and to provide context for the generated answer.\n")).max(50).optional() }).strict().describe("Represents a message within an `Explanation` or a `Knowledge Base Chat`.\nFor `Explanations` - An `assistant` message is either an initial `Explanation` for the document when no messages were provided in the request or an answer to a user message in the provided conversation history.\n")).max(50).describe("The conversation history. Provide at least one user message to start the conversation."), "markdown_response": z.boolean().describe("Whether the response should be returned as Markdown formatted text. If 'false', the response will be returned in plain text.") }).strict().optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/createexplanation.ts
+++ b/servers/api_totoy_ai_v1/src/operations/createexplanation.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createexplanation`
+export const toolDescription = `Explains a document in any language`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/explanation`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "output_language": z.enum(["ar","bs","cs","de","es","en","fa","fr","hr","hu","it","pl","ro","sk","sl","sr","tl","tr","uk"]).describe("The ISO 639-1 code for the language in which the `Explanation` should be generated.\nSupported Languages:\n- ar: Arabic\n- bs: Bosnian\n- cs: Czech\n- de: German\n- es: Spanish\n- en: English\n- fa: Farsi\n- fr: French\n- hr: Croatian\n- hu: Hungarian\n- it: Italian\n- pl: Polish\n- ro: Romanian\n- sk: Slovak\n- sl: Slovenian\n- sr: Serbian\n- tl: Tagalog\n- tr: Turkish\n- uk: Ukrainian\n"), "language_level": z.enum(["simple","plain","detailed"]).describe("One of three language levels for the generated text:\n1. Simple Language: Answers are short and simple, using easy words and a clear structure.\n2. Plain Language: Answers are short and the assistant explains complicated terms.\n3. Detailed Language: Answers are not simplified and the assistant answers in detail.\n"), "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("The unique identifier of the uploaded `Source` to be used as context for the `Explanation`."), "messages": z.array(z.object({ "role": z.enum(["user","assistant"]).describe("The entity that produced the message. One of `user` or `assistant`."), "content": z.string().max(16000).describe("The content of the message. The maximum length is 16,000 characters."), "references": z.array(z.object({ "text": z.string().max(8).describe("String in the message content that needs to be replaced."), "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("What `Source` the generated answer depended on."), "page_number": z.number().int().gte(1).lte(1000).nullable().describe("The page number in the `Source` the generated answer depended on. Only applicable for documents.").optional(), "backlink": z.string().max(512).describe("The backlink of the `Source`, so it can be called from the client.").optional(), "custom_metadata": z.record(z.any()).describe("Custom optional metadata for a `Source` provided by a client. Up to 10 key-value pairs.").optional() }).strict().describe("Represents a reference to a `Source` that was used to generate the answer.\nThe reference is used to provide backlinks to the original source and to provide context for the generated answer.\n")).max(50).optional() }).strict().describe("Represents a message within an `Explanation` or a `Knowledge Base Chat`.\nFor `Explanations` - An `assistant` message is either an initial `Explanation` for the document when no messages were provided in the request or an answer to a user message in the provided conversation history.\n")).max(50).describe("The conversation history. For an initial `Explanation` just provide an empty array or no messages. For follow-up questions, provide the entire conversation history.").optional(), "markdown_response": z.boolean().describe("Whether the response should be returned as Markdown formatted text. If 'false', the response will be returned in plain text.") }).strict().optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/createknowledgebase.ts
+++ b/servers/api_totoy_ai_v1/src/operations/createknowledgebase.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createknowledgebase`
+export const toolDescription = `Creates a Knowledge Base.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "name": z.string().max(256).describe("The name for the `Knowledge Base`").optional(), "instructions": z.string().max(4096).describe("The instructions for the `Knowledge Base`.").optional(), "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).describe("The unique identifier for the `Project` that the `Knowledge Base` will be assigned to. If no `project_id` is provided, the `Knowledge Base` will be assigned to the default `Project`.").optional() }).strict().optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/createproject.ts
+++ b/servers/api_totoy_ai_v1/src/operations/createproject.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createproject`
+export const toolDescription = `Creates a Project.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/projects`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "name": z.string().max(256).describe("The name of the `Project`.") }).strict().optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/createsource.ts
+++ b/servers/api_totoy_ai_v1/src/operations/createsource.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `createsource`
+export const toolDescription = `Creates a Document or Text Source`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/sources`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "text_content": z.string().max(1000000).describe("Plain-text string to be uploaded to `Sources`."), "title": z.string().max(512).nullable().describe("Title of the text `Source`.").optional(), "backlink": z.string().max(512).describe("A url to the text `Source` that can be used by clients to link back to the original text.").optional(), "valid_from": z.string().datetime({ offset: true }).nullable().describe("From what time the `Source` can be used by a `Knowledge Base` or an `Explanation`. If no `valid_from` is set, the `Source` is valid from the time it is added to `Sources`.").optional(), "valid_until": z.string().datetime({ offset: true }).nullable().describe("Until when the `Source` can be used by a `Knowledge Base` or an `Explanation`. If no `valid_until` is set, the `Source` is valid until it is removed from `Sources`.").optional(), "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).nullable().describe("The unique identifier of the project this `Source` should be assigned to. `Sources` can only be used by resources with the same `project_id`. If no `project_id` is set, the `Source` will be assigned to the default project.").optional(), "custom_metadata": z.record(z.any()).describe("Custom optional metadata for a `Source` provided by a client. Up to 10 key-value pairs.").optional() }).strict().optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/deleteknowledgebase.ts
+++ b/servers/api_totoy_ai_v1/src/operations/deleteknowledgebase.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deleteknowledgebase`
+export const toolDescription = `Deletes a Knowledge Base.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/deleteknowledgebasesource.ts
+++ b/servers/api_totoy_ai_v1/src/operations/deleteknowledgebasesource.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deleteknowledgebasesource`
+export const toolDescription = `Removes a Knowledge Base Source from a Knowledge Base.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}/sources/{source_id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`."), "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("Unique identifier for a `Source` that was uploaded to Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/deleteproject.ts
+++ b/servers/api_totoy_ai_v1/src/operations/deleteproject.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deleteproject`
+export const toolDescription = `Deletes a Project and all its associated resources.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/projects/{project_id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Project` created in Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/deletesource.ts
+++ b/servers/api_totoy_ai_v1/src/operations/deletesource.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `deletesource`
+export const toolDescription = `Deletes a Source.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/sources/{source_id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("Unique identifier for a `Source` that was uploaded to Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/getknowledgebase.ts
+++ b/servers/api_totoy_ai_v1/src/operations/getknowledgebase.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getknowledgebase`
+export const toolDescription = `Retrieves a Knowledge Base.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/getknowledgebasesource.ts
+++ b/servers/api_totoy_ai_v1/src/operations/getknowledgebasesource.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getknowledgebasesource`
+export const toolDescription = `Retrieves a Knowledge Base Source.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}/sources/{source_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`."), "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("Unique identifier for a `Source` that was uploaded to Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/getorganization.ts
+++ b/servers/api_totoy_ai_v1/src/operations/getorganization.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getorganization`
+export const toolDescription = `Returns the Organization details.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/organization`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({}).shape

--- a/servers/api_totoy_ai_v1/src/operations/getproject.ts
+++ b/servers/api_totoy_ai_v1/src/operations/getproject.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getproject`
+export const toolDescription = `Retrieves a Project.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/projects/{project_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Project` created in Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/getsource.ts
+++ b/servers/api_totoy_ai_v1/src/operations/getsource.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getsource`
+export const toolDescription = `Retrieves a Source.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/sources/{source_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("Unique identifier for a `Source` that was uploaded to Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/getsourcecontent.ts
+++ b/servers/api_totoy_ai_v1/src/operations/getsourcecontent.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `getsourcecontent`
+export const toolDescription = `Retrieves the content of a Source.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/sources/{source_id}/content`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("Unique identifier for a `Source` that was uploaded to Totoy.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/listknowledgebases.ts
+++ b/servers/api_totoy_ai_v1/src/operations/listknowledgebases.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `listknowledgebases`
+export const toolDescription = `Returns a list of Knowledge Bases.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({}).shape

--- a/servers/api_totoy_ai_v1/src/operations/listknowledgebasesources.ts
+++ b/servers/api_totoy_ai_v1/src/operations/listknowledgebasesources.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `listknowledgebasesources`
+export const toolDescription = `Returns a list of Knowledge Base Sources.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}/sources`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`.") }).optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/listprojects.ts
+++ b/servers/api_totoy_ai_v1/src/operations/listprojects.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `listprojects`
+export const toolDescription = `Returns a list of Projects.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/projects`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({}).shape

--- a/servers/api_totoy_ai_v1/src/operations/listsources.ts
+++ b/servers/api_totoy_ai_v1/src/operations/listsources.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `listsources`
+export const toolDescription = `Returns a list of Sources.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/sources`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({}).shape

--- a/servers/api_totoy_ai_v1/src/operations/modifyknowledgebase.ts
+++ b/servers/api_totoy_ai_v1/src/operations/modifyknowledgebase.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `modifyknowledgebase`
+export const toolDescription = `Modifies a Knowledge Base.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/knowledge-bases/{knowledge_base_id}`
+export const method = `patch`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "knowledge_base_id": z.string().regex(new RegExp("^kb_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Knowledge Base`.") }).optional(), "body": z.object({ "name": z.string().max(255).describe("The name for the `Knowledge Base`.").optional(), "instructions": z.string().max(4096).describe("The instructions for the `Knowledge Base`.").optional(), "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).describe("The unique identifier for the `Project` that the `Knowledge Base` should be assigned to. If the `project_id` is changed, the `project_ids` of the `Sources` that are used as `Knowledge Base Sources` will also be changed. If a `Source` is used by multiple `Knowledge Bases`, then the `project_id` of the `Knowledge Base` cannot be changed.").optional() }).strict().describe("Request body for modifying a `Knowledge Base`.").optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/modifyproject.ts
+++ b/servers/api_totoy_ai_v1/src/operations/modifyproject.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `modifyproject`
+export const toolDescription = `Modifies a Project.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/projects/{project_id}`
+export const method = `patch`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).describe("Unique identifier for a `Project` created in Totoy.") }).optional(), "body": z.object({ "name": z.string().max(256).describe("The name of the `Project`.").optional() }).strict().describe("Request body for modifying a `Project`.").optional() }).shape

--- a/servers/api_totoy_ai_v1/src/operations/modifysource.ts
+++ b/servers/api_totoy_ai_v1/src/operations/modifysource.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const toolName = `modifysource`
+export const toolDescription = `Modifies a Source.`
+export const baseUrl = `https://api.totoy.ai/v1`
+export const path = `/sources/{source_id}`
+export const method = `patch`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "source_id": z.string().regex(new RegExp("^src_[a-zA-Z0-9]{25}$")).max(29).describe("Unique identifier for a `Source` that was uploaded to Totoy.") }).optional(), "body": z.object({ "text_content": z.string().max(1000000).describe("Plain-text string to replace the original `text_content` of the `Source`.").optional(), "title": z.string().max(512).describe("Title of the text `Source`.").optional(), "backlink": z.string().max(512).describe("A url to the text `Source` that can be used by clients to link back to the original text.").optional(), "valid_from": z.string().datetime({ offset: true }).nullable().describe("From what time the `Source` can be used by a `Knowledge Base` or an `Explanation`. If no `valid_from` is set, the `Source` is valid from the time it is added to `Sources`.").optional(), "valid_until": z.string().datetime({ offset: true }).nullable().describe("Until when the `Source` can be used by a `Knowledge Base` or an `Explanation`. If no `valid_until` is set, the `Source` is valid until it is removed from `Sources`.").optional(), "project_id": z.string().regex(new RegExp("^pj_[a-zA-Z0-9]{25}$")).max(28).nullable().describe("The unique identifier of the project this `Source` should be assigned to. `Sources` can only be used by resources with the same `project_id`. If no `project_id` is set, the `Source` will be assigned to the default project. A `Source` can only be assigned to a different `Project`, if no `Knowledge Bases` are using the `Source`.").optional(), "custom_metadata": z.record(z.any()).describe("Custom optional metadata for a `Source` provided by a client. Up to 10 key-value pairs.").optional() }).strict().describe("Request body for modifying a `Text Source`.").optional() }).shape

--- a/servers/api_totoy_ai_v1/tsconfig.json
+++ b/servers/api_totoy_ai_v1/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_totoy_ai_v1`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_totoy_ai_v1`, which you’ll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_totoy_ai_v1": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_totoy_ai_v1"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won’t work as expected, but we’re working fast and confident that most edge cases will be ironed out soon.