### PR TITLE
Add MCP server `_metatx`

### DIFF
--- a/servers/_metatx/.npmignore
+++ b/servers/_metatx/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_metatx/README.md
+++ b/servers/_metatx/README.md
@@ -1,0 +1,84 @@
+# @open-mcp/_metatx
+
+## MCP client config
+
+Add the following to `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "_metatx": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_metatx"],
+      "env": {
+        "API_KEY": "..."
+      }
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+
+## Tools
+
+### blockchains_route_blockchains_get
+
+### list_registered_contracts_route_contracts_get
+
+### register_contract_route_contracts_post
+
+### get_registered_contract_route_contracts_contract_id_get
+
+### update_contract_route_contracts_contract_id_put
+
+### delete_contract_route_contracts_contract_id_delete
+
+### list_metatx_requesters_route_requesters_get
+
+### list_metatx_requester_holders_route_contracts_contract_id_holder
+
+### add_metatx_requester_holder_route_contracts_contract_id_holders_
+
+### delete_metatx_requester_holder_route_contracts_contract_id_holde
+
+### call_request_types_route_requests_types_get
+
+### call_request_types_route_contracts_types_get
+
+### list_requests_route_requests_get
+
+### create_requests_requests_post
+
+### delete_requests_requests_delete
+
+### check_requests_route_requests_check_get
+
+### get_request_requests_request_id_get
+
+### complete_call_request_route_requests_request_id_complete_post
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/_metatx
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/_metatx`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`

--- a/servers/_metatx/package.json
+++ b/servers/_metatx/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/_metatx",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "_metatx": "./build/index.js"
+  },
+  "files": [
+    "build"
+  ],
+  "scripts": {
+    "clean": "rm -rf build",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 build/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.9",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/_metatx/src/constants.ts
+++ b/servers/_metatx/src/constants.ts
@@ -1,0 +1,22 @@
+export const SERVER_NAME = "_metatx"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./operations/blockchains_route_blockchains_get.js",
+  "./operations/list_registered_contracts_route_contracts_get.js",
+  "./operations/register_contract_route_contracts_post.js",
+  "./operations/get_registered_contract_route_contracts_contract_id_get.js",
+  "./operations/update_contract_route_contracts_contract_id_put.js",
+  "./operations/delete_contract_route_contracts_contract_id_delete.js",
+  "./operations/list_metatx_requesters_route_requesters_get.js",
+  "./operations/list_metatx_requester_holders_route_contracts_contract_id_holder.js",
+  "./operations/add_metatx_requester_holder_route_contracts_contract_id_holders_.js",
+  "./operations/delete_metatx_requester_holder_route_contracts_contract_id_holde.js",
+  "./operations/call_request_types_route_requests_types_get.js",
+  "./operations/call_request_types_route_contracts_types_get.js",
+  "./operations/list_requests_route_requests_get.js",
+  "./operations/create_requests_requests_post.js",
+  "./operations/delete_requests_requests_delete.js",
+  "./operations/check_requests_route_requests_check_get.js",
+  "./operations/get_request_requests_request_id_get.js",
+  "./operations/complete_call_request_route_requests_request_id_complete_post.js"
+]

--- a/servers/_metatx/src/index.ts
+++ b/servers/_metatx/src/index.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (params) => {
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        typeof value === "object" ? JSON.stringify(value) : value.toString()
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(
+        key,
+        typeof value === "undefined"
+          ? ""
+          : typeof value === "object"
+          ? JSON.stringify(value)
+          : value.toString()
+      )
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+async function main() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error in main():", error)
+  process.exit(1)
+})

--- a/servers/_metatx/src/lib.ts
+++ b/servers/_metatx/src/lib.ts
@@ -1,0 +1,23 @@
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}

--- a/servers/_metatx/src/operations/add_metatx_requester_holder_route_contracts_contract_id_holders_.ts
+++ b/servers/_metatx/src/operations/add_metatx_requester_holder_route_contracts_contract_id_holders_.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `add_metatx_requester_holder_route_contracts_contract_id_holders_`
+export const toolDescription = `Add Metatx Requester Holder Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}/holders`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract_id": z.string().uuid() }).optional(), "body": z.object({ "holder_id": z.string().uuid(), "holder_type": z.enum(["user","group"]).describe("An enumeration."), "permissions": z.array(z.enum(["admin","create","read","update","delete"]).describe("An enumeration.")).optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/blockchains_route_blockchains_get.ts
+++ b/servers/_metatx/src/operations/blockchains_route_blockchains_get.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `blockchains_route_blockchains_get`
+export const toolDescription = `Blockchains Route`
+export const baseUrl = `/metatx`
+export const path = `/blockchains`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/operations/call_request_types_route_contracts_types_get.ts
+++ b/servers/_metatx/src/operations/call_request_types_route_contracts_types_get.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `call_request_types_route_contracts_types_get`
+export const toolDescription = `Call Request Types Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/types`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/operations/call_request_types_route_requests_types_get.ts
+++ b/servers/_metatx/src/operations/call_request_types_route_requests_types_get.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `call_request_types_route_requests_types_get`
+export const toolDescription = `Call Request Types Route`
+export const baseUrl = `/metatx`
+export const path = `/requests/types`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/operations/check_requests_route_requests_check_get.ts
+++ b/servers/_metatx/src/operations/check_requests_route_requests_check_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `check_requests_route_requests_check_get`
+export const toolDescription = `Check Requests Route`
+export const baseUrl = `/metatx`
+export const path = `/requests/check`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "contract_id": z.string().uuid().optional(), "contract_address": z.string().optional(), "specifications": z.array(z.object({ "caller": z.string(), "method": z.string(), "call_request_type": z.string(), "request_id": z.string(), "parameters": z.record(z.any()) })).optional(), "ttl_days": z.number().int().optional(), "live_at": z.number().int().optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/complete_call_request_route_requests_request_id_complete_post.ts
+++ b/servers/_metatx/src/operations/complete_call_request_route_requests_request_id_complete_post.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `complete_call_request_route_requests_request_id_complete_post`
+export const toolDescription = `Complete Call Request Route`
+export const baseUrl = `/metatx`
+export const path = `/requests/{request_id}/complete`
+export const method = `post`
+export const security = []
+
+export const inputParams = z.object({ "path": z.object({ "request_id": z.string().uuid() }).optional(), "header": z.object({ "authorization": z.string().optional() }).optional(), "body": z.object({ "tx_hash": z.string() }).optional() }).shape

--- a/servers/_metatx/src/operations/create_requests_requests_post.ts
+++ b/servers/_metatx/src/operations/create_requests_requests_post.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `create_requests_requests_post`
+export const toolDescription = `Create Requests`
+export const baseUrl = `/metatx`
+export const path = `/requests`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "contract_id": z.string().uuid().optional(), "contract_address": z.string().optional(), "specifications": z.array(z.object({ "caller": z.string(), "method": z.string(), "call_request_type": z.string(), "request_id": z.string(), "parameters": z.record(z.any()) })).optional(), "ttl_days": z.number().int().optional(), "live_at": z.number().int().optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/delete_contract_route_contracts_contract_id_delete.ts
+++ b/servers/_metatx/src/operations/delete_contract_route_contracts_contract_id_delete.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `delete_contract_route_contracts_contract_id_delete`
+export const toolDescription = `Delete Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract_id": z.string().uuid() }).optional() }).shape

--- a/servers/_metatx/src/operations/delete_metatx_requester_holder_route_contracts_contract_id_holde.ts
+++ b/servers/_metatx/src/operations/delete_metatx_requester_holder_route_contracts_contract_id_holde.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `delete_metatx_requester_holder_route_contracts_contract_id_holde`
+export const toolDescription = `Delete Metatx Requester Holder Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}/holders`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract_id": z.string().uuid() }).optional(), "body": z.object({ "holder_id": z.string().uuid(), "holder_type": z.enum(["user","group"]).describe("An enumeration."), "permissions": z.array(z.enum(["admin","create","read","update","delete"]).describe("An enumeration.")).optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/delete_requests_requests_delete.ts
+++ b/servers/_metatx/src/operations/delete_requests_requests_delete.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `delete_requests_requests_delete`
+export const toolDescription = `Delete Requests`
+export const baseUrl = `/metatx`
+export const path = `/requests`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "body": z.array(z.string().uuid()).optional() }).shape

--- a/servers/_metatx/src/operations/get_registered_contract_route_contracts_contract_id_get.ts
+++ b/servers/_metatx/src/operations/get_registered_contract_route_contracts_contract_id_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `get_registered_contract_route_contracts_contract_id_get`
+export const toolDescription = `Get Registered Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract_id": z.string().uuid() }).optional() }).shape

--- a/servers/_metatx/src/operations/get_request_requests_request_id_get.ts
+++ b/servers/_metatx/src/operations/get_request_requests_request_id_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `get_request_requests_request_id_get`
+export const toolDescription = `Get Request`
+export const baseUrl = `/metatx`
+export const path = `/requests/{request_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "request_id": z.string().uuid() }).optional() }).shape

--- a/servers/_metatx/src/operations/list_metatx_requester_holders_route_contracts_contract_id_holder.ts
+++ b/servers/_metatx/src/operations/list_metatx_requester_holders_route_contracts_contract_id_holder.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `list_metatx_requester_holders_route_contracts_contract_id_holder`
+export const toolDescription = `List Metatx Requester Holders Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}/holders`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract_id": z.string().uuid() }).optional(), "query": z.object({ "extended": z.boolean() }).optional() }).shape

--- a/servers/_metatx/src/operations/list_metatx_requesters_route_requesters_get.ts
+++ b/servers/_metatx/src/operations/list_metatx_requesters_route_requesters_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `list_metatx_requesters_route_requesters_get`
+export const toolDescription = `List Metatx Requesters Route`
+export const baseUrl = `/metatx`
+export const path = `/requesters`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/operations/list_registered_contracts_route_contracts_get.ts
+++ b/servers/_metatx/src/operations/list_registered_contracts_route_contracts_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `list_registered_contracts_route_contracts_get`
+export const toolDescription = `List Registered Contracts Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "query": z.object({ "blockchain": z.string().optional(), "address": z.string().optional(), "limit": z.number().int(), "offset": z.number().int().optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/list_requests_route_requests_get.ts
+++ b/servers/_metatx/src/operations/list_requests_route_requests_get.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const toolName = `list_requests_route_requests_get`
+export const toolDescription = `List Requests Route`
+export const baseUrl = `/metatx`
+export const path = `/requests`
+export const method = `get`
+export const security = []
+
+export const inputParams = z.object({ "query": z.object({ "contract_id": z.string().uuid().optional(), "contract_address": z.string().optional(), "caller": z.string(), "limit": z.number().int(), "offset": z.number().int().optional(), "show_expired": z.boolean(), "live_after": z.number().int().optional() }).optional(), "header": z.object({ "authorization": z.string().optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/register_contract_route_contracts_post.ts
+++ b/servers/_metatx/src/operations/register_contract_route_contracts_post.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `register_contract_route_contracts_post`
+export const toolDescription = `Register Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "body": z.object({ "blockchain": z.string(), "address": z.string(), "title": z.string().optional(), "description": z.string().optional(), "image_uri": z.string().optional() }).optional() }).shape

--- a/servers/_metatx/src/operations/update_contract_route_contracts_contract_id_put.ts
+++ b/servers/_metatx/src/operations/update_contract_route_contracts_contract_id_put.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `update_contract_route_contracts_contract_id_put`
+export const toolDescription = `Update Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+
+export const inputParams = z.object({ "path": z.object({ "contract_id": z.string().uuid() }).optional(), "body": z.object({ "title": z.string().optional(), "description": z.string().optional(), "image_uri": z.string().optional(), "ignore_nulls": z.boolean() }).optional() }).shape

--- a/servers/_metatx/tsconfig.json
+++ b/servers/_metatx/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_metatx`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_metatx`, which you’ll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_metatx": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_metatx"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won’t work as expected, but we’re working fast and confident that most edge cases will be ironed out soon.