### PR TITLE
Add MCP server `spotify`

### DIFF
--- a/servers/spotify/README.md
+++ b/servers/spotify/README.md
@@ -1,4 +1,4 @@
-# @open-mcp/api_spotify_com_v1
+# @open-mcp/spotify
 
 ## Installing
 
@@ -7,18 +7,20 @@
 Use the `add-to-client` helper to add the server to your MCP client:
 
 ```bash
-npx @open-mcp/api_spotify_com_v1 add-to-client /path/to/client/config.json
+npx @open-mcp/spotify add-to-client /path/to/client/config.json
 ```
 
 For example:
 
 ```bash
 # Claude desktop:
-npx @open-mcp/api_spotify_com_v1 add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+npx @open-mcp/spotify add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+
 # Cursor project (run from the project dir):
-npx @open-mcp/api_spotify_com_v1 add-to-client .cursor/mcp.json
+npx @open-mcp/spotify add-to-client .cursor/mcp.json
+
 # Cursor global (applies to all projects):
-npx @open-mcp/api_spotify_com_v1 add-to-client ~/.cursor/mcp.json
+npx @open-mcp/spotify add-to-client ~/.cursor/mcp.json
 ```
 
 ### Manually
@@ -28,9 +30,9 @@ If you don't want to use the helper above, add the following to your MCP client 
 ```json
 {
   "mcpServers": {
-    "api_spotify_com_v1": {
+    "spotify": {
       "command": "npx",
-      "args": ["-y", "@open-mcp/api_spotify_com_v1"],
+      "args": ["-y", "@open-mcp/spotify"],
       "env": {
         "API_KEY": "..."
       }
@@ -232,13 +234,13 @@ Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base UR
 Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
 
 ```bash
-npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_spotify_com_v1
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/spotify
 ```
 
 - Open http://localhost:5173
 - Transport type: `STDIO`
 - Command: `npx`
-- Arguments: `-y @open-mcp/api_spotify_com_v1`
+- Arguments: `-y @open-mcp/spotify`
 - Click `Environment Variables` to add
 - Click `Connect`
 

--- a/servers/spotify/package.json
+++ b/servers/spotify/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@open-mcp/api_spotify_com_v1",
-  "version": "1.0.1",
+  "name": "@open-mcp/spotify",
+  "version": "0.0.1",
   "main": "index.js",
   "type": "module",
   "bin": {
-    "api_spotify_com_v1": "./dist/index.js"
+    "spotify": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/servers/spotify/src/constants.ts
+++ b/servers/spotify/src/constants.ts
@@ -1,5 +1,5 @@
 export const OPENAPI_URL = "https://raw.githubusercontent.com/sonallux/spotify-web-api/refs/heads/main/fixed-spotify-open-api.yml"
-export const SERVER_NAME = "api_spotify_com_v1"
+export const SERVER_NAME = "spotify"
 export const SERVER_VERSION = "0.0.1"
 export const OPERATION_FILES_RELATIVE = [
   "./tools/get_an_album.js",

--- a/servers/spotify/src/mcp-client-config.json
+++ b/servers/spotify/src/mcp-client-config.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "api_spotify_com_v1": {
+    "spotify": {
       "command": "npx",
-      "args": ["-y", "@open-mcp/api_spotify_com_v1"],
+      "args": ["-y", "@open-mcp/spotify"],
       "env": {
         "API_KEY": "..."
       }


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `spotify`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/spotify`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "spotify": {
      "command": "npx",
      "args": ["-y", "@open-mcp/spotify"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.