### PR TITLE
Add MCP server `_metatx`

### DIFF
--- a/servers/_metatx/.npmignore
+++ b/servers/_metatx/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_metatx/README.md
+++ b/servers/_metatx/README.md
@@ -1,0 +1,105 @@
+# @open-mcp/_metatx
+
+## Installing
+
+### With helper
+
+Use the `add-to-client` helper to add the server to your MCP client:
+
+```bash
+npx @open-mcp/_metatx add-to-client /path/to/client/config.json
+```
+
+For example:
+
+```bash
+# Claude desktop:
+npx @open-mcp/_metatx add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+
+# Cursor project (run from the project dir):
+npx @open-mcp/_metatx add-to-client .cursor/mcp.json
+
+# Cursor global (applies to all projects):
+npx @open-mcp/_metatx add-to-client ~/.cursor/mcp.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_metatx": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_metatx"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `OAUTH2_TOKEN`
+
+## Tools
+
+### blockchains_route_blockchains_get
+
+### list_registered_contracts_route_contracts_get
+
+### register_contract_route_contracts_post
+
+### get_registered_contract_route_contracts_contract_id_get
+
+### update_contract_route_contracts_contract_id_put
+
+### delete_contract_route_contracts_contract_id_delete
+
+### list_metatx_requesters_route_requesters_get
+
+### list_metatx_requester_holders_route_contracts_contract_id_holder
+
+### add_metatx_requester_holder_route_contracts_contract_id_holders_
+
+### delete_metatx_requester_holder_route_contracts_contract_id_holde
+
+### call_request_types_route_requests_types_get
+
+### call_request_types_route_contracts_types_get
+
+### list_requests_route_requests_get
+
+### create_requests_requests_post
+
+### delete_requests_requests_delete
+
+### check_requests_route_requests_check_get
+
+### get_request_requests_request_id_get
+
+### complete_call_request_route_requests_request_id_complete_post
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/_metatx
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/_metatx`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`

--- a/servers/_metatx/package.json
+++ b/servers/_metatx/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/_metatx",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "_metatx": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/_metatx/src/add-to-client.ts
+++ b/servers/_metatx/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/_metatx/src/constants.ts
+++ b/servers/_metatx/src/constants.ts
@@ -1,0 +1,23 @@
+export const OPENAPI_URL = "https://engineapi.moonstream.to/metatx/openapi.json"
+export const SERVER_NAME = "_metatx"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/blockchains_route_blockchains_get.js",
+  "./tools/list_registered_contracts_route_contracts_get.js",
+  "./tools/register_contract_route_contracts_post.js",
+  "./tools/get_registered_contract_route_contracts_contract_id_get.js",
+  "./tools/update_contract_route_contracts_contract_id_put.js",
+  "./tools/delete_contract_route_contracts_contract_id_delete.js",
+  "./tools/list_metatx_requesters_route_requesters_get.js",
+  "./tools/list_metatx_requester_holders_route_contracts_contract_id_holder.js",
+  "./tools/add_metatx_requester_holder_route_contracts_contract_id_holders_.js",
+  "./tools/delete_metatx_requester_holder_route_contracts_contract_id_holde.js",
+  "./tools/call_request_types_route_requests_types_get.js",
+  "./tools/call_request_types_route_contracts_types_get.js",
+  "./tools/list_requests_route_requests_get.js",
+  "./tools/create_requests_requests_post.js",
+  "./tools/delete_requests_requests_delete.js",
+  "./tools/check_requests_route_requests_check_get.js",
+  "./tools/get_request_requests_request_id_get.js",
+  "./tools/complete_call_request_route_requests_request_id_complete_post.js"
+]

--- a/servers/_metatx/src/index.ts
+++ b/servers/_metatx/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/_metatx/src/lib.ts
+++ b/servers/_metatx/src/lib.ts
@@ -1,0 +1,49 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      paramObj[originalKey] = flat[flatKey]
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/_metatx/src/mcp-client-config.json
+++ b/servers/_metatx/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "_metatx": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_metatx"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}

--- a/servers/_metatx/src/server.ts
+++ b/servers/_metatx/src/server.ts
@@ -1,0 +1,186 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_metatx/src/tools/add_metatx_requester_holder_route_contracts_contract_id_holders_.ts
+++ b/servers/_metatx/src/tools/add_metatx_requester_holder_route_contracts_contract_id_holders_.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+export const toolName = `add_metatx_requester_holder_route_contracts_contract_id_holders_`
+export const toolDescription = `Add Metatx Requester Holder Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}/holders`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "contract_id"
+  ],
+  "cookie": [],
+  "body": [
+    "holder_id",
+    "holder_type",
+    "permissions"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid(), "holder_id": z.string().uuid(), "holder_type": z.enum(["user","group"]).describe("An enumeration."), "permissions": z.array(z.enum(["admin","create","read","update","delete"]).describe("An enumeration.")).optional() }).shape

--- a/servers/_metatx/src/tools/blockchains_route_blockchains_get.ts
+++ b/servers/_metatx/src/tools/blockchains_route_blockchains_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `blockchains_route_blockchains_get`
+export const toolDescription = `Blockchains Route`
+export const baseUrl = `/metatx`
+export const path = `/blockchains`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/tools/call_request_types_route_contracts_types_get.ts
+++ b/servers/_metatx/src/tools/call_request_types_route_contracts_types_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `call_request_types_route_contracts_types_get`
+export const toolDescription = `Call Request Types Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/types`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/tools/call_request_types_route_requests_types_get.ts
+++ b/servers/_metatx/src/tools/call_request_types_route_requests_types_get.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `call_request_types_route_requests_types_get`
+export const toolDescription = `Call Request Types Route`
+export const baseUrl = `/metatx`
+export const path = `/requests/types`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/tools/check_requests_route_requests_check_get.ts
+++ b/servers/_metatx/src/tools/check_requests_route_requests_check_get.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+export const toolName = `check_requests_route_requests_check_get`
+export const toolDescription = `Check Requests Route`
+export const baseUrl = `/metatx`
+export const path = `/requests/check`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "contract_id",
+    "contract_address",
+    "specifications",
+    "ttl_days",
+    "live_at"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid().optional(), "contract_address": z.string().optional(), "specifications": z.array(z.object({ "caller": z.string(), "method": z.string(), "call_request_type": z.string(), "request_id": z.string(), "parameters": z.record(z.any()) })).optional(), "ttl_days": z.number().int().optional(), "live_at": z.number().int().optional() }).shape

--- a/servers/_metatx/src/tools/complete_call_request_route_requests_request_id_complete_post.ts
+++ b/servers/_metatx/src/tools/complete_call_request_route_requests_request_id_complete_post.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const toolName = `complete_call_request_route_requests_request_id_complete_post`
+export const toolDescription = `Complete Call Request Route`
+export const baseUrl = `/metatx`
+export const path = `/requests/{request_id}/complete`
+export const method = `post`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [
+    "authorization"
+  ],
+  "path": [
+    "request_id"
+  ],
+  "cookie": [],
+  "body": [
+    "tx_hash"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "request_id": z.string().uuid(), "tx_hash": z.string(), "authorization": z.string().optional() }).shape

--- a/servers/_metatx/src/tools/create_requests_requests_post.ts
+++ b/servers/_metatx/src/tools/create_requests_requests_post.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+export const toolName = `create_requests_requests_post`
+export const toolDescription = `Create Requests`
+export const baseUrl = `/metatx`
+export const path = `/requests`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "contract_id",
+    "contract_address",
+    "specifications",
+    "ttl_days",
+    "live_at"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid().optional(), "contract_address": z.string().optional(), "specifications": z.array(z.object({ "caller": z.string(), "method": z.string(), "call_request_type": z.string(), "request_id": z.string(), "parameters": z.record(z.any()) })).optional(), "ttl_days": z.number().int().optional(), "live_at": z.number().int().optional() }).shape

--- a/servers/_metatx/src/tools/delete_contract_route_contracts_contract_id_delete.ts
+++ b/servers/_metatx/src/tools/delete_contract_route_contracts_contract_id_delete.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const toolName = `delete_contract_route_contracts_contract_id_delete`
+export const toolDescription = `Delete Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "contract_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid() }).shape

--- a/servers/_metatx/src/tools/delete_metatx_requester_holder_route_contracts_contract_id_holde.ts
+++ b/servers/_metatx/src/tools/delete_metatx_requester_holder_route_contracts_contract_id_holde.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+export const toolName = `delete_metatx_requester_holder_route_contracts_contract_id_holde`
+export const toolDescription = `Delete Metatx Requester Holder Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}/holders`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "contract_id"
+  ],
+  "cookie": [],
+  "body": [
+    "holder_id",
+    "holder_type",
+    "permissions"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid(), "holder_id": z.string().uuid(), "holder_type": z.enum(["user","group"]).describe("An enumeration."), "permissions": z.array(z.enum(["admin","create","read","update","delete"]).describe("An enumeration.")).optional() }).shape

--- a/servers/_metatx/src/tools/delete_requests_requests_delete.ts
+++ b/servers/_metatx/src/tools/delete_requests_requests_delete.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+
+export const toolName = `delete_requests_requests_delete`
+export const toolDescription = `Delete Requests`
+export const baseUrl = `/metatx`
+export const path = `/requests`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/tools/get_registered_contract_route_contracts_contract_id_get.ts
+++ b/servers/_metatx/src/tools/get_registered_contract_route_contracts_contract_id_get.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const toolName = `get_registered_contract_route_contracts_contract_id_get`
+export const toolDescription = `Get Registered Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "contract_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid() }).shape

--- a/servers/_metatx/src/tools/get_request_requests_request_id_get.ts
+++ b/servers/_metatx/src/tools/get_request_requests_request_id_get.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const toolName = `get_request_requests_request_id_get`
+export const toolDescription = `Get Request`
+export const baseUrl = `/metatx`
+export const path = `/requests/{request_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "request_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "request_id": z.string().uuid() }).shape

--- a/servers/_metatx/src/tools/list_metatx_requester_holders_route_contracts_contract_id_holder.ts
+++ b/servers/_metatx/src/tools/list_metatx_requester_holders_route_contracts_contract_id_holder.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+export const toolName = `list_metatx_requester_holders_route_contracts_contract_id_holder`
+export const toolDescription = `List Metatx Requester Holders Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}/holders`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [
+    "extended"
+  ],
+  "header": [],
+  "path": [
+    "contract_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid(), "extended": z.boolean() }).shape

--- a/servers/_metatx/src/tools/list_metatx_requesters_route_requesters_get.ts
+++ b/servers/_metatx/src/tools/list_metatx_requesters_route_requesters_get.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+
+export const toolName = `list_metatx_requesters_route_requesters_get`
+export const toolDescription = `List Metatx Requesters Route`
+export const baseUrl = `/metatx`
+export const path = `/requesters`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({}).shape

--- a/servers/_metatx/src/tools/list_registered_contracts_route_contracts_get.ts
+++ b/servers/_metatx/src/tools/list_registered_contracts_route_contracts_get.ts
@@ -1,0 +1,31 @@
+import { z } from "zod"
+
+export const toolName = `list_registered_contracts_route_contracts_get`
+export const toolDescription = `List Registered Contracts Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [
+    "blockchain",
+    "address",
+    "limit",
+    "offset"
+  ],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "blockchain": z.string().optional(), "address": z.string().optional(), "limit": z.number().int(), "offset": z.number().int().optional() }).shape

--- a/servers/_metatx/src/tools/list_requests_route_requests_get.ts
+++ b/servers/_metatx/src/tools/list_requests_route_requests_get.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const toolName = `list_requests_route_requests_get`
+export const toolDescription = `List Requests Route`
+export const baseUrl = `/metatx`
+export const path = `/requests`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [
+    "contract_id",
+    "contract_address",
+    "caller",
+    "limit",
+    "offset",
+    "show_expired",
+    "live_after"
+  ],
+  "header": [
+    "authorization"
+  ],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid().optional(), "contract_address": z.string().optional(), "caller": z.string(), "limit": z.number().int(), "offset": z.number().int().optional(), "show_expired": z.boolean(), "live_after": z.number().int().optional(), "authorization": z.string().optional() }).shape

--- a/servers/_metatx/src/tools/register_contract_route_contracts_post.ts
+++ b/servers/_metatx/src/tools/register_contract_route_contracts_post.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+export const toolName = `register_contract_route_contracts_post`
+export const toolDescription = `Register Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "blockchain",
+    "address",
+    "title",
+    "description",
+    "image_uri"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "blockchain": z.string(), "address": z.string(), "title": z.string().optional(), "description": z.string().optional(), "image_uri": z.string().optional() }).shape

--- a/servers/_metatx/src/tools/update_contract_route_contracts_contract_id_put.ts
+++ b/servers/_metatx/src/tools/update_contract_route_contracts_contract_id_put.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `update_contract_route_contracts_contract_id_put`
+export const toolDescription = `Update Contract Route`
+export const baseUrl = `/metatx`
+export const path = `/contracts/{contract_id}`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "contract_id"
+  ],
+  "cookie": [],
+  "body": [
+    "title",
+    "description",
+    "image_uri",
+    "ignore_nulls"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = z.object({ "contract_id": z.string().uuid(), "title": z.string().optional(), "description": z.string().optional(), "image_uri": z.string().optional(), "ignore_nulls": z.boolean() }).shape

--- a/servers/_metatx/tsconfig.json
+++ b/servers/_metatx/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_metatx`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_metatx`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_metatx": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_metatx"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.