### PR TITLE
Add MCP server `cloud_lambda_ai`

### DIFF
--- a/servers/cloud_lambda_ai/.npmignore
+++ b/servers/cloud_lambda_ai/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/cloud_lambda_ai/README.md
+++ b/servers/cloud_lambda_ai/README.md
@@ -1,0 +1,308 @@
+# @open-mcp/cloud_lambda_ai
+
+## Installing
+
+Use the helper command `add-to-client` to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/cloud_lambda_ai add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/cloud_lambda_ai add-to-client .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/cloud_lambda_ai add-to-client /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "cloud_lambda_ai": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/cloud_lambda_ai"],
+      "env": {"API_KEY":"...","USERNAME_PASSWORD_BASE64":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/cloud_lambda_ai
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/cloud_lambda_ai`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### listinstances
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### getinstance
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "id": z.string().describe("The unique identifier (ID) of the instance")
+}
+```
+
+### postinstance
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "id": z.string().describe("The unique identifier (ID) of the instance"),
+  "name": z.string().min(0).max(64).describe("The new, user-provided name for the instance.").optional()
+}
+```
+
+### listinstancetypes
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### launchinstance
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "region_name": z.enum(["europe-central-1","asia-south-1","australia-east-1","me-west-1","asia-northeast-1","asia-northeast-2","us-east-1","us-west-2","us-west-1","us-south-1","us-west-3","us-midwest-1","us-east-2","us-south-2","us-south-3","us-east-3","us-midwest-2","test-east-1","test-west-1"]).describe("The region into which you want to launch the instance."),
+  "instance_type_name": z.string().describe("The type of instance you want to launch. To retrieve a list of available instance types, see\n[List available instance types](#get-/api/v1/instance-types)."),
+  "ssh_key_names": z.array(z.string()).describe("The names of the SSH keys you want to use to provide access to the instance.\nCurrently, exactly one SSH key must be specified."),
+  "file_system_names": z.array(z.string()).describe("The names of the filesystems you want to attach to the instance.\nCurrently, you can attach only one filesystem during instance creation.\nBy default, no filesystems are attached.").optional(),
+  "name": z.string().min(0).max(64).describe("The name you want to assign to your instance. Must be 64 characters or fewer.").optional(),
+  "image": z.union([z.object({ "id": z.string() }).describe("Specifies the image to use by its unique identifier."), z.object({ "family": z.string().describe("The family name of the image.") }).describe("Specifies the image to use by its family name.")]).describe("The machine image you want to use. Defaults to the latest Lambda Stack image.").optional(),
+  "user_data": z.string().describe("An instance configuration string specified in a valid\n[cloud-init user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html)\nformat. You can use this field to configure your instance on launch. The\nuser data string must be plain text and cannot exceed 1MB in size.").optional()
+}
+```
+
+### restartinstance
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "instance_ids": z.array(z.string()).describe("The unique identifiers (IDs) of the instances to restart.")
+}
+```
+
+### terminateinstance
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "instance_ids": z.array(z.string()).describe("The unique identifiers (IDs) of the instances to terminate.")
+}
+```
+
+### listsshkeys
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### addsshkey
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "name": z.string().min(1).max(64).describe("The name of the SSH key."),
+  "public_key": z.string().min(1).max(4096).describe("The public key for the SSH key.").optional()
+}
+```
+
+### deletesshkey
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "id": z.string()
+}
+```
+
+### listfilesystems
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### createfilesystem
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "name": z.string().regex(new RegExp("^[a-zA-Z]+[0-9a-zA-Z-]*$")).min(1).max(60).describe("The name of the filesystem."),
+  "region": z.enum(["europe-central-1","asia-south-1","australia-east-1","me-west-1","asia-northeast-1","asia-northeast-2","us-east-1","us-west-2","us-west-1","us-south-1","us-west-3","us-midwest-1","us-east-2","us-south-2","us-south-3","us-east-3","us-midwest-2","test-east-1","test-west-1"]).describe("The region in which you want to create the filesystem.")
+}
+```
+
+### filesystemdelete
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "id": z.string()
+}
+```
+
+### listimages
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### firewallruleslist
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### firewallrulesset
+
+**Environment variables**
+
+- `API_KEY`
+- `USERNAME_PASSWORD_BASE64`
+
+**Input schema**
+
+```ts
+{
+  "data": z.array(z.object({ "protocol": z.enum(["tcp","udp","icmp","all"]).describe("The protocol to which the rule applies."), "port_range": z.array(z.number().int().gte(1).lte(65535)).min(2).max(2).describe("An inclusive range of network ports specified as \`[min, max]\`.\nNot allowed for the \`icmp\` protocol but required for the others.\n\nTo specify a single port, list it twice (for example, \`[22,22]\`).").optional(), "source_network": z.string().describe("The set of source IPv4 addresses from which you want to allow inbound\ntraffic. These addresses must be specified in CIDR notation. You can\nspecify individual public IPv4 CIDR blocks such as \`1.2.3.4\` or\n\`1.2.3.4/32\`, or you can specify \`0.0.0.0/0\` to allow access from any\naddress.\n\nThis value is a string consisting of a public IPv4 address optionally\nfollowed by a slash (/) and an integer mask (the network prefix).\nIf no mask is provided, the API assumes \`/32\` by default."), "description": z.string().min(0).max(128).describe("A human-readable description of the rule.") })).describe("The list of inbound firewall rules.")
+}
+```

--- a/servers/cloud_lambda_ai/package.json
+++ b/servers/cloud_lambda_ai/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/cloud_lambda_ai",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "cloud_lambda_ai": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/cloud_lambda_ai/src/add-to-client.ts
+++ b/servers/cloud_lambda_ai/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/cloud_lambda_ai/src/constants.ts
+++ b/servers/cloud_lambda_ai/src/constants.ts
@@ -1,0 +1,21 @@
+export const OPENAPI_URL = "https://cloud.lambda.ai/api/v1/openapi.json"
+export const SERVER_NAME = "cloud_lambda_ai"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/listinstances.js",
+  "./tools/getinstance.js",
+  "./tools/postinstance.js",
+  "./tools/listinstancetypes.js",
+  "./tools/launchinstance.js",
+  "./tools/restartinstance.js",
+  "./tools/terminateinstance.js",
+  "./tools/listsshkeys.js",
+  "./tools/addsshkey.js",
+  "./tools/deletesshkey.js",
+  "./tools/listfilesystems.js",
+  "./tools/createfilesystem.js",
+  "./tools/filesystemdelete.js",
+  "./tools/listimages.js",
+  "./tools/firewallruleslist.js",
+  "./tools/firewallrulesset.js"
+]

--- a/servers/cloud_lambda_ai/src/index.ts
+++ b/servers/cloud_lambda_ai/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/cloud_lambda_ai/src/lib.ts
+++ b/servers/cloud_lambda_ai/src/lib.ts
@@ -1,0 +1,49 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      paramObj[originalKey] = flat[flatKey]
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/cloud_lambda_ai/src/mcp-client-config.json
+++ b/servers/cloud_lambda_ai/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "cloud_lambda_ai": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/cloud_lambda_ai"],
+      "env": {"API_KEY":"...","USERNAME_PASSWORD_BASE64":"..."}
+    }
+  }
+}

--- a/servers/cloud_lambda_ai/src/server.ts
+++ b/servers/cloud_lambda_ai/src/server.ts
@@ -1,0 +1,186 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/cloud_lambda_ai/src/tools/addsshkey.ts
+++ b/servers/cloud_lambda_ai/src/tools/addsshkey.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+export const toolName = `addsshkey`
+export const toolDescription = `Add an SSH key`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/ssh-keys`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "name",
+    "public_key"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "name": z.string().min(1).max(64).describe("The name of the SSH key."),
+  "public_key": z.string().min(1).max(4096).describe("The public key for the SSH key.").optional()
+}

--- a/servers/cloud_lambda_ai/src/tools/createfilesystem.ts
+++ b/servers/cloud_lambda_ai/src/tools/createfilesystem.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+export const toolName = `createfilesystem`
+export const toolDescription = `Create filesystem`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/filesystems`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "name",
+    "region"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "name": z.string().regex(new RegExp("^[a-zA-Z]+[0-9a-zA-Z-]*$")).min(1).max(60).describe("The name of the filesystem."),
+  "region": z.enum(["europe-central-1","asia-south-1","australia-east-1","me-west-1","asia-northeast-1","asia-northeast-2","us-east-1","us-west-2","us-west-1","us-south-1","us-west-3","us-midwest-1","us-east-2","us-south-2","us-south-3","us-east-3","us-midwest-2","test-east-1","test-west-1"]).describe("The region in which you want to create the filesystem.")
+}

--- a/servers/cloud_lambda_ai/src/tools/deletesshkey.ts
+++ b/servers/cloud_lambda_ai/src/tools/deletesshkey.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+export const toolName = `deletesshkey`
+export const toolDescription = `Delete an SSH key`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/ssh-keys/{id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.string()
+}

--- a/servers/cloud_lambda_ai/src/tools/filesystemdelete.ts
+++ b/servers/cloud_lambda_ai/src/tools/filesystemdelete.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+export const toolName = `filesystemdelete`
+export const toolDescription = `Delete filesystem`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/filesystems/{id}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.string()
+}

--- a/servers/cloud_lambda_ai/src/tools/firewallruleslist.ts
+++ b/servers/cloud_lambda_ai/src/tools/firewallruleslist.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `firewallruleslist`
+export const toolDescription = `List inbound firewall rules`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/firewall-rules`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/cloud_lambda_ai/src/tools/firewallrulesset.ts
+++ b/servers/cloud_lambda_ai/src/tools/firewallrulesset.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+export const toolName = `firewallrulesset`
+export const toolDescription = `Replace inbound firewall rules`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/firewall-rules`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "data"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "data": z.array(z.object({ "protocol": z.enum(["tcp","udp","icmp","all"]).describe("The protocol to which the rule applies."), "port_range": z.array(z.number().int().gte(1).lte(65535)).min(2).max(2).describe("An inclusive range of network ports specified as `[min, max]`.\nNot allowed for the `icmp` protocol but required for the others.\n\nTo specify a single port, list it twice (for example, `[22,22]`).").optional(), "source_network": z.string().describe("The set of source IPv4 addresses from which you want to allow inbound\ntraffic. These addresses must be specified in CIDR notation. You can\nspecify individual public IPv4 CIDR blocks such as `1.2.3.4` or\n`1.2.3.4/32`, or you can specify `0.0.0.0/0` to allow access from any\naddress.\n\nThis value is a string consisting of a public IPv4 address optionally\nfollowed by a slash (/) and an integer mask (the network prefix).\nIf no mask is provided, the API assumes `/32` by default."), "description": z.string().min(0).max(128).describe("A human-readable description of the rule.") })).describe("The list of inbound firewall rules.")
+}

--- a/servers/cloud_lambda_ai/src/tools/getinstance.ts
+++ b/servers/cloud_lambda_ai/src/tools/getinstance.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+export const toolName = `getinstance`
+export const toolDescription = `Retrieve instance details`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instances/{id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.string().describe("The unique identifier (ID) of the instance")
+}

--- a/servers/cloud_lambda_ai/src/tools/launchinstance.ts
+++ b/servers/cloud_lambda_ai/src/tools/launchinstance.ts
@@ -1,0 +1,51 @@
+import { z } from "zod"
+
+export const toolName = `launchinstance`
+export const toolDescription = `Launch instances`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instance-operations/launch`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "region_name",
+    "instance_type_name",
+    "ssh_key_names",
+    "file_system_names",
+    "name",
+    "image",
+    "user_data"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "region_name": z.enum(["europe-central-1","asia-south-1","australia-east-1","me-west-1","asia-northeast-1","asia-northeast-2","us-east-1","us-west-2","us-west-1","us-south-1","us-west-3","us-midwest-1","us-east-2","us-south-2","us-south-3","us-east-3","us-midwest-2","test-east-1","test-west-1"]).describe("The region into which you want to launch the instance."),
+  "instance_type_name": z.string().describe("The type of instance you want to launch. To retrieve a list of available instance types, see\n[List available instance types](#get-/api/v1/instance-types)."),
+  "ssh_key_names": z.array(z.string()).describe("The names of the SSH keys you want to use to provide access to the instance.\nCurrently, exactly one SSH key must be specified."),
+  "file_system_names": z.array(z.string()).describe("The names of the filesystems you want to attach to the instance.\nCurrently, you can attach only one filesystem during instance creation.\nBy default, no filesystems are attached.").optional(),
+  "name": z.string().min(0).max(64).describe("The name you want to assign to your instance. Must be 64 characters or fewer.").optional(),
+  "image": z.union([z.object({ "id": z.string() }).describe("Specifies the image to use by its unique identifier."), z.object({ "family": z.string().describe("The family name of the image.") }).describe("Specifies the image to use by its family name.")]).describe("The machine image you want to use. Defaults to the latest Lambda Stack image.").optional(),
+  "user_data": z.string().describe("An instance configuration string specified in a valid\n[cloud-init user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html)\nformat. You can use this field to configure your instance on launch. The\nuser data string must be plain text and cannot exceed 1MB in size.").optional()
+}

--- a/servers/cloud_lambda_ai/src/tools/listfilesystems.ts
+++ b/servers/cloud_lambda_ai/src/tools/listfilesystems.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `listfilesystems`
+export const toolDescription = `List filesystems`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/file-systems`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/cloud_lambda_ai/src/tools/listimages.ts
+++ b/servers/cloud_lambda_ai/src/tools/listimages.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `listimages`
+export const toolDescription = `List available images`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/images`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/cloud_lambda_ai/src/tools/listinstances.ts
+++ b/servers/cloud_lambda_ai/src/tools/listinstances.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `listinstances`
+export const toolDescription = `List running instances`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instances`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/cloud_lambda_ai/src/tools/listinstancetypes.ts
+++ b/servers/cloud_lambda_ai/src/tools/listinstancetypes.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `listinstancetypes`
+export const toolDescription = `List available instance types`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instance-types`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/cloud_lambda_ai/src/tools/listsshkeys.ts
+++ b/servers/cloud_lambda_ai/src/tools/listsshkeys.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `listsshkeys`
+export const toolDescription = `List your SSH keys`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/ssh-keys`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/cloud_lambda_ai/src/tools/postinstance.ts
+++ b/servers/cloud_lambda_ai/src/tools/postinstance.ts
@@ -1,0 +1,42 @@
+import { z } from "zod"
+
+export const toolName = `postinstance`
+export const toolDescription = `Update instance details`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instances/{id}`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "id"
+  ],
+  "cookie": [],
+  "body": [
+    "name"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.string().describe("The unique identifier (ID) of the instance"),
+  "name": z.string().min(0).max(64).describe("The new, user-provided name for the instance.").optional()
+}

--- a/servers/cloud_lambda_ai/src/tools/restartinstance.ts
+++ b/servers/cloud_lambda_ai/src/tools/restartinstance.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+export const toolName = `restartinstance`
+export const toolDescription = `Restart instances`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instance-operations/restart`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "instance_ids"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "instance_ids": z.array(z.string()).describe("The unique identifiers (IDs) of the instances to restart.")
+}

--- a/servers/cloud_lambda_ai/src/tools/terminateinstance.ts
+++ b/servers/cloud_lambda_ai/src/tools/terminateinstance.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+export const toolName = `terminateinstance`
+export const toolDescription = `Terminate instances`
+export const baseUrl = `https://cloud.lambda.ai`
+export const path = `/api/v1/instance-operations/terminate`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+    "in": "header",
+    "envVarName": "USERNAME_PASSWORD_BASE64",
+    "schemeType": "http",
+    "schemeScheme": "basic"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "instance_ids"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "instance_ids": z.array(z.string()).describe("The unique identifiers (IDs) of the instances to terminate.")
+}

--- a/servers/cloud_lambda_ai/tsconfig.json
+++ b/servers/cloud_lambda_ai/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `cloud_lambda_ai`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/cloud_lambda_ai`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "cloud_lambda_ai": {
      "command": "npx",
      "args": ["-y", "@open-mcp/cloud_lambda_ai"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.