### PR TITLE
Add MCP server `postontarget_com`

### DIFF
--- a/servers/postontarget_com/.npmignore
+++ b/servers/postontarget_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/postontarget_com/README.md
+++ b/servers/postontarget_com/README.md
@@ -1,0 +1,245 @@
+# @open-mcp/postontarget_com
+
+## Installing
+
+Use the helper command `add-to-client` to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/postontarget_com add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/postontarget_com add-to-client .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/postontarget_com add-to-client /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "postontarget_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/postontarget_com"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/postontarget_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/postontarget_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### post_fields_country
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "country_code": z.string().optional(), "country_name_EN": z.string().optional(), "country_name_IT": z.string().optional() }).optional()
+}
+```
+
+### post_fields_admin1_geo
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.string().optional(), "admin1_name": z.string().optional(), "admin1_name_ascii": z.string().optional(), "country_code": z.string().optional() }).optional()
+}
+```
+
+### post_fields_admin2_geo
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.string().optional(), "admin2_name": z.string().optional(), "admin2_name_ascii": z.string().optional(), "country_code": z.string().optional(), "id_admin1": z.string().optional() }).optional()
+}
+```
+
+### post_fields_dipendenti
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "dipendenti": z.string().optional() }).optional()
+}
+```
+
+### post_fields_fatturato
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "fatturato": z.string().optional() }).optional()
+}
+```
+
+### post_fields_forma_giuridica
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.number().int().optional(), "forma_giuridica": z.string().optional(), "country_code": z.string().optional() }).optional()
+}
+```
+
+### post_fields_macrocategorie
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.number().int().optional(), "macro_name_IT": z.string().optional(), "macro_name_EN": z.string().optional() }).optional()
+}
+```
+
+### post_fields_microcategorie
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.number().int().optional(), "micro_name_IT": z.string().optional(), "micro_name_EN": z.string().optional(), "id_macro": z.number().int().optional() }).optional()
+}
+```
+
+### post_search
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "query": z.object({ "country_code": z.string().describe("Code of the country where you want to search for personal data").optional(), "admin1_code": z.string().describe("Code of the region where you want to search for data").optional(), "admin2_code": z.string().describe("Code of the province where you want to search for data").optional(), "dipendenti": z.string().describe("Range of employed employees who must have the company").optional(), "fatturato": z.string().describe("Range of turnover in which the company must be included").optional(), "forma_giuridica_id": z.number().int().describe("Legal form identifier that the company must have").optional(), "macro_id": z.number().int().describe("Commodity macro-category identifier to which the company must belong").optional(), "micro_id": z.number().int().describe("Commodity macro-category identifier to which the company must belong").optional() })
+}
+```
+
+### post_buying
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "id_request": z.string().describe("Request identifier returned after performing a POST Search").optional(),
+  "records": z.number().int().describe("Number of records that you want to buy").optional()
+}
+```
+
+### get_state
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### get_state_id_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "_id": z.string().describe("Request / search identifier")
+}
+```

--- a/servers/postontarget_com/package.json
+++ b/servers/postontarget_com/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/postontarget_com",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "postontarget_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/postontarget_com/src/add-to-client.ts
+++ b/servers/postontarget_com/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/postontarget_com/src/constants.ts
+++ b/servers/postontarget_com/src/constants.ts
@@ -1,0 +1,17 @@
+export const OPENAPI_URL = "https://console.openapi.com/oas/en/postontarget.openapi.json"
+export const SERVER_NAME = "postontarget_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/post_fields_country.js",
+  "./tools/post_fields_admin1_geo.js",
+  "./tools/post_fields_admin2_geo.js",
+  "./tools/post_fields_dipendenti.js",
+  "./tools/post_fields_fatturato.js",
+  "./tools/post_fields_forma_giuridica.js",
+  "./tools/post_fields_macrocategorie.js",
+  "./tools/post_fields_microcategorie.js",
+  "./tools/post_search.js",
+  "./tools/post_buying.js",
+  "./tools/get_state.js",
+  "./tools/get_state_id_.js"
+]

--- a/servers/postontarget_com/src/index.ts
+++ b/servers/postontarget_com/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/postontarget_com/src/lib.ts
+++ b/servers/postontarget_com/src/lib.ts
@@ -1,0 +1,49 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      paramObj[originalKey] = flat[flatKey]
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/postontarget_com/src/mcp-client-config.json
+++ b/servers/postontarget_com/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "postontarget_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/postontarget_com"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}

--- a/servers/postontarget_com/src/server.ts
+++ b/servers/postontarget_com/src/server.ts
@@ -1,0 +1,186 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/postontarget_com/src/tools/get_state.ts
+++ b/servers/postontarget_com/src/tools/get_state.ts
@@ -1,0 +1,27 @@
+import { z } from "zod"
+
+export const toolName = `get_state`
+export const toolDescription = `List of requests`
+export const baseUrl = `https://postontarget.com`
+export const path = `/state`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/postontarget_com/src/tools/get_state_id_.ts
+++ b/servers/postontarget_com/src/tools/get_state_id_.ts
@@ -1,0 +1,31 @@
+import { z } from "zod"
+
+export const toolName = `get_state_id_`
+export const toolDescription = `Single request`
+export const baseUrl = `https://postontarget.com`
+export const path = `/state/{_id}`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "_id": z.string().describe("Request / search identifier")
+}

--- a/servers/postontarget_com/src/tools/post_buying.ts
+++ b/servers/postontarget_com/src/tools/post_buying.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_buying`
+export const toolDescription = `Purchase of personal data`
+export const baseUrl = `https://postontarget.com`
+export const path = `/buying`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "id_request",
+    "records"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id_request": z.string().describe("Request identifier returned after performing a POST Search").optional(),
+  "records": z.number().int().describe("Number of records that you want to buy").optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_admin1_geo.ts
+++ b/servers/postontarget_com/src/tools/post_fields_admin1_geo.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_admin1_geo`
+export const toolDescription = `List of regions`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/admin1_geo`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.string().optional(), "admin1_name": z.string().optional(), "admin1_name_ascii": z.string().optional(), "country_code": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_admin2_geo.ts
+++ b/servers/postontarget_com/src/tools/post_fields_admin2_geo.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_admin2_geo`
+export const toolDescription = `List of provinces`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/admin2_geo`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.string().optional(), "admin2_name": z.string().optional(), "admin2_name_ascii": z.string().optional(), "country_code": z.string().optional(), "id_admin1": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_country.ts
+++ b/servers/postontarget_com/src/tools/post_fields_country.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_country`
+export const toolDescription = `List of countries`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/country`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "country_code": z.string().optional(), "country_name_EN": z.string().optional(), "country_name_IT": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_dipendenti.ts
+++ b/servers/postontarget_com/src/tools/post_fields_dipendenti.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_dipendenti`
+export const toolDescription = `List of number of employees`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/dipendenti`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "dipendenti": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_fatturato.ts
+++ b/servers/postontarget_com/src/tools/post_fields_fatturato.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_fatturato`
+export const toolDescription = `List of companies turnover`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/fatturato`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "fatturato": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_forma_giuridica.ts
+++ b/servers/postontarget_com/src/tools/post_fields_forma_giuridica.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_forma_giuridica`
+export const toolDescription = `List of corporate legal forms`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/forma_giuridica`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.number().int().optional(), "forma_giuridica": z.string().optional(), "country_code": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_macrocategorie.ts
+++ b/servers/postontarget_com/src/tools/post_fields_macrocategorie.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_macrocategorie`
+export const toolDescription = `List of commercial macro-categories`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/macrocategorie`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.number().int().optional(), "macro_name_IT": z.string().optional(), "macro_name_EN": z.string().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_fields_microcategorie.ts
+++ b/servers/postontarget_com/src/tools/post_fields_microcategorie.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `post_fields_microcategorie`
+export const toolDescription = `List of micro-commercial categories`
+export const baseUrl = `https://postontarget.com`
+export const path = `/fields/microcategorie`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "limit",
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "limit": z.number().int().optional(),
+  "query": z.object({ "ID": z.number().int().optional(), "micro_name_IT": z.string().optional(), "micro_name_EN": z.string().optional(), "id_macro": z.number().int().optional() }).optional()
+}

--- a/servers/postontarget_com/src/tools/post_search.ts
+++ b/servers/postontarget_com/src/tools/post_search.ts
@@ -1,0 +1,31 @@
+import { z } from "zod"
+
+export const toolName = `post_search`
+export const toolDescription = `Find company records`
+export const baseUrl = `https://postontarget.com`
+export const path = `/search`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "http",
+    "schemeScheme": "bearer"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "query"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "query": z.object({ "country_code": z.string().describe("Code of the country where you want to search for personal data").optional(), "admin1_code": z.string().describe("Code of the region where you want to search for data").optional(), "admin2_code": z.string().describe("Code of the province where you want to search for data").optional(), "dipendenti": z.string().describe("Range of employed employees who must have the company").optional(), "fatturato": z.string().describe("Range of turnover in which the company must be included").optional(), "forma_giuridica_id": z.number().int().describe("Legal form identifier that the company must have").optional(), "macro_id": z.number().int().describe("Commodity macro-category identifier to which the company must belong").optional(), "micro_id": z.number().int().describe("Commodity macro-category identifier to which the company must belong").optional() })
+}

--- a/servers/postontarget_com/tsconfig.json
+++ b/servers/postontarget_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `postontarget_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/postontarget_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "postontarget_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/postontarget_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.