### PR TITLE
Add MCP server `verkehr_autobahn_de_o_autobahn`

### DIFF
--- a/servers/verkehr_autobahn_de_o_autobahn/.npmignore
+++ b/servers/verkehr_autobahn_de_o_autobahn/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/verkehr_autobahn_de_o_autobahn/README.md
+++ b/servers/verkehr_autobahn_de_o_autobahn/README.md
@@ -1,0 +1,250 @@
+# @open-mcp/verkehr_autobahn_de_o_autobahn
+
+## Installing
+
+Use the helper command `add-to-client` to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/verkehr_autobahn_de_o_autobahn add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/verkehr_autobahn_de_o_autobahn add-to-client .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/verkehr_autobahn_de_o_autobahn add-to-client /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "verkehr_autobahn_de_o_autobahn": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/verkehr_autobahn_de_o_autobahn"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/verkehr_autobahn_de_o_autobahn
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/verkehr_autobahn_de_o_autobahn`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### list_autobahnen
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### list_roadworks
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}
+```
+
+### get_roadwork
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadworkId": z.string()
+}
+```
+
+### list_webcams
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}
+```
+
+### get_webcam
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "webcamId": z.string()
+}
+```
+
+### list_parking_lorries
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}
+```
+
+### get_parking_lorry
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "lorryId": z.string()
+}
+```
+
+### list_warnings
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}
+```
+
+### get_warning
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "warningId": z.string()
+}
+```
+
+### list_closures
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}
+```
+
+### get_closure
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "closureId": z.string()
+}
+```
+
+### list_charging_stations
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}
+```
+
+### get_charging_station
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "stationId": z.string()
+}
+```

--- a/servers/verkehr_autobahn_de_o_autobahn/package.json
+++ b/servers/verkehr_autobahn_de_o_autobahn/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/verkehr_autobahn_de_o_autobahn",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "verkehr_autobahn_de_o_autobahn": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/add-to-client.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/constants.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/constants.ts
@@ -1,0 +1,18 @@
+export const OPENAPI_URL = "https://autobahn.api.bund.dev/openapi.yaml"
+export const SERVER_NAME = "verkehr_autobahn_de_o_autobahn"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/list_autobahnen.js",
+  "./tools/list_roadworks.js",
+  "./tools/get_roadwork.js",
+  "./tools/list_webcams.js",
+  "./tools/get_webcam.js",
+  "./tools/list_parking_lorries.js",
+  "./tools/get_parking_lorry.js",
+  "./tools/list_warnings.js",
+  "./tools/get_warning.js",
+  "./tools/list_closures.js",
+  "./tools/get_closure.js",
+  "./tools/list_charging_stations.js",
+  "./tools/get_charging_station.js"
+]

--- a/servers/verkehr_autobahn_de_o_autobahn/src/index.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/lib.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/lib.ts
@@ -1,0 +1,49 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      paramObj[originalKey] = flat[flatKey]
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/mcp-client-config.json
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "verkehr_autobahn_de_o_autobahn": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/verkehr_autobahn_de_o_autobahn"],
+      "env": {}
+    }
+  }
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/server.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/server.ts
@@ -1,0 +1,186 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_charging_station.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_charging_station.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `get_charging_station`
+export const toolDescription = `Details zu einer Ladestation`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/details/electric_charging_station/{stationId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "stationId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "stationId": z.string()
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_closure.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_closure.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `get_closure`
+export const toolDescription = `Details zu einer Sperrung`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/details/closure/{closureId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "closureId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "closureId": z.string()
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_parking_lorry.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_parking_lorry.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `get_parking_lorry`
+export const toolDescription = `Details eines Rastplatzes`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/details/parking_lorry/{lorryId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "lorryId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "lorryId": z.string()
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_roadwork.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_roadwork.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `get_roadwork`
+export const toolDescription = `Details einer Baustelle`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/details/roadworks/{roadworkId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadworkId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadworkId": z.string()
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_warning.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_warning.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `get_warning`
+export const toolDescription = `Details zu einer Verkehrsmeldung`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/details/warning/{warningId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "warningId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "warningId": z.string()
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_webcam.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/get_webcam.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `get_webcam`
+export const toolDescription = `Details einer Webcam`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/details/webcam/{webcamId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "webcamId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "webcamId": z.string()
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_autobahnen.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_autobahnen.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `list_autobahnen`
+export const toolDescription = `Liste verfügbarer Autobahnen`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_charging_stations.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_charging_stations.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `list_charging_stations`
+export const toolDescription = `Liste aktueller Ladestationen`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/{roadId}/services/electric_charging_station`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_closures.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_closures.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `list_closures`
+export const toolDescription = `Liste aktueller Sperrungen`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/{roadId}/services/closure`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_parking_lorries.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_parking_lorries.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `list_parking_lorries`
+export const toolDescription = `Liste verfügbarer Rastplätze`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/{roadId}/services/parking_lorry`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_roadworks.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_roadworks.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `list_roadworks`
+export const toolDescription = `Liste aktueller Baustellen`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/{roadId}/services/roadworks`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_warnings.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_warnings.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `list_warnings`
+export const toolDescription = `Liste aktueller Verkehrsmeldungen`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/{roadId}/services/warning`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_webcams.ts
+++ b/servers/verkehr_autobahn_de_o_autobahn/src/tools/list_webcams.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `list_webcams`
+export const toolDescription = `Liste verfügbarer Webcams`
+export const baseUrl = `https://verkehr.autobahn.de/o/autobahn`
+export const path = `/{roadId}/services/webcam`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "roadId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "roadId": z.string().regex(new RegExp("[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?")).describe("Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).\n")
+}

--- a/servers/verkehr_autobahn_de_o_autobahn/tsconfig.json
+++ b/servers/verkehr_autobahn_de_o_autobahn/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `verkehr_autobahn_de_o_autobahn`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/verkehr_autobahn_de_o_autobahn`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "verkehr_autobahn_de_o_autobahn": {
      "command": "npx",
      "args": ["-y", "@open-mcp/verkehr_autobahn_de_o_autobahn"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.