### PR TITLE
Add MCP server `mintlify`

### DIFF
--- a/servers/mintlify/README.md
+++ b/servers/mintlify/README.md
@@ -2,25 +2,26 @@
 
 ## Installing
 
-### With helper
+Use the helper command `add-to-client` to add the server to your MCP client:
 
-Use the `add-to-client` helper to add the server to your MCP client:
+### Claude desktop
+
+```bash
+npx @open-mcp/mintlify add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/mintlify add-to-client .cursor/mcp.json
+```
+
+### Other
 
 ```bash
 npx @open-mcp/mintlify add-to-client /path/to/client/config.json
-```
-
-For example:
-
-```bash
-# Claude desktop:
-npx @open-mcp/mintlify add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
-
-# Cursor project (run from the project dir):
-npx @open-mcp/mintlify add-to-client .cursor/mcp.json
-
-# Cursor global (applies to all projects):
-npx @open-mcp/mintlify add-to-client ~/.cursor/mcp.json
 ```
 
 ### Manually
@@ -47,14 +48,6 @@ Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base UR
 
 - `API_KEY`
 
-## Tools
-
-### get_plants
-
-### post_plants
-
-### delete_plants_id_
-
 ## Inspector
 
 Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
@@ -73,3 +66,45 @@ npx -y @modelcontextprotocol/inspector npx -y @open-mcp/mintlify
 It should say _MCP Server running on stdio_ in red.
 
 - Click `List Tools`
+
+## Tools
+
+### get_plants
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "limit": z.number().int().describe("The maximum number of results to return").optional()
+}
+```
+
+### post_plants
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### delete_plants_id_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().describe("ID of plant to delete")
+}
+```

--- a/servers/mintlify/package.json
+++ b/servers/mintlify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mcp/mintlify",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "main": "index.js",
   "type": "module",
   "bin": {

--- a/servers/mintlify/src/tools/delete_plants_id_.ts
+++ b/servers/mintlify/src/tools/delete_plants_id_.ts
@@ -26,4 +26,6 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "id": z.number().int().describe("ID of plant to delete") }).shape
+export const inputParams = {
+  "id": z.number().int().describe("ID of plant to delete")
+}

--- a/servers/mintlify/src/tools/get_plants.ts
+++ b/servers/mintlify/src/tools/get_plants.ts
@@ -26,4 +26,6 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "limit": z.number().int().describe("The maximum number of results to return").optional() }).shape
+export const inputParams = {
+  "limit": z.number().int().describe("The maximum number of results to return").optional()
+}

--- a/servers/mintlify/src/tools/post_plants.ts
+++ b/servers/mintlify/src/tools/post_plants.ts
@@ -24,4 +24,4 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({}).shape
+export const inputParams = {}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `mintlify`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/mintlify`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "mintlify": {
      "command": "npx",
      "args": ["-y", "@open-mcp/mintlify"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.