### PR TITLE
Add MCP server `thegraph-token-api`

### DIFF
--- a/servers/thegraph-token-api/README.md
+++ b/servers/thegraph-token-api/README.md
@@ -2,25 +2,26 @@
 
 ## Installing
 
-### With helper
+Use the helper command `add-to-client` to add the server to your MCP client:
 
-Use the `add-to-client` helper to add the server to your MCP client:
+### Claude desktop
+
+```bash
+npx @open-mcp/thegraph-token-api add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/thegraph-token-api add-to-client .cursor/mcp.json
+```
+
+### Other
 
 ```bash
 npx @open-mcp/thegraph-token-api add-to-client /path/to/client/config.json
-```
-
-For example:
-
-```bash
-# Claude desktop:
-npx @open-mcp/thegraph-token-api add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
-
-# Cursor project (run from the project dir):
-npx @open-mcp/thegraph-token-api add-to-client .cursor/mcp.json
-
-# Cursor global (applies to all projects):
-npx @open-mcp/thegraph-token-api add-to-client ~/.cursor/mcp.json
 ```
 
 ### Manually
@@ -47,24 +48,6 @@ Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base UR
 
 - `API_KEY`
 
-## Tools
-
-### getbalancesevmbyaddress
-
-### gettransfersevmbyaddress
-
-### getholdersevmbycontract
-
-### gettokensevmbycontract
-
-### getohlcpricesevmbycontract
-
-### gethealth
-
-### getversion
-
-### getnetworks
-
 ## Inspector
 
 Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
@@ -83,3 +66,131 @@ npx -y @modelcontextprotocol/inspector npx -y @open-mcp/thegraph-token-api
 It should say _MCP Server running on stdio_ in red.
 
 - Click `List Tools`
+
+## Tools
+
+### getbalancesevmbyaddress
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "contract": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}
+```
+
+### gettransfersevmbyaddress
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "age": z.number().int().gte(1).lte(180).describe("Indicates how many days have passed since the data's creation or insertion.").optional(),
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("Filter by contract address").optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}
+```
+
+### getholdersevmbycontract
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "order_by": z.enum(["asc","desc"]).describe("The order in which to return the results: Ascending (asc) or Descending (desc).").optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}
+```
+
+### gettokensevmbycontract
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional()
+}
+```
+
+### getohlcpricesevmbycontract
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "interval": z.enum(["1h","4h","1d","1w"]).describe("The interval for which to aggregate price data (hourly, 4-hours, daily or weekly).").optional(),
+  "startTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(),
+  "endTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}
+```
+
+### gethealth
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### getversion
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### getnetworks
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```

--- a/servers/thegraph-token-api/package.json
+++ b/servers/thegraph-token-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mcp/thegraph-token-api",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "main": "index.js",
   "type": "module",
   "bin": {

--- a/servers/thegraph-token-api/src/tools/getbalancesevmbyaddress.ts
+++ b/servers/thegraph-token-api/src/tools/getbalancesevmbyaddress.ts
@@ -31,4 +31,10 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query"), "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "contract": z.string().optional(), "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).shape
+export const inputParams = {
+  "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "contract": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}

--- a/servers/thegraph-token-api/src/tools/gethealth.ts
+++ b/servers/thegraph-token-api/src/tools/gethealth.ts
@@ -15,4 +15,4 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({}).shape
+export const inputParams = {}

--- a/servers/thegraph-token-api/src/tools/getholdersevmbycontract.ts
+++ b/servers/thegraph-token-api/src/tools/getholdersevmbycontract.ts
@@ -31,4 +31,10 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"), "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "order_by": z.enum(["asc","desc"]).describe("The order in which to return the results: Ascending (asc) or Descending (desc)."), "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).shape
+export const inputParams = {
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "order_by": z.enum(["asc","desc"]).describe("The order in which to return the results: Ascending (asc) or Descending (desc).").optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}

--- a/servers/thegraph-token-api/src/tools/getnetworks.ts
+++ b/servers/thegraph-token-api/src/tools/getnetworks.ts
@@ -15,4 +15,4 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({}).shape
+export const inputParams = {}

--- a/servers/thegraph-token-api/src/tools/getohlcpricesevmbycontract.ts
+++ b/servers/thegraph-token-api/src/tools/getohlcpricesevmbycontract.ts
@@ -33,4 +33,12 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"), "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "interval": z.enum(["1h","4h","1d","1w"]).describe("The interval for which to aggregate price data (hourly, 4-hours, daily or weekly)."), "startTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(), "endTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(), "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).shape
+export const inputParams = {
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "interval": z.enum(["1h","4h","1d","1w"]).describe("The interval for which to aggregate price data (hourly, 4-hours, daily or weekly).").optional(),
+  "startTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(),
+  "endTime": z.number().gte(0).describe("UNIX timestamp in seconds.").optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}

--- a/servers/thegraph-token-api/src/tools/gettokensevmbycontract.ts
+++ b/servers/thegraph-token-api/src/tools/gettokensevmbycontract.ts
@@ -28,4 +28,7 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"), "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional() }).shape
+export const inputParams = {
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM contract address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional()
+}

--- a/servers/thegraph-token-api/src/tools/gettransfersevmbyaddress.ts
+++ b/servers/thegraph-token-api/src/tools/gettransfersevmbyaddress.ts
@@ -32,4 +32,11 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({ "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query"), "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(), "age": z.number().int().gte(1).lte(180).describe("Indicates how many days have passed since the data's creation or insertion."), "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("Filter by contract address").optional(), "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request."), "page": z.number().int().gte(1).describe("The page number of the results to return.") }).shape
+export const inputParams = {
+  "address": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("EVM wallet address to query"),
+  "network_id": z.enum(["mainnet","bsc","base","arbitrum-one","optimism","matic"]).describe("The Graph Network ID https://thegraph.com/networks").optional(),
+  "age": z.number().int().gte(1).lte(180).describe("Indicates how many days have passed since the data's creation or insertion.").optional(),
+  "contract": z.string().regex(new RegExp("^(0[xX])?[0-9a-fA-F]{40}$")).describe("Filter by contract address").optional(),
+  "limit": z.number().int().gte(1).lte(1000).describe("The maximum number of items returned in a single request.").optional(),
+  "page": z.number().int().gte(1).describe("The page number of the results to return.").optional()
+}

--- a/servers/thegraph-token-api/src/tools/getversion.ts
+++ b/servers/thegraph-token-api/src/tools/getversion.ts
@@ -15,4 +15,4 @@ export const keys = {
 }
 export const flatMap = {}
 
-export const inputParams = z.object({}).shape
+export const inputParams = {}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `thegraph-token-api`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/thegraph-token-api`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "thegraph-token-api": {
      "command": "npx",
      "args": ["-y", "@open-mcp/thegraph-token-api"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.