### PR TITLE
Add MCP server `APIG-MCP-Server`

### DIFF
--- a/servers/APIG-MCP-Server/.npmignore
+++ b/servers/APIG-MCP-Server/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/APIG-MCP-Server/README.md
+++ b/servers/APIG-MCP-Server/README.md
@@ -1,0 +1,367 @@
+# @open-mcp/APIG-MCP-Server
+
+## Installing
+
+Use the helper command `add-to-client` to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/APIG-MCP-Server add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/APIG-MCP-Server add-to-client .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/APIG-MCP-Server add-to-client /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "APIG-MCP-Server": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/APIG-MCP-Server"],
+      "env": {"OAUTH2_TOKEN":"...","API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `OAUTH2_TOKEN`
+- `API_KEY`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/APIG-MCP-Server
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/APIG-MCP-Server`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### updatepet
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.object({ "id": z.number().int().optional(), "name": z.string().optional() }).optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}
+```
+
+### addpet
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.object({ "id": z.number().int().optional(), "name": z.string().optional() }).optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}
+```
+
+### findpetsbystatus
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "status": z.enum(["available","pending","sold"]).describe("Status values that need to be considered for filter").optional()
+}
+```
+
+### findpetsbytags
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "tags": z.array(z.string()).describe("Tags to filter by").optional()
+}
+```
+
+### getpetbyid
+
+**Environment variables**
+
+- `API_KEY`
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("ID of pet to return")
+}
+```
+
+### updatepetwithform
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("ID of pet that needs to be updated"),
+  "name": z.string().describe("Name of pet that needs to be updated").optional(),
+  "status": z.string().describe("Status of pet that needs to be updated").optional()
+}
+```
+
+### deletepet
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("Pet id to delete"),
+  "api_key": z.string().optional()
+}
+```
+
+### uploadfile
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("ID of pet to update"),
+  "additionalMetadata": z.string().describe("Additional Metadata").optional()
+}
+```
+
+### getinventory
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### placeorder
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "petId": z.number().int().optional(),
+  "quantity": z.number().int().optional(),
+  "shipDate": z.string().datetime({ offset: true }).optional(),
+  "status": z.enum(["placed","approved","delivered"]).describe("Order Status").optional(),
+  "complete": z.boolean().optional()
+}
+```
+
+### getorderbyid
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "orderId": z.number().int().describe("ID of order that needs to be fetched")
+}
+```
+
+### deleteorder
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "orderId": z.number().int().describe("ID of the order that needs to be deleted")
+}
+```
+
+### createuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}
+```
+
+### createuserswithlistinput
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### loginuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("The user name for login").optional(),
+  "password": z.string().describe("The password for login in clear text").optional()
+}
+```
+
+### logoutuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### getuserbyname
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("The name that needs to be fetched. Use user1 for testing")
+}
+```
+
+### updateuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("name that need to be deleted"),
+  "id": z.number().int().optional(),
+  "b_username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}
+```
+
+### deleteuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("The name that needs to be deleted")
+}
+```

--- a/servers/APIG-MCP-Server/package.json
+++ b/servers/APIG-MCP-Server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@open-mcp/APIG-MCP-Server",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "APIG-MCP-Server": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/APIG-MCP-Server/src/add-to-client.ts
+++ b/servers/APIG-MCP-Server/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/APIG-MCP-Server/src/constants.ts
+++ b/servers/APIG-MCP-Server/src/constants.ts
@@ -1,0 +1,24 @@
+export const OPENAPI_URL = "https://petstore3.swagger.io/api/v3/openapi.json"
+export const SERVER_NAME = "APIG-MCP-Server"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/updatepet.js",
+  "./tools/addpet.js",
+  "./tools/findpetsbystatus.js",
+  "./tools/findpetsbytags.js",
+  "./tools/getpetbyid.js",
+  "./tools/updatepetwithform.js",
+  "./tools/deletepet.js",
+  "./tools/uploadfile.js",
+  "./tools/getinventory.js",
+  "./tools/placeorder.js",
+  "./tools/getorderbyid.js",
+  "./tools/deleteorder.js",
+  "./tools/createuser.js",
+  "./tools/createuserswithlistinput.js",
+  "./tools/loginuser.js",
+  "./tools/logoutuser.js",
+  "./tools/getuserbyname.js",
+  "./tools/updateuser.js",
+  "./tools/deleteuser.js"
+]

--- a/servers/APIG-MCP-Server/src/index.ts
+++ b/servers/APIG-MCP-Server/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/APIG-MCP-Server/src/lib.ts
+++ b/servers/APIG-MCP-Server/src/lib.ts
@@ -1,0 +1,49 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      paramObj[originalKey] = flat[flatKey]
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/APIG-MCP-Server/src/mcp-client-config.json
+++ b/servers/APIG-MCP-Server/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "APIG-MCP-Server": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/APIG-MCP-Server"],
+      "env": {"OAUTH2_TOKEN":"...","API_KEY":"..."}
+    }
+  }
+}

--- a/servers/APIG-MCP-Server/src/server.ts
+++ b/servers/APIG-MCP-Server/src/server.ts
@@ -1,0 +1,186 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const headers = {
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, { method, headers })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/APIG-MCP-Server/src/tools/addpet.ts
+++ b/servers/APIG-MCP-Server/src/tools/addpet.ts
@@ -1,0 +1,40 @@
+import { z } from "zod"
+
+export const toolName = `addpet`
+export const toolDescription = `Add a new pet to the store.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "id",
+    "name",
+    "category",
+    "photoUrls",
+    "tags",
+    "status"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.object({ "id": z.number().int().optional(), "name": z.string().optional() }).optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/createuser.ts
+++ b/servers/APIG-MCP-Server/src/tools/createuser.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+
+export const toolName = `createuser`
+export const toolDescription = `Create user.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user`
+export const method = `post`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "id",
+    "username",
+    "firstName",
+    "lastName",
+    "email",
+    "password",
+    "phone",
+    "userStatus"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/createuserswithlistinput.ts
+++ b/servers/APIG-MCP-Server/src/tools/createuserswithlistinput.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `createuserswithlistinput`
+export const toolDescription = `Creates list of users with given input array.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user/createWithList`
+export const method = `post`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/APIG-MCP-Server/src/tools/deleteorder.ts
+++ b/servers/APIG-MCP-Server/src/tools/deleteorder.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `deleteorder`
+export const toolDescription = `Delete purchase order by identifier.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/store/order/{orderId}`
+export const method = `delete`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "orderId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "orderId": z.number().int().describe("ID of the order that needs to be deleted")
+}

--- a/servers/APIG-MCP-Server/src/tools/deletepet.ts
+++ b/servers/APIG-MCP-Server/src/tools/deletepet.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `deletepet`
+export const toolDescription = `Deletes a pet.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet/{petId}`
+export const method = `delete`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [
+    "api_key"
+  ],
+  "path": [
+    "petId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "petId": z.number().int().describe("Pet id to delete"),
+  "api_key": z.string().optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/deleteuser.ts
+++ b/servers/APIG-MCP-Server/src/tools/deleteuser.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `deleteuser`
+export const toolDescription = `Delete user resource.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user/{username}`
+export const method = `delete`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "username"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "username": z.string().describe("The name that needs to be deleted")
+}

--- a/servers/APIG-MCP-Server/src/tools/findpetsbystatus.ts
+++ b/servers/APIG-MCP-Server/src/tools/findpetsbystatus.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+export const toolName = `findpetsbystatus`
+export const toolDescription = `Finds Pets by status.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet/findByStatus`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [
+    "status"
+  ],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "status": z.enum(["available","pending","sold"]).describe("Status values that need to be considered for filter").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/findpetsbytags.ts
+++ b/servers/APIG-MCP-Server/src/tools/findpetsbytags.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+export const toolName = `findpetsbytags`
+export const toolDescription = `Finds Pets by tags.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet/findByTags`
+export const method = `get`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [
+    "tags"
+  ],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "tags": z.array(z.string()).describe("Tags to filter by").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/getinventory.ts
+++ b/servers/APIG-MCP-Server/src/tools/getinventory.ts
@@ -1,0 +1,27 @@
+import { z } from "zod"
+
+export const toolName = `getinventory`
+export const toolDescription = `Returns pet inventories by status.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/store/inventory`
+export const method = `get`
+export const security = [
+  {
+    "key": "api_key",
+    "value": "<mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "apiKey",
+    "schemeName": "api_key"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/APIG-MCP-Server/src/tools/getorderbyid.ts
+++ b/servers/APIG-MCP-Server/src/tools/getorderbyid.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `getorderbyid`
+export const toolDescription = `Find purchase order by ID.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/store/order/{orderId}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "orderId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "orderId": z.number().int().describe("ID of order that needs to be fetched")
+}

--- a/servers/APIG-MCP-Server/src/tools/getpetbyid.ts
+++ b/servers/APIG-MCP-Server/src/tools/getpetbyid.ts
@@ -1,0 +1,38 @@
+import { z } from "zod"
+
+export const toolName = `getpetbyid`
+export const toolDescription = `Find pet by ID.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet/{petId}`
+export const method = `get`
+export const security = [
+  {
+    "key": "api_key",
+    "value": "<mcp-env-var>API_KEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "API_KEY",
+    "schemeType": "apiKey",
+    "schemeName": "api_key"
+  },
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "petId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "petId": z.number().int().describe("ID of pet to return")
+}

--- a/servers/APIG-MCP-Server/src/tools/getuserbyname.ts
+++ b/servers/APIG-MCP-Server/src/tools/getuserbyname.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const toolName = `getuserbyname`
+export const toolDescription = `Get user by user name.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user/{username}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "username"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "username": z.string().describe("The name that needs to be fetched. Use user1 for testing")
+}

--- a/servers/APIG-MCP-Server/src/tools/loginuser.ts
+++ b/servers/APIG-MCP-Server/src/tools/loginuser.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const toolName = `loginuser`
+export const toolDescription = `Logs user into the system.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user/login`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [
+    "username",
+    "password"
+  ],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "username": z.string().describe("The user name for login").optional(),
+  "password": z.string().describe("The password for login in clear text").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/logoutuser.ts
+++ b/servers/APIG-MCP-Server/src/tools/logoutuser.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const toolName = `logoutuser`
+export const toolDescription = `Logs out current logged in user session.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user/logout`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {}

--- a/servers/APIG-MCP-Server/src/tools/placeorder.ts
+++ b/servers/APIG-MCP-Server/src/tools/placeorder.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+export const toolName = `placeorder`
+export const toolDescription = `Place an order for a pet.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/store/order`
+export const method = `post`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "id",
+    "petId",
+    "quantity",
+    "shipDate",
+    "status",
+    "complete"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.number().int().optional(),
+  "petId": z.number().int().optional(),
+  "quantity": z.number().int().optional(),
+  "shipDate": z.string().datetime({ offset: true }).optional(),
+  "status": z.enum(["placed","approved","delivered"]).describe("Order Status").optional(),
+  "complete": z.boolean().optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/updatepet.ts
+++ b/servers/APIG-MCP-Server/src/tools/updatepet.ts
@@ -1,0 +1,40 @@
+import { z } from "zod"
+
+export const toolName = `updatepet`
+export const toolDescription = `Update an existing pet.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet`
+export const method = `put`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "id",
+    "name",
+    "category",
+    "photoUrls",
+    "tags",
+    "status"
+  ]
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.object({ "id": z.number().int().optional(), "name": z.string().optional() }).optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/updatepetwithform.ts
+++ b/servers/APIG-MCP-Server/src/tools/updatepetwithform.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+
+export const toolName = `updatepetwithform`
+export const toolDescription = `Updates a pet in the store with form data.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet/{petId}`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [
+    "name",
+    "status"
+  ],
+  "header": [],
+  "path": [
+    "petId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "petId": z.number().int().describe("ID of pet that needs to be updated"),
+  "name": z.string().describe("Name of pet that needs to be updated").optional(),
+  "status": z.string().describe("Status of pet that needs to be updated").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/updateuser.ts
+++ b/servers/APIG-MCP-Server/src/tools/updateuser.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+export const toolName = `updateuser`
+export const toolDescription = `Update user resource.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/user/{username}`
+export const method = `put`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "username"
+  ],
+  "cookie": [],
+  "body": [
+    "id",
+    "b_username",
+    "firstName",
+    "lastName",
+    "email",
+    "password",
+    "phone",
+    "userStatus"
+  ]
+}
+export const flatMap = {
+  "b_username": "username"
+}
+
+export const inputParams = {
+  "username": z.string().describe("name that need to be deleted"),
+  "id": z.number().int().optional(),
+  "b_username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}

--- a/servers/APIG-MCP-Server/src/tools/uploadfile.ts
+++ b/servers/APIG-MCP-Server/src/tools/uploadfile.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const toolName = `uploadfile`
+export const toolDescription = `Uploads an image.`
+export const baseUrl = `https://petstore.swagger.io/v2`
+export const path = `/pet/{petId}/uploadImage`
+export const method = `post`
+export const security = [
+  {
+    "key": "Authorization",
+    "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+    "in": "header",
+    "envVarName": "OAUTH2_TOKEN",
+    "schemeType": "oauth2"
+  }
+]
+export const keys = {
+  "query": [
+    "additionalMetadata"
+  ],
+  "header": [],
+  "path": [
+    "petId"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}
+
+export const inputParams = {
+  "petId": z.number().int().describe("ID of pet to update"),
+  "additionalMetadata": z.string().describe("Additional Metadata").optional()
+}

--- a/servers/APIG-MCP-Server/tsconfig.json
+++ b/servers/APIG-MCP-Server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `APIG-MCP-Server`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/APIG-MCP-Server`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "APIG-MCP-Server": {
      "command": "npx",
      "args": ["-y", "@open-mcp/APIG-MCP-Server"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.