### PR TITLE
Add MCP server `apisetu_gov_in_ucobank_v3`

### DIFF
--- a/servers/apisetu_gov_in_ucobank_v3/.npmignore
+++ b/servers/apisetu_gov_in_ucobank_v3/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/apisetu_gov_in_ucobank_v3/README.md
+++ b/servers/apisetu_gov_in_ucobank_v3/README.md
@@ -1,0 +1,102 @@
+# @open-mcp/apisetu_gov_in_ucobank_v3
+
+## Installing
+
+Use the helper command `add-to-client` to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/apisetu_gov_in_ucobank_v3 add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/apisetu_gov_in_ucobank_v3 add-to-client .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/apisetu_gov_in_ucobank_v3 add-to-client /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "apisetu_gov_in_ucobank_v3": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/apisetu_gov_in_ucobank_v3"],
+      "env": {"X_APISETU_APIKEY":"...","X_APISETU_CLIENTID":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `X_APISETU_APIKEY`
+- `X_APISETU_CLIENTID`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/apisetu_gov_in_ucobank_v3
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/apisetu_gov_in_ucobank_v3`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### tdcer
+
+**Environment variables**
+
+- `X_APISETU_APIKEY`
+- `X_APISETU_CLIENTID`
+
+**Input schema**
+
+```ts
+{
+  "certificateParameters": z.record(z.any()).describe("[EXPANDABLE PARAMETER]:").optional(),
+  "consentArtifact": z.any().optional(),
+  "format": z.literal("pdf").describe("The format of the certificate in response."),
+  "txnId": z.string().uuid().describe("A unique transaction id for this request in UUID format. It is used for tracking the request.")
+}
+```

--- a/servers/apisetu_gov_in_ucobank_v3/package.json
+++ b/servers/apisetu_gov_in_ucobank_v3/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@open-mcp/apisetu_gov_in_ucobank_v3",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "apisetu_gov_in_ucobank_v3": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/add-to-client.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/constants.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/constants.ts
@@ -1,0 +1,6 @@
+export const OPENAPI_URL = "https://api.apis.guru/v2/specs/apisetu.gov.in/ucobank/3.0.0/openapi.json"
+export const SERVER_NAME = "apisetu_gov_in_ucobank_v3"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/tdcer/index.js"
+]

--- a/servers/apisetu_gov_in_ucobank_v3/src/index.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/lib.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/lib.ts
@@ -1,0 +1,51 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      if (flatKey in flat) {
+        paramObj[originalKey] = flat[flatKey]
+      }
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/mcp-client-config.json
+++ b/servers/apisetu_gov_in_ucobank_v3/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "apisetu_gov_in_ucobank_v3": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/apisetu_gov_in_ucobank_v3"],
+      "env": {"X_APISETU_APIKEY":"...","X_APISETU_CLIENTID":"..."}
+    }
+  }
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/server.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/server.ts
@@ -1,0 +1,252 @@
+import { z } from "zod"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const body =
+      params.body && Object.keys(params.body).length > 0
+        ? JSON.stringify(params.body)
+        : undefined
+
+    const headers = {
+      ...(body ? { "Content-Type": "application/json" } : {}),
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body,
+    })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    server.tool(
+      "expandSchema",
+      "Expand the input schema for a tool before calling the tool",
+      {
+        toolName: z.string(), // could make this enum?
+        jsonPointers: z
+          .array(
+            z
+              .string()
+              .startsWith("/")
+              .describe(
+                "The pointer to the JSON schema object which needs expanding"
+              )
+          )
+          .describe("A list of JSON pointers"),
+      },
+      async ({ toolName, jsonPointers }) => {
+        const promises = jsonPointers.map((jsonPointer) =>
+          import(`./tools/${toolName}/schema-json${jsonPointer}.json`, {
+            with: { type: "json" },
+          })
+            .then((schema) => {
+              return {
+                type: "text" as "text",
+                text: JSON.stringify(
+                  {
+                    jsonPointer,
+                    schema,
+                  },
+                  null,
+                  2
+                ),
+              }
+            })
+            .catch(() => {
+              return {
+                type: "text" as "text",
+                text: JSON.stringify(
+                  {
+                    jsonPointer,
+                    schema: null,
+                    error:
+                      "Provided tool and JSON pointer do not match. Try again with a different tool/pointer combination.",
+                  },
+                  null,
+                  2
+                ),
+              }
+            })
+        )
+        const content = await Promise.all(promises)
+        return { content }
+      }
+    )
+
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/index.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/index.ts
@@ -1,0 +1,38 @@
+export { inputParams } from "./schema/root.js"
+
+export const toolName = `tdcer`
+export const toolDescription = `TDS Certificate`
+export const baseUrl = `https://apisetu.gov.in/ucobank/v3`
+export const path = `/tdcer/certificate`
+export const method = `post`
+export const security = [
+  {
+    "key": "X-APISETU-APIKEY",
+    "value": "<mcp-env-var>X_APISETU_APIKEY</mcp-env-var>",
+    "in": "header",
+    "envVarName": "X_APISETU_APIKEY",
+    "schemeType": "apiKey",
+    "schemeName": "X-APISETU-APIKEY"
+  },
+  {
+    "key": "X-APISETU-CLIENTID",
+    "value": "<mcp-env-var>X_APISETU_CLIENTID</mcp-env-var>",
+    "in": "header",
+    "envVarName": "X_APISETU_CLIENTID",
+    "schemeType": "apiKey",
+    "schemeName": "X-APISETU-CLIENTID"
+  }
+]
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "certificateParameters",
+    "consentArtifact",
+    "format",
+    "txnId"
+  ]
+}
+export const flatMap = {}

--- a/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema-json/properties/certificateParameters.json
+++ b/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema-json/properties/certificateParameters.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "CustID": {
+      "description": "Account Number",
+      "example": "Enter 14 Digit A/c No - TDS Information will be generated for all A/cs associated with Customer ID.",
+      "type": "string"
+    },
+    "DOB": {
+      "description": "Date of birth in DD-MM-YYYY format",
+      "example": "31-12-1980",
+      "type": "string"
+    },
+    "finYr": {
+      "description": "Financial Year",
+      "example": "2018-2019",
+      "type": "string"
+    }
+  },
+  "required": [
+    "CustID",
+    "finYr",
+    "DOB"
+  ],
+  "type": "object"
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema-json/root.json
+++ b/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema-json/root.json
@@ -1,0 +1,200 @@
+{
+  "type": "object",
+  "properties": {
+    "certificateParameters": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `certificateParameters` to the tool, first call the tool `expandSchema` with \"/properties/certificateParameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "consentArtifact": {
+      "properties": {
+        "consent": {
+          "properties": {
+            "consentId": {
+              "description": "A unique consent id in UUID format.",
+              "example": "ea9c43aa-7f5a-4bf3-a0be-e1caa24737ba",
+              "format": "uuid",
+              "minLength": 1,
+              "type": "string"
+            },
+            "data": {
+              "properties": {
+                "id": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "type": "object"
+            },
+            "dataConsumer": {
+              "properties": {
+                "id": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "type": "object"
+            },
+            "dataProvider": {
+              "properties": {
+                "id": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "type": "object"
+            },
+            "permission": {
+              "properties": {
+                "access": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "dateRange": {
+                  "properties": {
+                    "from": {
+                      "description": "Date time format in UTC, includes miliseconds YYYY-MM-DDThh:mm:ss.vZ",
+                      "format": "date-time",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Date time format in UTC, includes miliseconds YYYY-MM-DDThh:mm:ss.vZ",
+                      "format": "date-time",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "from",
+                    "to"
+                  ],
+                  "type": "object"
+                },
+                "frequency": {
+                  "properties": {
+                    "repeats": {
+                      "type": "number"
+                    },
+                    "unit": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "unit",
+                    "value",
+                    "repeats"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "access",
+                "dateRange",
+                "frequency"
+              ],
+              "type": "object"
+            },
+            "purpose": {
+              "properties": {
+                "description": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description"
+              ],
+              "type": "object"
+            },
+            "timestamp": {
+              "description": "Date time format in UTC, includes miliseconds YYYY-MM-DDThh:mm:ss.vZ",
+              "format": "date-time",
+              "minLength": 1,
+              "type": "string"
+            },
+            "user": {
+              "properties": {
+                "email": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "idNumber": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "idType": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "mobile": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "idType",
+                "idNumber",
+                "mobile",
+                "email"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "consentId",
+            "timestamp",
+            "dataConsumer",
+            "dataProvider",
+            "purpose",
+            "user",
+            "data",
+            "permission"
+          ],
+          "type": "object"
+        },
+        "signature": {
+          "properties": {
+            "signature": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "signature"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    "format": {
+      "description": "The format of the certificate in response.",
+      "enum": [
+        "pdf"
+      ],
+      "type": "string"
+    },
+    "txnId": {
+      "description": "A unique transaction id for this request in UUID format. It is used for tracking the request.",
+      "example": "f7f1469c-29b0-4325-9dfc-c567200a70f7",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "format",
+    "txnId"
+  ]
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema/properties/certificateParameters.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema/properties/certificateParameters.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParams = {
+  "CustID": z.string().describe("Account Number"),
+  "DOB": z.string().describe("Date of birth in DD-MM-YYYY format"),
+  "finYr": z.string().describe("Financial Year")
+}

--- a/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema/root.ts
+++ b/servers/apisetu_gov_in_ucobank_v3/src/tools/tdcer/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParams = {
+  "certificateParameters": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `certificateParameters` to the tool, first call the tool `expandSchema` with \"/properties/certificateParameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional(),
+  "consentArtifact": z.any().optional(),
+  "format": z.literal("pdf").describe("The format of the certificate in response."),
+  "txnId": z.string().uuid().describe("A unique transaction id for this request in UUID format. It is used for tracking the request.")
+}

--- a/servers/apisetu_gov_in_ucobank_v3/tsconfig.json
+++ b/servers/apisetu_gov_in_ucobank_v3/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `apisetu_gov_in_ucobank_v3`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/apisetu_gov_in_ucobank_v3`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "apisetu_gov_in_ucobank_v3": {
      "command": "npx",
      "args": ["-y", "@open-mcp/apisetu_gov_in_ucobank_v3"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.