### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,156 @@
+# @open-mcp/api_example_com
+
+## Installing
+
+Use the helper command `add-to-client` to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/api_example_com add-to-client ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/api_example_com add-to-client .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/api_example_com add-to-client /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_example_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/api_example_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### _list_people_people_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### _create_person_people_post
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "name": z.string().min(1).describe("Full name of this person"),
+  "address": z.string(),
+  "birth": z.string().date().describe("Date of birth, in format YYYY-MM-DD, or Unix timestamp").optional()
+}
+```
+
+### _get_person_people_person_id_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "person_id": z.string()
+}
+```
+
+### _delete_person_people_person_id_delete
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "person_id": z.string()
+}
+```
+
+### _update_person_people_person_id_patch
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "person_id": z.string(),
+  "name": z.string().min(1).describe("Full name of this person").optional(),
+  "address": z.string().optional(),
+  "birth": z.string().date().describe("Date of birth, in format YYYY-MM-DD, or Unix timestamp").optional()
+}
+```

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm install --save-dev @wegotdocs/shared@latest && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "@wegotdocs/shared": "^0.1.12",
+    "typescript": "^5.8.2"
+  }
+}

--- a/servers/api_example_com/src/add-to-client.ts
+++ b/servers/api_example_com/src/add-to-client.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+import newConfig from "./mcp-client-config.json" with { type: "json" }
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+export async function addToClient(pathname?: string) {
+  if (!pathname) {
+    throw new Error("Please provide the path to your MCP client config")
+  }
+  const configPath = path.resolve(pathname)
+
+  // Read existing config file or create empty object if not exists
+  let config = {} as { mcpServers?: Record<string, any> }
+  try {
+    if (fs.existsSync(configPath)) {
+      const fileContent = fs.readFileSync(configPath, "utf8")
+      config = JSON.parse(fileContent)
+      console.log(`Loaded existing config from ${configPath}`)
+    } else {
+      console.log(
+        `Config file doesn't exist. Will create new file at ${configPath}`
+      )
+    }
+  } catch (error: any) {
+    console.error(`Error reading config file: ${error.message}`)
+    throw error
+  }
+
+  // Extend mcpServers with new configuration
+  if (!config.mcpServers) {
+    config.mcpServers = {}
+  }
+
+  // Check for key overlaps and ask for confirmation if needed
+  const existingKeys = Object.keys(config.mcpServers);
+  const newKeys = Object.keys(newConfig.mcpServers);
+  const overlappingKeys = newKeys.filter(key => existingKeys.includes(key));
+  
+  if (overlappingKeys.length > 0) {
+    console.log("The following tools already exist in your config and will be overwritten:");
+    overlappingKeys.forEach(key => console.log(`- ${key}`));
+    
+    // Ask for confirmation
+
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Do you want to overwrite them? (y/N): ', resolve);
+    });
+    rl.close();
+    
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Operation cancelled.');
+      process.exit(0);
+    }
+  }
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    ...newConfig.mcpServers,
+  }
+
+  // Create directory if it doesn't exist
+  const configDir = path.dirname(configPath)
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // Save the updated config
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8")
+  console.log(`Successfully updated config at ${configPath}`)
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,10 @@
+export const OPENAPI_URL = "http://main.norhome.casa:60003/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/_list_people_people_get/index.js",
+  "./tools/_create_person_people_post/index.js",
+  "./tools/_get_person_people_person_id_get/index.js",
+  "./tools/_delete_person_people_person_id_delete/index.js",
+  "./tools/_update_person_people_person_id_patch/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const args = process.argv
+
+if (args[2] === "add-to-client") {
+  import("./add-to-client.js")
+    .then((module) => module.addToClient(args[3]))
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(`Failed to update config: ${error.message}`)
+      process.exit(1)
+    })
+} else {
+  import("./server.js").then((module) => {
+    module.runServer().catch((error) => {
+      console.error("Fatal error running server:", error)
+      process.exit(1)
+    })
+  })
+}

--- a/servers/api_example_com/src/lib.ts
+++ b/servers/api_example_com/src/lib.ts
@@ -1,0 +1,51 @@
+import type { MCPServerModule, ParamType } from "@wegotdocs/shared"
+import { SERVER_NAME } from "./constants.js"
+
+export function enclose(str: string) {
+  return `<mcp-env-var>${str}</mcp-env-var>`
+}
+
+export function getConfigExample(envVarNames: string[]) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [SERVER_NAME]: {
+          env: envVarNames.reduce((acc, envVarName) => {
+            acc[envVarName] = "..."
+            return acc
+          }, {} as Record<string, string>),
+          command: "...",
+        },
+      },
+    },
+    null,
+    2
+  )
+}
+
+interface FlatObj {
+  [key: string]: unknown
+}
+
+type RequestObj = Record<ParamType, Record<string, unknown>>
+
+export function unflatten({
+  flat,
+  keys,
+  flatMap,
+}: {
+  flat: FlatObj
+  keys: MCPServerModule["keys"]
+  flatMap: MCPServerModule["flatMap"]
+}): RequestObj {
+  return Object.entries(keys).reduce((acc, [paramType, paramTypeKeys]) => {
+    acc[paramType as ParamType] = paramTypeKeys.reduce((paramObj, flatKey) => {
+      const originalKey = flatMap[flatKey] || flatKey
+      if (flatKey in flat) {
+        paramObj[originalKey] = flat[flatKey]
+      }
+      return paramObj
+    }, {} as Record<string, unknown>)
+    return acc
+  }, {} as RequestObj)
+}

--- a/servers/api_example_com/src/mcp-client-config.json
+++ b/servers/api_example_com/src/mcp-client-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,252 @@
+import { z } from "zod"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { enclose, getConfigExample, unflatten } from "./lib.js"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+import type { MCPServerModule } from "@wegotdocs/shared"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+function cleanUrl(url: string) {
+  if (!url) {
+    return url
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function stringify({
+  value,
+  arrayToCSV,
+}: {
+  value: any
+  arrayToCSV: boolean
+}): string {
+  if (typeof value === "undefined") {
+    return ""
+  }
+  if (typeof value === "object") {
+    const isArray = Array.isArray(value)
+    if (isArray && arrayToCSV) {
+      return value
+        .map((x) => stringify({ value: x, arrayToCSV: false }))
+        .join(",")
+    }
+    return JSON.stringify(value)
+  }
+  return value.toString()
+}
+
+async function registerToolFromOperation(operationFileRelativePath: string) {
+  const operation = (await import(operationFileRelativePath)) as MCPServerModule
+
+  const requiredKeys: (keyof typeof operation)[] = [
+    "path",
+    "method",
+    "toolName",
+    "inputParams",
+    "keys",
+    "flatMap",
+  ]
+  for (const key of requiredKeys) {
+    if (!operation[key]) {
+      throw new Error(
+        `Parameter '${key}' in '${operationFileRelativePath}' is not well-defined`
+      )
+    }
+  }
+
+  const {
+    baseUrl,
+    path: opPath,
+    method,
+    toolName,
+    toolDescription,
+    inputParams,
+    security,
+    keys,
+    flatMap,
+  } = operation
+
+  const customBaseUrl = cleanUrl(process.env.OPEN_MCP_BASE_URL || baseUrl)
+
+  if (
+    !customBaseUrl.startsWith("http://") &&
+    !customBaseUrl.startsWith("https://")
+  ) {
+    throw new Error(
+      `Base URL must start with 'http://' or 'https://', received '${customBaseUrl}'`
+    )
+  }
+
+  if (!opPath.startsWith("/")) {
+    throw new Error("path must start with slash")
+  }
+
+  server.tool(toolName, toolDescription, inputParams, async (flat) => {
+    const params = unflatten({ flat, keys, flatMap })
+
+    const securityHeadersObj: Record<string, string> = {}
+    const securityQueryObj: Record<string, string> = {}
+    for (const item of security) {
+      const ENV_VAR = process.env[item.envVarName]
+      if (ENV_VAR) {
+        const value = item.value.replace(enclose(item.envVarName), ENV_VAR)
+        if (item.in === "header") {
+          securityHeadersObj[item.key] = value
+        } else if (item.in === "query") {
+          securityQueryObj[item.key] = value
+        }
+      }
+    }
+
+    if (
+      Object.keys(securityHeadersObj).length === 0 &&
+      Object.keys(securityQueryObj).length === 0 &&
+      security.length > 0
+    ) {
+      const envVarsString = security
+        .map((x) => `\`${x.envVarName}\``)
+        .join(", ")
+      const sampleConfig = getConfigExample(security.map((x) => x.envVarName))
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Must provide at least one of the following environment variables: ${envVarsString}.`,
+          },
+          {
+            type: "text",
+            text: `For example, in your MCP client config file:\n\n${sampleConfig}`,
+          },
+        ],
+      }
+    }
+
+    let opPathResolved = opPath
+    for (const [key, value] of Object.entries(params.path || {})) {
+      if (typeof value === "undefined") {
+        continue
+      }
+      opPathResolved = opPathResolved.replaceAll(
+        `{${key}}`,
+        stringify({ value, arrayToCSV: true })
+      )
+    }
+
+    const url = new URL(`${customBaseUrl}${opPathResolved}`)
+    for (const [key, value] of Object.entries({
+      ...securityQueryObj,
+      ...(params.query || {}),
+    })) {
+      url.searchParams.set(key, stringify({ value, arrayToCSV: true }))
+    }
+
+    const body =
+      params.body && Object.keys(params.body).length > 0
+        ? JSON.stringify(params.body)
+        : undefined
+
+    const headers = {
+      ...(body ? { "Content-Type": "application/json" } : {}),
+      ...(params.header || {}),
+      ...securityHeadersObj,
+    } as Record<string, string>
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body,
+    })
+    const text = await response.text()
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Response from ${url.toString()}`,
+        },
+        {
+          type: "text",
+          text,
+        },
+      ],
+    }
+  })
+}
+
+export async function runServer() {
+  try {
+    server.tool(
+      "expandSchema",
+      "Expand the input schema for a tool before calling the tool",
+      {
+        toolName: z.string(), // could make this enum?
+        jsonPointers: z
+          .array(
+            z
+              .string()
+              .startsWith("/")
+              .describe(
+                "The pointer to the JSON schema object which needs expanding"
+              )
+          )
+          .describe("A list of JSON pointers"),
+      },
+      async ({ toolName, jsonPointers }) => {
+        const promises = jsonPointers.map((jsonPointer) =>
+          import(`./tools/${toolName}/schema-json${jsonPointer}.json`, {
+            with: { type: "json" },
+          })
+            .then((schema) => {
+              return {
+                type: "text" as "text",
+                text: JSON.stringify(
+                  {
+                    jsonPointer,
+                    schema,
+                  },
+                  null,
+                  2
+                ),
+              }
+            })
+            .catch(() => {
+              return {
+                type: "text" as "text",
+                text: JSON.stringify(
+                  {
+                    jsonPointer,
+                    schema: null,
+                    error:
+                      "Provided tool and JSON pointer do not match. Try again with a different tool/pointer combination.",
+                  },
+                  null,
+                  2
+                ),
+              }
+            })
+        )
+        const content = await Promise.all(promises)
+        return { content }
+      }
+    )
+
+    for (const file of OPERATION_FILES_RELATIVE) {
+      await registerToolFromOperation(file)
+    }
+
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/_create_person_people_post/index.ts
+++ b/servers/api_example_com/src/tools/_create_person_people_post/index.ts
@@ -1,0 +1,20 @@
+export { inputParams } from "./schema/root.js"
+
+export const toolName = `_create_person_people_post`
+export const toolDescription = `Create Person`
+export const baseUrl = `https://api.example.com`
+export const path = `/people`
+export const method = `post`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": [
+    "name",
+    "address",
+    "birth"
+  ]
+}
+export const flatMap = {}

--- a/servers/api_example_com/src/tools/_create_person_people_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/_create_person_people_post/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "minLength": 1,
+      "type": "string",
+      "description": "Full name of this person",
+      "example": "John Smith"
+    },
+    "address": {
+      "type": "string"
+    },
+    "birth": {
+      "title": "Birth",
+      "type": "string",
+      "description": "Date of birth, in format YYYY-MM-DD, or Unix timestamp",
+      "format": "date",
+      "example": "1999-12-31"
+    }
+  },
+  "required": [
+    "name",
+    "address"
+  ]
+}

--- a/servers/api_example_com/src/tools/_create_person_people_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/_create_person_people_post/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParams = {
+  "name": z.string().min(1).describe("Full name of this person"),
+  "address": z.string(),
+  "birth": z.string().date().describe("Date of birth, in format YYYY-MM-DD, or Unix timestamp").optional()
+}

--- a/servers/api_example_com/src/tools/_delete_person_people_person_id_delete/index.ts
+++ b/servers/api_example_com/src/tools/_delete_person_people_person_id_delete/index.ts
@@ -1,0 +1,18 @@
+export { inputParams } from "./schema/root.js"
+
+export const toolName = `_delete_person_people_person_id_delete`
+export const toolDescription = `Delete Person`
+export const baseUrl = `https://api.example.com`
+export const path = `/people/{person_id}`
+export const method = `delete`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "person_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}

--- a/servers/api_example_com/src/tools/_delete_person_people_person_id_delete/schema-json/root.json
+++ b/servers/api_example_com/src/tools/_delete_person_people_person_id_delete/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "person_id": {
+      "title": "Person Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "person_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/_delete_person_people_person_id_delete/schema/root.ts
+++ b/servers/api_example_com/src/tools/_delete_person_people_person_id_delete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParams = {
+  "person_id": z.string()
+}

--- a/servers/api_example_com/src/tools/_get_person_people_person_id_get/index.ts
+++ b/servers/api_example_com/src/tools/_get_person_people_person_id_get/index.ts
@@ -1,0 +1,18 @@
+export { inputParams } from "./schema/root.js"
+
+export const toolName = `_get_person_people_person_id_get`
+export const toolDescription = `Get Person`
+export const baseUrl = `https://api.example.com`
+export const path = `/people/{person_id}`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "person_id"
+  ],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}

--- a/servers/api_example_com/src/tools/_get_person_people_person_id_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/_get_person_people_person_id_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "person_id": {
+      "title": "Person Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "person_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/_get_person_people_person_id_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/_get_person_people_person_id_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParams = {
+  "person_id": z.string()
+}

--- a/servers/api_example_com/src/tools/_list_people_people_get/index.ts
+++ b/servers/api_example_com/src/tools/_list_people_people_get/index.ts
@@ -1,0 +1,16 @@
+export { inputParams } from "./schema/root.js"
+
+export const toolName = `_list_people_people_get`
+export const toolDescription = `List People`
+export const baseUrl = `https://api.example.com`
+export const path = `/people`
+export const method = `get`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [],
+  "cookie": [],
+  "body": []
+}
+export const flatMap = {}

--- a/servers/api_example_com/src/tools/_list_people_people_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/_list_people_people_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/_list_people_people_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/_list_people_people_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParams = {}

--- a/servers/api_example_com/src/tools/_update_person_people_person_id_patch/index.ts
+++ b/servers/api_example_com/src/tools/_update_person_people_person_id_patch/index.ts
@@ -1,0 +1,22 @@
+export { inputParams } from "./schema/root.js"
+
+export const toolName = `_update_person_people_person_id_patch`
+export const toolDescription = `Update Person`
+export const baseUrl = `https://api.example.com`
+export const path = `/people/{person_id}`
+export const method = `patch`
+export const security = []
+export const keys = {
+  "query": [],
+  "header": [],
+  "path": [
+    "person_id"
+  ],
+  "cookie": [],
+  "body": [
+    "name",
+    "address",
+    "birth"
+  ]
+}
+export const flatMap = {}

--- a/servers/api_example_com/src/tools/_update_person_people_person_id_patch/schema-json/root.json
+++ b/servers/api_example_com/src/tools/_update_person_people_person_id_patch/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "person_id": {
+      "title": "Person Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "minLength": 1,
+      "type": "string",
+      "description": "Full name of this person",
+      "example": "John Smith"
+    },
+    "address": {
+      "type": "string"
+    },
+    "birth": {
+      "title": "Birth",
+      "type": "string",
+      "description": "Date of birth, in format YYYY-MM-DD, or Unix timestamp",
+      "format": "date",
+      "example": "1999-12-31"
+    }
+  },
+  "required": [
+    "person_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/_update_person_people_person_id_patch/schema/root.ts
+++ b/servers/api_example_com/src/tools/_update_person_people_person_id_patch/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParams = {
+  "person_id": z.string(),
+  "name": z.string().min(1).describe("Full name of this person").optional(),
+  "address": z.string().optional(),
+  "birth": z.string().date().describe("Date of birth, in format YYYY-MM-DD, or Unix timestamp").optional()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.