### PR TITLE
Add MCP server `admin_openbuilder_net_custom`

### DIFF
--- a/servers/admin_openbuilder_net_custom/.npmignore
+++ b/servers/admin_openbuilder_net_custom/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/admin_openbuilder_net_custom/README.md
+++ b/servers/admin_openbuilder_net_custom/README.md
@@ -1,0 +1,169 @@
+# @open-mcp/admin_openbuilder_net_custom
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add admin_openbuilder_net_custom \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=...
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add admin_openbuilder_net_custom \
+  .cursor/mcp.json \
+  --API_KEY=...
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add admin_openbuilder_net_custom \
+  /path/to/client/config.json \
+  --API_KEY=...
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "admin_openbuilder_net_custom": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/admin_openbuilder_net_custom"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/admin_openbuilder_net_custom
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/admin_openbuilder_net_custom`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### executecommand
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "project_id": z.number().int().describe("ID del progetto nel database"),
+  "command": z.string().describe("Comando SSH da eseguire sul server remoto")
+}
+```
+
+### executequery
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "project_id": z.number().int().describe("ID del progetto nel database"),
+  "query": z.string().describe("Query SQL da eseguire"),
+  "params": z.array(z.union([z.string(), z.number(), z.boolean()])).describe("Parametri per query preparate (opzionale)").optional()
+}
+```
+
+### createrecord
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "project_id": z.number().int().describe("ID del progetto contenente le configurazioni del database"),
+  "entity": z.string().describe("Nome dell'entità su cui operare"),
+  "datas": z.record(z.any()).describe("[EXPANDABLE PARAMETER]:\nDati da inserire nel record")
+}
+```
+
+### editrecord
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "project_id": z.number().int().describe("ID del progetto contenente le configurazioni del database"),
+  "entity": z.string().describe("Nome dell'entità su cui operare"),
+  "id": z.number().int().describe("ID del record da modificare"),
+  "data": z.record(z.any()).describe("[EXPANDABLE PARAMETER]:\nDati da aggiornare nel record")
+}
+```
+
+### deleterecord
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "project_id": z.number().int().describe("ID del progetto contenente le configurazioni del database"),
+  "entity": z.string().describe("Nome dell'entità su cui operare"),
+  "id": z.number().int().describe("ID del record da eliminare")
+}
+```

--- a/servers/admin_openbuilder_net_custom/package.json
+++ b/servers/admin_openbuilder_net_custom/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/admin_openbuilder_net_custom",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "admin_openbuilder_net_custom": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/admin_openbuilder_net_custom/src/constants.ts
+++ b/servers/admin_openbuilder_net_custom/src/constants.ts
@@ -1,0 +1,10 @@
+export const OPENAPI_URL = "http://admin.openbuilder.net/aimid.json"
+export const SERVER_NAME = "admin_openbuilder_net_custom"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/executecommand/index.js",
+  "./tools/executequery/index.js",
+  "./tools/createrecord/index.js",
+  "./tools/editrecord/index.js",
+  "./tools/deleterecord/index.js"
+]

--- a/servers/admin_openbuilder_net_custom/src/index.ts
+++ b/servers/admin_openbuilder_net_custom/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/admin_openbuilder_net_custom/src/server.ts
+++ b/servers/admin_openbuilder_net_custom/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/createrecord/index.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/createrecord/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createrecord",
+  "toolDescription": "Crea un nuovo record in un database remoto",
+  "baseUrl": "https://admin.openbuilder.net/custom",
+  "path": "/aimid/create_record",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "project_id": "project_id",
+      "entity": "entity",
+      "datas": "datas"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema-json/properties/datas.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema-json/properties/datas.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "description": "Dati da inserire nel record",
+  "examples": [
+    {
+      "passwords_reference": "Prova1111"
+    }
+  ],
+  "properties": {}
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema-json/root.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": "integer",
+      "description": "ID del progetto contenente le configurazioni del database",
+      "examples": [
+        2392
+      ]
+    },
+    "entity": {
+      "type": "string",
+      "description": "Nome dell'entità su cui operare",
+      "examples": [
+        "passwords"
+      ]
+    },
+    "datas": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `datas` to the tool, first call the tool `expandSchema` with \"/properties/datas\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Dati da inserire nel record</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "project_id",
+    "entity",
+    "datas"
+  ]
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema/properties/datas.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema/properties/datas.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema/root.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/createrecord/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "project_id": z.number().int().describe("ID del progetto contenente le configurazioni del database"),
+  "entity": z.string().describe("Nome dell'entità su cui operare"),
+  "datas": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `datas` to the tool, first call the tool `expandSchema` with \"/properties/datas\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Dati da inserire nel record</property-description>")
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/deleterecord/index.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/deleterecord/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleterecord",
+  "toolDescription": "Elimina un record in un database remoto",
+  "baseUrl": "https://admin.openbuilder.net/custom",
+  "path": "/aimid/delete_record",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "project_id": "project_id",
+      "entity": "entity",
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/admin_openbuilder_net_custom/src/tools/deleterecord/schema-json/root.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/deleterecord/schema-json/root.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": "integer",
+      "description": "ID del progetto contenente le configurazioni del database",
+      "examples": [
+        2392
+      ]
+    },
+    "entity": {
+      "type": "string",
+      "description": "Nome dell'entità su cui operare",
+      "examples": [
+        "passwords"
+      ]
+    },
+    "id": {
+      "type": "integer",
+      "description": "ID del record da eliminare",
+      "examples": [
+        1
+      ]
+    }
+  },
+  "required": [
+    "project_id",
+    "entity",
+    "id"
+  ]
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/deleterecord/schema/root.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/deleterecord/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "project_id": z.number().int().describe("ID del progetto contenente le configurazioni del database"),
+  "entity": z.string().describe("Nome dell'entità su cui operare"),
+  "id": z.number().int().describe("ID del record da eliminare")
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/editrecord/index.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/editrecord/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "editrecord",
+  "toolDescription": "Modifica un record esistente in un database remoto",
+  "baseUrl": "https://admin.openbuilder.net/custom",
+  "path": "/aimid/edit_record",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "project_id": "project_id",
+      "entity": "entity",
+      "id": "id",
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema-json/properties/data.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema-json/properties/data.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "description": "Dati da aggiornare nel record",
+  "examples": [
+    {
+      "passwords_reference": "Prova modificato"
+    }
+  ],
+  "properties": {}
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema-json/root.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema-json/root.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": "integer",
+      "description": "ID del progetto contenente le configurazioni del database",
+      "examples": [
+        2392
+      ]
+    },
+    "entity": {
+      "type": "string",
+      "description": "Nome dell'entità su cui operare",
+      "examples": [
+        "passwords"
+      ]
+    },
+    "id": {
+      "type": "integer",
+      "description": "ID del record da modificare",
+      "examples": [
+        1
+      ]
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Dati da aggiornare nel record</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "project_id",
+    "entity",
+    "id",
+    "data"
+  ]
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema/properties/data.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema/properties/data.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema/root.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/editrecord/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "project_id": z.number().int().describe("ID del progetto contenente le configurazioni del database"),
+  "entity": z.string().describe("Nome dell'entità su cui operare"),
+  "id": z.number().int().describe("ID del record da modificare"),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Dati da aggiornare nel record</property-description>")
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/executecommand/index.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/executecommand/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "executecommand",
+  "toolDescription": "Esegue un comando SSH su un server remoto",
+  "baseUrl": "https://admin.openbuilder.net/custom",
+  "path": "/aimid/execute_command",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "project_id": "project_id",
+      "command": "command"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/admin_openbuilder_net_custom/src/tools/executecommand/schema-json/root.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/executecommand/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": "integer",
+      "description": "ID del progetto nel database",
+      "examples": [
+        2392
+      ]
+    },
+    "command": {
+      "type": "string",
+      "description": "Comando SSH da eseguire sul server remoto",
+      "examples": [
+        "df -h"
+      ]
+    }
+  },
+  "required": [
+    "project_id",
+    "command"
+  ]
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/executecommand/schema/root.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/executecommand/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "project_id": z.number().int().describe("ID del progetto nel database"),
+  "command": z.string().describe("Comando SSH da eseguire sul server remoto")
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/executequery/index.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/executequery/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "executequery",
+  "toolDescription": "Esegue una query SQL su un database remoto",
+  "baseUrl": "https://admin.openbuilder.net/custom",
+  "path": "/aimid/execute_query",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "project_id": "project_id",
+      "query": "query",
+      "params": "params"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/admin_openbuilder_net_custom/src/tools/executequery/schema-json/root.json
+++ b/servers/admin_openbuilder_net_custom/src/tools/executequery/schema-json/root.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": "integer",
+      "description": "ID del progetto nel database",
+      "examples": [
+        2392
+      ]
+    },
+    "query": {
+      "type": "string",
+      "description": "Query SQL da eseguire",
+      "examples": [
+        "SELECT * FROM users LIMIT 10",
+        "DESCRIBE users"
+      ]
+    },
+    "params": {
+      "type": "array",
+      "items": {
+        "type": [
+          "string",
+          "number",
+          "boolean"
+        ]
+      },
+      "description": "Parametri per query preparate (opzionale)",
+      "examples": [
+        [
+          "value1",
+          "value2"
+        ]
+      ]
+    }
+  },
+  "required": [
+    "project_id",
+    "query"
+  ]
+}

--- a/servers/admin_openbuilder_net_custom/src/tools/executequery/schema/root.ts
+++ b/servers/admin_openbuilder_net_custom/src/tools/executequery/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "project_id": z.number().int().describe("ID del progetto nel database"),
+  "query": z.string().describe("Query SQL da eseguire"),
+  "params": z.array(z.union([z.string(), z.number(), z.boolean()])).describe("Parametri per query preparate (opzionale)").optional()
+}

--- a/servers/admin_openbuilder_net_custom/tsconfig.json
+++ b/servers/admin_openbuilder_net_custom/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `admin_openbuilder_net_custom`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/admin_openbuilder_net_custom`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "admin_openbuilder_net_custom": {
      "command": "npx",
      "args": ["-y", "@open-mcp/admin_openbuilder_net_custom"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.