### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,124 @@
+# @open-mcp/api_example_com
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_example_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/api_example_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### single_point_data_request_api_temporal_hourly_point_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "start": z.number().int().describe("This is the start time for the data request formatted as YYYYMMDD."),
+  "end": z.number().int().describe("This is the end time for the data request formatted as YYYYMMDD."),
+  "latitude": z.number().describe("This is the point latitude value."),
+  "longitude": z.number().describe("This is the point longitude value."),
+  "community": z.enum(["ag","sb","re"]).describe("The user community to return units for."),
+  "parameters": z.string().describe("A comma delimited list of the parameter abbreviations."),
+  "format": z.enum(["csv","json","ascii","netcdf","epw","epw_csv","xarray","sam","srw"]).describe("The response objects output format.").optional(),
+  "user": z.string().describe("A user name for identification purposes.").optional(),
+  "header": z.boolean().describe("To show or hide the header files of CSV and ASCII formats.").optional(),
+  "time-standard": z.enum(["lst","utc"]).describe("The time standard to return timestamps for.").optional(),
+  "site-elevation": z.number().describe("The custom site elevation in meters to produce the corrected atmospheric pressure adjusted for elevation.").optional(),
+  "wind-elevation": z.number().describe("The custom wind elevation in meters to produce the wind speed adjusted for elevation.").optional(),
+  "wind-surface": z.string().describe("The definable surface type to adjusted the wind speed.").optional()
+}
+```
+
+### configuration_settings_request_api_temporal_hourly_configuration
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,7 @@
+export const OPENAPI_URL = "https://power.larc.nasa.gov/api/temporal/hourly/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/single_point_data_request_api_temporal_hourly_point_get/index.js",
+  "./tools/configuration_settings_request_api_temporal_hourly_configuration/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/configuration_settings_request_api_temporal_hourly_configuration/index.ts
+++ b/servers/api_example_com/src/tools/configuration_settings_request_api_temporal_hourly_configuration/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "configuration_settings_request_api_temporal_hourly_configuration",
+  "toolDescription": "Configuration Settings Request",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/temporal/hourly/configuration",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/configuration_settings_request_api_temporal_hourly_configuration/schema-json/root.json
+++ b/servers/api_example_com/src/tools/configuration_settings_request_api_temporal_hourly_configuration/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/configuration_settings_request_api_temporal_hourly_configuration/schema/root.ts
+++ b/servers/api_example_com/src/tools/configuration_settings_request_api_temporal_hourly_configuration/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/single_point_data_request_api_temporal_hourly_point_get/index.ts
+++ b/servers/api_example_com/src/tools/single_point_data_request_api_temporal_hourly_point_get/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "single_point_data_request_api_temporal_hourly_point_get",
+  "toolDescription": "Single Point Data Request",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/temporal/hourly/point",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "start": "start",
+      "end": "end",
+      "latitude": "latitude",
+      "longitude": "longitude",
+      "community": "community",
+      "parameters": "parameters",
+      "format": "format",
+      "user": "user",
+      "header": "header",
+      "time-standard": "time-standard",
+      "site-elevation": "site-elevation",
+      "wind-elevation": "wind-elevation",
+      "wind-surface": "wind-surface"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/single_point_data_request_api_temporal_hourly_point_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/single_point_data_request_api_temporal_hourly_point_get/schema-json/root.json
@@ -1,0 +1,100 @@
+{
+  "type": "object",
+  "properties": {
+    "start": {
+      "description": "This is the start time for the data request formatted as YYYYMMDD.",
+      "type": "integer",
+      "title": "Start Time"
+    },
+    "end": {
+      "description": "This is the end time for the data request formatted as YYYYMMDD.",
+      "type": "integer",
+      "title": "End Time"
+    },
+    "latitude": {
+      "description": "This is the point latitude value.",
+      "type": "number",
+      "title": "Latitude Value"
+    },
+    "longitude": {
+      "description": "This is the point longitude value.",
+      "type": "number",
+      "title": "Longitude Value"
+    },
+    "community": {
+      "description": "The user community to return units for.",
+      "title": "User Community",
+      "type": "string",
+      "enum": [
+        "ag",
+        "sb",
+        "re"
+      ]
+    },
+    "parameters": {
+      "description": "A comma delimited list of the parameter abbreviations.",
+      "type": "string",
+      "title": "Parameter Abbreviations"
+    },
+    "format": {
+      "description": "The response objects output format.",
+      "title": "Format Abbreviation",
+      "type": "string",
+      "enum": [
+        "csv",
+        "json",
+        "ascii",
+        "netcdf",
+        "epw",
+        "epw_csv",
+        "xarray",
+        "sam",
+        "srw"
+      ]
+    },
+    "user": {
+      "description": "A user name for identification purposes.",
+      "type": "string",
+      "title": "User Name"
+    },
+    "header": {
+      "description": "To show or hide the header files of CSV and ASCII formats.",
+      "type": "boolean",
+      "title": "File Header",
+      "default": true
+    },
+    "time-standard": {
+      "description": "The time standard to return timestamps for.",
+      "title": "Time Standard",
+      "default": "lst",
+      "type": "string",
+      "enum": [
+        "lst",
+        "utc"
+      ]
+    },
+    "site-elevation": {
+      "description": "The custom site elevation in meters to produce the corrected atmospheric pressure adjusted for elevation.",
+      "type": "number",
+      "title": "Site Elevation"
+    },
+    "wind-elevation": {
+      "description": "The custom wind elevation in meters to produce the wind speed adjusted for elevation.",
+      "type": "number",
+      "title": "Wind Elevation"
+    },
+    "wind-surface": {
+      "description": "The definable surface type to adjusted the wind speed.",
+      "type": "string",
+      "title": "Wind Surface Type"
+    }
+  },
+  "required": [
+    "start",
+    "end",
+    "latitude",
+    "longitude",
+    "community",
+    "parameters"
+  ]
+}

--- a/servers/api_example_com/src/tools/single_point_data_request_api_temporal_hourly_point_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/single_point_data_request_api_temporal_hourly_point_get/schema/root.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "start": z.number().int().describe("This is the start time for the data request formatted as YYYYMMDD."),
+  "end": z.number().int().describe("This is the end time for the data request formatted as YYYYMMDD."),
+  "latitude": z.number().describe("This is the point latitude value."),
+  "longitude": z.number().describe("This is the point longitude value."),
+  "community": z.enum(["ag","sb","re"]).describe("The user community to return units for."),
+  "parameters": z.string().describe("A comma delimited list of the parameter abbreviations."),
+  "format": z.enum(["csv","json","ascii","netcdf","epw","epw_csv","xarray","sam","srw"]).describe("The response objects output format.").optional(),
+  "user": z.string().describe("A user name for identification purposes.").optional(),
+  "header": z.boolean().describe("To show or hide the header files of CSV and ASCII formats.").optional(),
+  "time-standard": z.enum(["lst","utc"]).describe("The time standard to return timestamps for.").optional(),
+  "site-elevation": z.number().describe("The custom site elevation in meters to produce the corrected atmospheric pressure adjusted for elevation.").optional(),
+  "wind-elevation": z.number().describe("The custom wind elevation in meters to produce the wind speed adjusted for elevation.").optional(),
+  "wind-surface": z.string().describe("The definable surface type to adjusted the wind speed.").optional()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.