### PR TITLE
Add MCP server `example_com_api`

### DIFF
--- a/servers/example_com_api/.npmignore
+++ b/servers/example_com_api/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/example_com_api/README.md
+++ b/servers/example_com_api/README.md
@@ -1,0 +1,128 @@
+# @open-mcp/example_com_api
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add example_com_api \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add example_com_api \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add example_com_api \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "example_com_api": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/example_com_api"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/example_com_api
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/example_com_api`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### get_users
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### post_users
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.string().describe("The unique identifier of the user"),
+  "name": z.string().describe("The name of the user"),
+  "email": z.string().email().describe("The email address of the user")
+}
+```
+
+### get_users_id_
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.string().describe("The ID of the user to retrieve")
+}
+```

--- a/servers/example_com_api/package.json
+++ b/servers/example_com_api/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/example_com_api",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "example_com_api": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/example_com_api/src/constants.ts
+++ b/servers/example_com_api/src/constants.ts
@@ -1,0 +1,8 @@
+export const OPENAPI_URL = "https://ceph.chinamye.com/bucket.admin/test.yaml"
+export const SERVER_NAME = "example_com_api"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_users/index.js",
+  "./tools/post_users/index.js",
+  "./tools/get_users_id_/index.js"
+]

--- a/servers/example_com_api/src/index.ts
+++ b/servers/example_com_api/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/example_com_api/src/server.ts
+++ b/servers/example_com_api/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/example_com_api/src/tools/get_users/index.ts
+++ b/servers/example_com_api/src/tools/get_users/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_users",
+  "toolDescription": "Get a list of users",
+  "baseUrl": "https://example.com/api",
+  "path": "/users",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/example_com_api/src/tools/get_users/schema-json/root.json
+++ b/servers/example_com_api/src/tools/get_users/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/example_com_api/src/tools/get_users/schema/root.ts
+++ b/servers/example_com_api/src/tools/get_users/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/example_com_api/src/tools/get_users_id_/index.ts
+++ b/servers/example_com_api/src/tools/get_users_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_users_id_",
+  "toolDescription": "Get a specific user",
+  "baseUrl": "https://example.com/api",
+  "path": "/users/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/example_com_api/src/tools/get_users_id_/schema-json/root.json
+++ b/servers/example_com_api/src/tools/get_users_id_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The ID of the user to retrieve",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/example_com_api/src/tools/get_users_id_/schema/root.ts
+++ b/servers/example_com_api/src/tools/get_users_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("The ID of the user to retrieve")
+}

--- a/servers/example_com_api/src/tools/post_users/index.ts
+++ b/servers/example_com_api/src/tools/post_users/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_users",
+  "toolDescription": "Create a new user",
+  "baseUrl": "https://example.com/api",
+  "path": "/users",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "name": "name",
+      "email": "email"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/example_com_api/src/tools/post_users/schema-json/root.json
+++ b/servers/example_com_api/src/tools/post_users/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "The unique identifier of the user"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the user"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "The email address of the user"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "email"
+  ]
+}

--- a/servers/example_com_api/src/tools/post_users/schema/root.ts
+++ b/servers/example_com_api/src/tools/post_users/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("The unique identifier of the user"),
+  "name": z.string().describe("The name of the user"),
+  "email": z.string().email().describe("The email address of the user")
+}

--- a/servers/example_com_api/tsconfig.json
+++ b/servers/example_com_api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `example_com_api`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/example_com_api`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "example_com_api": {
      "command": "npx",
      "args": ["-y", "@open-mcp/example_com_api"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.