### PR TITLE
Add MCP server `api_coachify_jp_public`

### DIFF
--- a/servers/api_coachify_jp_public/.npmignore
+++ b/servers/api_coachify_jp_public/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_coachify_jp_public/README.md
+++ b/servers/api_coachify_jp_public/README.md
@@ -1,0 +1,178 @@
+# @open-mcp/api_coachify_jp_public
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_coachify_jp_public \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=...
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_coachify_jp_public \
+  .cursor/mcp.json \
+  --API_KEY=...
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_coachify_jp_public \
+  /path/to/client/config.json \
+  --API_KEY=...
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_coachify_jp_public": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_coachify_jp_public"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_coachify_jp_public
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/api_coachify_jp_public`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### get_mail_magazine_contents_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "page": z.number().int().describe("ページ番号").optional(),
+  "page_size": z.number().int().lte(20).describe("1ページあたりの表示件数（最大20）").optional()
+}
+```
+
+### post_mail_magazine_contents_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "subject": z.string().describe("メールの件名"),
+  "price": z.number().int().gte(110).describe("価格（110円以上）"),
+  "html_body": z.string().describe("HTMLフォーマットのメール本文"),
+  "text_body": z.string().describe("テキストフォーマットのメール本文"),
+  "delivery_date": z.string().datetime({ offset: true }).describe("配信予定日時（現在より未来の日時、e.g. 2025-04-25T09:00:00.00+08:00 形式でタイムゾーン情報を含める）"),
+  "is_active": z.boolean().describe("有効/無効フラグ").optional()
+}
+```
+
+### parameters_mail_magazine_contents_content_id_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### get_mail_magazine_contents_content_id_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### patch_mail_magazine_contents_content_id_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "subject": z.string().describe("メールの件名").optional(),
+  "price": z.number().int().gte(110).describe("価格（110円以上）").optional(),
+  "html_body": z.string().describe("HTMLフォーマットのメール本文").optional(),
+  "text_body": z.string().describe("テキストフォーマットのメール本文").optional(),
+  "delivery_date": z.string().datetime({ offset: true }).describe("配信予定日時（現在より未来の日時、e.g. 2025-04-25T09:00:00.00+08:00 形式でタイムゾーン情報を含める）").optional(),
+  "is_active": z.boolean().describe("有効/無効フラグ").optional()
+}
+```
+
+### delete_mail_magazine_contents_content_id_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```

--- a/servers/api_coachify_jp_public/package.json
+++ b/servers/api_coachify_jp_public/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_coachify_jp_public",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_coachify_jp_public": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_coachify_jp_public/src/constants.ts
+++ b/servers/api_coachify_jp_public/src/constants.ts
@@ -1,0 +1,11 @@
+export const OPENAPI_URL = "https://coachify.jp/api-documents/openapi.yaml"
+export const SERVER_NAME = "api_coachify_jp_public"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_mail_magazine_contents_/index.js",
+  "./tools/post_mail_magazine_contents_/index.js",
+  "./tools/parameters_mail_magazine_contents_content_id_/index.js",
+  "./tools/get_mail_magazine_contents_content_id_/index.js",
+  "./tools/patch_mail_magazine_contents_content_id_/index.js",
+  "./tools/delete_mail_magazine_contents_content_id_/index.js"
+]

--- a/servers/api_coachify_jp_public/src/index.ts
+++ b/servers/api_coachify_jp_public/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_coachify_jp_public/src/server.ts
+++ b/servers/api_coachify_jp_public/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_coachify_jp_public/src/tools/delete_mail_magazine_contents_content_id_/index.ts
+++ b/servers/api_coachify_jp_public/src/tools/delete_mail_magazine_contents_content_id_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_mail_magazine_contents_content_id_",
+  "toolDescription": "メールマガジンコンテンツ削除",
+  "baseUrl": "https://api.coachify.jp/public",
+  "path": "/mail-magazine-contents/{content_id}/",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_coachify_jp_public/src/tools/delete_mail_magazine_contents_content_id_/schema-json/root.json
+++ b/servers/api_coachify_jp_public/src/tools/delete_mail_magazine_contents_content_id_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_coachify_jp_public/src/tools/delete_mail_magazine_contents_content_id_/schema/root.ts
+++ b/servers/api_coachify_jp_public/src/tools/delete_mail_magazine_contents_content_id_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_/index.ts
+++ b/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_mail_magazine_contents_",
+  "toolDescription": "メールマガジンコンテンツ一覧取得",
+  "baseUrl": "https://api.coachify.jp/public",
+  "path": "/mail-magazine-contents/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "page": "page",
+      "page_size": "page_size"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_/schema-json/root.json
+++ b/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "description": "ページ番号",
+      "type": "integer",
+      "default": 1
+    },
+    "page_size": {
+      "description": "1ページあたりの表示件数（最大20）",
+      "type": "integer",
+      "default": 10,
+      "maximum": 20
+    }
+  },
+  "required": []
+}

--- a/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_/schema/root.ts
+++ b/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().int().describe("ページ番号").optional(),
+  "page_size": z.number().int().lte(20).describe("1ページあたりの表示件数（最大20）").optional()
+}

--- a/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_content_id_/index.ts
+++ b/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_content_id_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_mail_magazine_contents_content_id_",
+  "toolDescription": "メールマガジンコンテンツ詳細取得",
+  "baseUrl": "https://api.coachify.jp/public",
+  "path": "/mail-magazine-contents/{content_id}/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_content_id_/schema-json/root.json
+++ b/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_content_id_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_content_id_/schema/root.ts
+++ b/servers/api_coachify_jp_public/src/tools/get_mail_magazine_contents_content_id_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_coachify_jp_public/src/tools/parameters_mail_magazine_contents_content_id_/index.ts
+++ b/servers/api_coachify_jp_public/src/tools/parameters_mail_magazine_contents_content_id_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_mail_magazine_contents_content_id_",
+  "toolDescription": "",
+  "baseUrl": "https://api.coachify.jp/public",
+  "path": "/mail-magazine-contents/{content_id}/",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_coachify_jp_public/src/tools/parameters_mail_magazine_contents_content_id_/schema-json/root.json
+++ b/servers/api_coachify_jp_public/src/tools/parameters_mail_magazine_contents_content_id_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_coachify_jp_public/src/tools/parameters_mail_magazine_contents_content_id_/schema/root.ts
+++ b/servers/api_coachify_jp_public/src/tools/parameters_mail_magazine_contents_content_id_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_coachify_jp_public/src/tools/patch_mail_magazine_contents_content_id_/index.ts
+++ b/servers/api_coachify_jp_public/src/tools/patch_mail_magazine_contents_content_id_/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "patch_mail_magazine_contents_content_id_",
+  "toolDescription": "メールマガジンコンテンツ更新",
+  "baseUrl": "https://api.coachify.jp/public",
+  "path": "/mail-magazine-contents/{content_id}/",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "subject": "subject",
+      "price": "price",
+      "html_body": "html_body",
+      "text_body": "text_body",
+      "delivery_date": "delivery_date",
+      "is_active": "is_active"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_coachify_jp_public/src/tools/patch_mail_magazine_contents_content_id_/schema-json/root.json
+++ b/servers/api_coachify_jp_public/src/tools/patch_mail_magazine_contents_content_id_/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "メールの件名"
+    },
+    "price": {
+      "type": "integer",
+      "minimum": 110,
+      "description": "価格（110円以上）"
+    },
+    "html_body": {
+      "type": "string",
+      "example": "<h1>Hello, World</h1><p></p><p>Hello, World</p>",
+      "description": "HTMLフォーマットのメール本文"
+    },
+    "text_body": {
+      "type": "string",
+      "example": "Hello, World\\n\\nHello, World",
+      "description": "テキストフォーマットのメール本文"
+    },
+    "delivery_date": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2025-04-25T09:00:00.00+08:00",
+      "description": "配信予定日時（現在より未来の日時、e.g. 2025-04-25T09:00:00.00+08:00 形式でタイムゾーン情報を含める）"
+    },
+    "is_active": {
+      "type": "boolean",
+      "description": "有効/無効フラグ"
+    }
+  },
+  "required": []
+}

--- a/servers/api_coachify_jp_public/src/tools/patch_mail_magazine_contents_content_id_/schema/root.ts
+++ b/servers/api_coachify_jp_public/src/tools/patch_mail_magazine_contents_content_id_/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "subject": z.string().describe("メールの件名").optional(),
+  "price": z.number().int().gte(110).describe("価格（110円以上）").optional(),
+  "html_body": z.string().describe("HTMLフォーマットのメール本文").optional(),
+  "text_body": z.string().describe("テキストフォーマットのメール本文").optional(),
+  "delivery_date": z.string().datetime({ offset: true }).describe("配信予定日時（現在より未来の日時、e.g. 2025-04-25T09:00:00.00+08:00 形式でタイムゾーン情報を含める）").optional(),
+  "is_active": z.boolean().describe("有効/無効フラグ").optional()
+}

--- a/servers/api_coachify_jp_public/src/tools/post_mail_magazine_contents_/index.ts
+++ b/servers/api_coachify_jp_public/src/tools/post_mail_magazine_contents_/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_mail_magazine_contents_",
+  "toolDescription": "メールマガジンコンテンツ作成",
+  "baseUrl": "https://api.coachify.jp/public",
+  "path": "/mail-magazine-contents/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "subject": "subject",
+      "price": "price",
+      "html_body": "html_body",
+      "text_body": "text_body",
+      "delivery_date": "delivery_date",
+      "is_active": "is_active"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_coachify_jp_public/src/tools/post_mail_magazine_contents_/schema-json/root.json
+++ b/servers/api_coachify_jp_public/src/tools/post_mail_magazine_contents_/schema-json/root.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "メールの件名"
+    },
+    "price": {
+      "type": "integer",
+      "minimum": 110,
+      "description": "価格（110円以上）"
+    },
+    "html_body": {
+      "type": "string",
+      "example": "<h1>Hello, World</h1><p></p><p>Hello, World</p>",
+      "description": "HTMLフォーマットのメール本文"
+    },
+    "text_body": {
+      "type": "string",
+      "example": "Hello, World\\n\\nHello, World",
+      "description": "テキストフォーマットのメール本文"
+    },
+    "delivery_date": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2025-04-25T09:00:00.00+08:00",
+      "description": "配信予定日時（現在より未来の日時、e.g. 2025-04-25T09:00:00.00+08:00 形式でタイムゾーン情報を含める）"
+    },
+    "is_active": {
+      "type": "boolean",
+      "default": true,
+      "description": "有効/無効フラグ"
+    }
+  },
+  "required": [
+    "subject",
+    "price",
+    "html_body",
+    "text_body",
+    "delivery_date"
+  ]
+}

--- a/servers/api_coachify_jp_public/src/tools/post_mail_magazine_contents_/schema/root.ts
+++ b/servers/api_coachify_jp_public/src/tools/post_mail_magazine_contents_/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "subject": z.string().describe("メールの件名"),
+  "price": z.number().int().gte(110).describe("価格（110円以上）"),
+  "html_body": z.string().describe("HTMLフォーマットのメール本文"),
+  "text_body": z.string().describe("テキストフォーマットのメール本文"),
+  "delivery_date": z.string().datetime({ offset: true }).describe("配信予定日時（現在より未来の日時、e.g. 2025-04-25T09:00:00.00+08:00 形式でタイムゾーン情報を含める）"),
+  "is_active": z.boolean().describe("有効/無効フラグ").optional()
+}

--- a/servers/api_coachify_jp_public/tsconfig.json
+++ b/servers/api_coachify_jp_public/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_coachify_jp_public`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_coachify_jp_public`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_coachify_jp_public": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_coachify_jp_public"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.