### PR TITLE
Add MCP server `shot-url`

### DIFF
--- a/servers/shot-url/.npmignore
+++ b/servers/shot-url/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/shot-url/README.md
+++ b/servers/shot-url/README.md
@@ -1,0 +1,183 @@
+# @open-mcp/shot-url
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add shot-url \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OAUTH2_TOKEN=...
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add shot-url \
+  .cursor/mcp.json \
+  --OAUTH2_TOKEN=...
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add shot-url \
+  /path/to/client/config.json \
+  --OAUTH2_TOKEN=...
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "shot-url": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/shot-url"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `OAUTH2_TOKEN`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/shot-url
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/shot-url`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### oauthapplicationlist
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### revokeoauthtoken
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "token": z.string().optional(),
+  "token_type_hint": z.string().describe("Enums(access_token,refresh_token)").optional()
+}
+```
+
+### oauthtokenrequest
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### shorturllist
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### removeshorturl
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "key": z.string().describe("short url key")
+}
+```
+
+### generateqrcode
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "key": z.string().describe("short url request").optional()
+}
+```
+
+### generateshorturl
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "key": z.string().describe("nullable").optional(),
+  "url": z.string().optional()
+}
+```

--- a/servers/shot-url/package.json
+++ b/servers/shot-url/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/shot-url",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "shot-url": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/shot-url/src/constants.ts
+++ b/servers/shot-url/src/constants.ts
@@ -1,0 +1,12 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/n-creativesystem/short-url/refs/heads/main/docs/openapi/api/swagger.yaml"
+export const SERVER_NAME = "shot-url"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/oauthapplicationlist/index.js",
+  "./tools/revokeoauthtoken/index.js",
+  "./tools/oauthtokenrequest/index.js",
+  "./tools/shorturllist/index.js",
+  "./tools/removeshorturl/index.js",
+  "./tools/generateqrcode/index.js",
+  "./tools/generateshorturl/index.js"
+]

--- a/servers/shot-url/src/index.ts
+++ b/servers/shot-url/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/shot-url/src/server.ts
+++ b/servers/shot-url/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/shot-url/src/tools/generateqrcode/index.ts
+++ b/servers/shot-url/src/tools/generateqrcode/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "generateqrcode",
+  "toolDescription": "短縮URLのQRコード生成",
+  "baseUrl": "https://api.example.com",
+  "path": "/shorts/{key}/qrcode",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "key": "key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/generateqrcode/schema-json/root.json
+++ b/servers/shot-url/src/tools/generateqrcode/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "description": "short url request",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/shot-url/src/tools/generateqrcode/schema/root.ts
+++ b/servers/shot-url/src/tools/generateqrcode/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key": z.string().describe("short url request").optional()
+}

--- a/servers/shot-url/src/tools/generateshorturl/index.ts
+++ b/servers/shot-url/src/tools/generateshorturl/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "generateshorturl",
+  "toolDescription": "短縮URLの生成",
+  "baseUrl": "https://api.example.com",
+  "path": "/shorts/generate",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "key": "key",
+      "url": "url"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/generateshorturl/schema-json/root.json
+++ b/servers/shot-url/src/tools/generateshorturl/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "description": "nullable",
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/shot-url/src/tools/generateshorturl/schema/root.ts
+++ b/servers/shot-url/src/tools/generateshorturl/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key": z.string().describe("nullable").optional(),
+  "url": z.string().optional()
+}

--- a/servers/shot-url/src/tools/oauthapplicationlist/index.ts
+++ b/servers/shot-url/src/tools/oauthapplicationlist/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "oauthapplicationlist",
+  "toolDescription": "登録されているOAuthアプリケーションの一覧",
+  "baseUrl": "https://api.example.com",
+  "path": "/oauth2",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/oauthapplicationlist/schema-json/root.json
+++ b/servers/shot-url/src/tools/oauthapplicationlist/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/shot-url/src/tools/oauthapplicationlist/schema/root.ts
+++ b/servers/shot-url/src/tools/oauthapplicationlist/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/shot-url/src/tools/oauthtokenrequest/index.ts
+++ b/servers/shot-url/src/tools/oauthtokenrequest/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "oauthtokenrequest",
+  "toolDescription": "アクセストークンの生成",
+  "baseUrl": "https://api.example.com",
+  "path": "/oauth2/token",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/oauthtokenrequest/schema-json/root.json
+++ b/servers/shot-url/src/tools/oauthtokenrequest/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/shot-url/src/tools/oauthtokenrequest/schema/root.ts
+++ b/servers/shot-url/src/tools/oauthtokenrequest/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/shot-url/src/tools/removeshorturl/index.ts
+++ b/servers/shot-url/src/tools/removeshorturl/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "removeshorturl",
+  "toolDescription": "短縮URLの削除",
+  "baseUrl": "https://api.example.com",
+  "path": "/shorts/{key}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "key": "key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/removeshorturl/schema-json/root.json
+++ b/servers/shot-url/src/tools/removeshorturl/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "description": "short url key",
+      "type": "string"
+    }
+  },
+  "required": [
+    "key"
+  ]
+}

--- a/servers/shot-url/src/tools/removeshorturl/schema/root.ts
+++ b/servers/shot-url/src/tools/removeshorturl/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key": z.string().describe("short url key")
+}

--- a/servers/shot-url/src/tools/revokeoauthtoken/index.ts
+++ b/servers/shot-url/src/tools/revokeoauthtoken/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "revokeoauthtoken",
+  "toolDescription": "アクセストークンの取消",
+  "baseUrl": "https://api.example.com",
+  "path": "/oauth2/revoke",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "token": "token",
+      "token_type_hint": "token_type_hint"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/revokeoauthtoken/schema-json/root.json
+++ b/servers/shot-url/src/tools/revokeoauthtoken/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "type": "string"
+    },
+    "token_type_hint": {
+      "description": "Enums(access_token,refresh_token)",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/shot-url/src/tools/revokeoauthtoken/schema/root.ts
+++ b/servers/shot-url/src/tools/revokeoauthtoken/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().optional(),
+  "token_type_hint": z.string().describe("Enums(access_token,refresh_token)").optional()
+}

--- a/servers/shot-url/src/tools/shorturllist/index.ts
+++ b/servers/shot-url/src/tools/shorturllist/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "shorturllist",
+  "toolDescription": "短縮URLの一覧",
+  "baseUrl": "https://api.example.com",
+  "path": "/shorts",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/shot-url/src/tools/shorturllist/schema-json/root.json
+++ b/servers/shot-url/src/tools/shorturllist/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/shot-url/src/tools/shorturllist/schema/root.ts
+++ b/servers/shot-url/src/tools/shorturllist/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/shot-url/tsconfig.json
+++ b/servers/shot-url/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `shot-url`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/shot-url`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "shot-url": {
      "command": "npx",
      "args": ["-y", "@open-mcp/shot-url"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.