### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,262 @@
+# @open-mcp/api_example_com
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_example_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/api_example_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### submit_stock_prediction_api_v1_predictions_submit_stock_predicti
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### get_all_predictions_api_v1_predictions_get_all_predictions_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### test_connection_api_v1_predictions_test_connection_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### get_leaderboard_api_v1_predictions_leaderboard_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "time_window": z.string().describe("Time window for leaderboard").optional()
+}
+```
+
+### get_user_stats_api_v1_predictions_user_stats_email_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "email": z.string(),
+  "time_window": z.string().describe("Time window for user stats").optional()
+}
+```
+
+### get_model_summary_api_v1_predictions_summary_model_name_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "model_name": z.string()
+}
+```
+
+### get_stock_price_api_v1_stockget_price_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "symbol": z.string().describe("Stock symbol, e.g., QQQ")
+}
+```
+
+### get_available_symbols_api_v1_stock_predictions_symbols_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### get_latest_prediction_api_v1_stock_predictions_latest_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "ticker": z.string().describe("股票代码").optional(),
+  "date": z.union([z.string(), z.null()]).describe("预测日期，格式: YYYY-MM-DD，默认为最近的交易日").optional()
+}
+```
+
+### get_prediction_api_v1_stock_predictions_ticker_date_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "ticker": z.string(),
+  "date": z.string(),
+  "start_bar": z.number().int().describe("开始的时间段编号，1表示开盘后15分钟").optional(),
+  "end_bar": z.number().int().describe("结束的时间段编号，2表示开盘后30分钟").optional()
+}
+```
+
+### get_stock_prediction_api_v1_stock_predictions_predictions_ticker
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "ticker": z.string(),
+  "date": z.string().optional()
+}
+```
+
+### root_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### health_check_health_get
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,18 @@
+export const OPENAPI_URL = "http://arena.when2buy.ai:8000/api/v1/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/index.js",
+  "./tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/index.js",
+  "./tools/test_connection_api_v1_predictions_test_connection_get/index.js",
+  "./tools/get_leaderboard_api_v1_predictions_leaderboard_get/index.js",
+  "./tools/get_user_stats_api_v1_predictions_user_stats_email_get/index.js",
+  "./tools/get_model_summary_api_v1_predictions_summary_model_name_get/index.js",
+  "./tools/get_stock_price_api_v1_stockget_price_get/index.js",
+  "./tools/get_available_symbols_api_v1_stock_predictions_symbols_get/index.js",
+  "./tools/get_latest_prediction_api_v1_stock_predictions_latest_get/index.js",
+  "./tools/get_prediction_api_v1_stock_predictions_ticker_date_get/index.js",
+  "./tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/index.js",
+  "./tools/root_get/index.js",
+  "./tools/health_check_health_get/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/index.ts
+++ b/servers/api_example_com/src/tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_all_predictions_api_v1_predictions_get_all_predictions_get",
+  "toolDescription": "Get All Predictions",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/predictions/get_all_predictions",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_all_predictions_api_v1_predictions_get_all_predictions_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/get_available_symbols_api_v1_stock_predictions_symbols_get/index.ts
+++ b/servers/api_example_com/src/tools/get_available_symbols_api_v1_stock_predictions_symbols_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_available_symbols_api_v1_stock_predictions_symbols_get",
+  "toolDescription": "Get Available Symbols",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/stock-predictions/symbols",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_available_symbols_api_v1_stock_predictions_symbols_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_available_symbols_api_v1_stock_predictions_symbols_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_available_symbols_api_v1_stock_predictions_symbols_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_available_symbols_api_v1_stock_predictions_symbols_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/get_latest_prediction_api_v1_stock_predictions_latest_get/index.ts
+++ b/servers/api_example_com/src/tools/get_latest_prediction_api_v1_stock_predictions_latest_get/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_latest_prediction_api_v1_stock_predictions_latest_get",
+  "toolDescription": "Get Latest Prediction",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/stock-predictions/latest",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "ticker": "ticker",
+      "date": "date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_latest_prediction_api_v1_stock_predictions_latest_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_latest_prediction_api_v1_stock_predictions_latest_get/schema-json/root.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "ticker": {
+      "description": "股票代码",
+      "type": "string",
+      "default": "QQQ",
+      "title": "Ticker"
+    },
+    "date": {
+      "description": "预测日期，格式: YYYY-MM-DD，默认为最近的交易日",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Date"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_latest_prediction_api_v1_stock_predictions_latest_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_latest_prediction_api_v1_stock_predictions_latest_get/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "ticker": z.string().describe("股票代码").optional(),
+  "date": z.union([z.string(), z.null()]).describe("预测日期，格式: YYYY-MM-DD，默认为最近的交易日").optional()
+}

--- a/servers/api_example_com/src/tools/get_leaderboard_api_v1_predictions_leaderboard_get/index.ts
+++ b/servers/api_example_com/src/tools/get_leaderboard_api_v1_predictions_leaderboard_get/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_leaderboard_api_v1_predictions_leaderboard_get",
+  "toolDescription": "Get Leaderboard",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/predictions/leaderboard",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "time_window": "time_window"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_leaderboard_api_v1_predictions_leaderboard_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_leaderboard_api_v1_predictions_leaderboard_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "time_window": {
+      "description": "Time window for leaderboard",
+      "type": "string",
+      "default": "all",
+      "title": "Time Window"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_leaderboard_api_v1_predictions_leaderboard_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_leaderboard_api_v1_predictions_leaderboard_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "time_window": z.string().describe("Time window for leaderboard").optional()
+}

--- a/servers/api_example_com/src/tools/get_model_summary_api_v1_predictions_summary_model_name_get/index.ts
+++ b/servers/api_example_com/src/tools/get_model_summary_api_v1_predictions_summary_model_name_get/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_model_summary_api_v1_predictions_summary_model_name_get",
+  "toolDescription": "Get Model Summary",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/predictions/summary/{model_name}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "model_name": "model_name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_model_summary_api_v1_predictions_summary_model_name_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_model_summary_api_v1_predictions_summary_model_name_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "model_name": {
+      "type": "string",
+      "title": "Model Name"
+    }
+  },
+  "required": [
+    "model_name"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_model_summary_api_v1_predictions_summary_model_name_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_model_summary_api_v1_predictions_summary_model_name_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "model_name": z.string()
+}

--- a/servers/api_example_com/src/tools/get_prediction_api_v1_stock_predictions_ticker_date_get/index.ts
+++ b/servers/api_example_com/src/tools/get_prediction_api_v1_stock_predictions_ticker_date_get/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_prediction_api_v1_stock_predictions_ticker_date_get",
+  "toolDescription": "Get Prediction",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/stock-predictions/{ticker}/{date}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "ticker": "ticker",
+      "date": "date"
+    },
+    "query": {
+      "start_bar": "start_bar",
+      "end_bar": "end_bar"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_prediction_api_v1_stock_predictions_ticker_date_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_prediction_api_v1_stock_predictions_ticker_date_get/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "ticker": {
+      "type": "string",
+      "title": "Ticker"
+    },
+    "date": {
+      "type": "string",
+      "title": "Date"
+    },
+    "start_bar": {
+      "description": "开始的时间段编号，1表示开盘后15分钟",
+      "type": "integer",
+      "default": 1,
+      "title": "Start Bar"
+    },
+    "end_bar": {
+      "description": "结束的时间段编号，2表示开盘后30分钟",
+      "type": "integer",
+      "default": 2,
+      "title": "End Bar"
+    }
+  },
+  "required": [
+    "ticker",
+    "date"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_prediction_api_v1_stock_predictions_ticker_date_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_prediction_api_v1_stock_predictions_ticker_date_get/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "ticker": z.string(),
+  "date": z.string(),
+  "start_bar": z.number().int().describe("开始的时间段编号，1表示开盘后15分钟").optional(),
+  "end_bar": z.number().int().describe("结束的时间段编号，2表示开盘后30分钟").optional()
+}

--- a/servers/api_example_com/src/tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/index.ts
+++ b/servers/api_example_com/src/tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_stock_prediction_api_v1_stock_predictions_predictions_ticker",
+  "toolDescription": "Get Stock Prediction",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/stock-predictions/predictions/{ticker}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "ticker": "ticker"
+    },
+    "query": {
+      "date": "date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "ticker": {
+      "type": "string",
+      "title": "Ticker"
+    },
+    "date": {
+      "type": "string",
+      "title": "Date"
+    }
+  },
+  "required": [
+    "ticker"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_stock_prediction_api_v1_stock_predictions_predictions_ticker/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "ticker": z.string(),
+  "date": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/get_stock_price_api_v1_stockget_price_get/index.ts
+++ b/servers/api_example_com/src/tools/get_stock_price_api_v1_stockget_price_get/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_stock_price_api_v1_stockget_price_get",
+  "toolDescription": "Get Stock Price",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/stockget/price",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "symbol": "symbol"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_stock_price_api_v1_stockget_price_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_stock_price_api_v1_stockget_price_get/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "symbol": {
+      "description": "Stock symbol, e.g., QQQ",
+      "type": "string",
+      "title": "Symbol"
+    }
+  },
+  "required": [
+    "symbol"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_stock_price_api_v1_stockget_price_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_stock_price_api_v1_stockget_price_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "symbol": z.string().describe("Stock symbol, e.g., QQQ")
+}

--- a/servers/api_example_com/src/tools/get_user_stats_api_v1_predictions_user_stats_email_get/index.ts
+++ b/servers/api_example_com/src/tools/get_user_stats_api_v1_predictions_user_stats_email_get/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_user_stats_api_v1_predictions_user_stats_email_get",
+  "toolDescription": "Get User Stats",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/predictions/user_stats/{email}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "email": "email"
+    },
+    "query": {
+      "time_window": "time_window"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_user_stats_api_v1_predictions_user_stats_email_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_user_stats_api_v1_predictions_user_stats_email_get/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "title": "Email"
+    },
+    "time_window": {
+      "description": "Time window for user stats",
+      "type": "string",
+      "default": "all",
+      "title": "Time Window"
+    }
+  },
+  "required": [
+    "email"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_user_stats_api_v1_predictions_user_stats_email_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_user_stats_api_v1_predictions_user_stats_email_get/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email": z.string(),
+  "time_window": z.string().describe("Time window for user stats").optional()
+}

--- a/servers/api_example_com/src/tools/health_check_health_get/index.ts
+++ b/servers/api_example_com/src/tools/health_check_health_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "health_check_health_get",
+  "toolDescription": "Health Check",
+  "baseUrl": "https://api.example.com",
+  "path": "/health",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/health_check_health_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/health_check_health_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/health_check_health_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/health_check_health_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/root_get/index.ts
+++ b/servers/api_example_com/src/tools/root_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "root_get",
+  "toolDescription": "Root",
+  "baseUrl": "https://api.example.com",
+  "path": "/",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/root_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/root_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/root_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/root_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/index.ts
+++ b/servers/api_example_com/src/tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "submit_stock_prediction_api_v1_predictions_submit_stock_predicti",
+  "toolDescription": "提交股票预测",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/predictions/submit_stock_prediction",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/schema-json/root.json
+++ b/servers/api_example_com/src/tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/schema/root.ts
+++ b/servers/api_example_com/src/tools/submit_stock_prediction_api_v1_predictions_submit_stock_predicti/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/test_connection_api_v1_predictions_test_connection_get/index.ts
+++ b/servers/api_example_com/src/tools/test_connection_api_v1_predictions_test_connection_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "test_connection_api_v1_predictions_test_connection_get",
+  "toolDescription": "Test Connection",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/predictions/test_connection",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/test_connection_api_v1_predictions_test_connection_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/test_connection_api_v1_predictions_test_connection_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/test_connection_api_v1_predictions_test_connection_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/test_connection_api_v1_predictions_test_connection_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.