### PR TITLE
Add MCP server `petstore3_swagger_io_api_v3`

### DIFF
--- a/servers/petstore3_swagger_io_api_v3/.npmignore
+++ b/servers/petstore3_swagger_io_api_v3/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/petstore3_swagger_io_api_v3/README.md
+++ b/servers/petstore3_swagger_io_api_v3/README.md
@@ -1,0 +1,389 @@
+# @open-mcp/petstore3_swagger_io_api_v3
+
+## Installing
+
+Use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add petstore3_swagger_io_api_v3 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OAUTH2_TOKEN=... \
+  --API_KEY=...
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add petstore3_swagger_io_api_v3 \
+  .cursor/mcp.json \
+  --OAUTH2_TOKEN=... \
+  --API_KEY=...
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add petstore3_swagger_io_api_v3 \
+  /path/to/client/config.json \
+  --OAUTH2_TOKEN=... \
+  --API_KEY=...
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "petstore3_swagger_io_api_v3": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/petstore3_swagger_io_api_v3"],
+      "env": {"OAUTH2_TOKEN":"...","API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `OAUTH2_TOKEN`
+- `API_KEY`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/petstore3_swagger_io_api_v3
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/petstore3_swagger_io_api_v3`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### updatepet
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.record(z.any()).describe("[EXPANDABLE PARAMETER]:").optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}
+```
+
+### addpet
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.record(z.any()).describe("[EXPANDABLE PARAMETER]:").optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}
+```
+
+### findpetsbystatus
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "status": z.enum(["available","pending","sold"]).describe("Status values that need to be considered for filter").optional()
+}
+```
+
+### findpetsbytags
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "tags": z.array(z.string()).describe("Tags to filter by").optional()
+}
+```
+
+### getpetbyid
+
+**Environment variables**
+
+- `API_KEY`
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("ID of pet to return")
+}
+```
+
+### updatepetwithform
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("ID of pet that needs to be updated"),
+  "name": z.string().describe("Name of pet that needs to be updated").optional(),
+  "status": z.string().describe("Status of pet that needs to be updated").optional()
+}
+```
+
+### deletepet
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("Pet id to delete"),
+  "api_key": z.string().optional()
+}
+```
+
+### uploadfile
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+```ts
+{
+  "petId": z.number().int().describe("ID of pet to update"),
+  "additionalMetadata": z.string().describe("Additional Metadata").optional()
+}
+```
+
+### getinventory
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{}
+```
+
+### placeorder
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "petId": z.number().int().optional(),
+  "quantity": z.number().int().optional(),
+  "shipDate": z.string().datetime({ offset: true }).optional(),
+  "status": z.enum(["placed","approved","delivered"]).describe("Order Status").optional(),
+  "complete": z.boolean().optional()
+}
+```
+
+### getorderbyid
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "orderId": z.number().int().describe("ID of order that needs to be fetched")
+}
+```
+
+### deleteorder
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "orderId": z.number().int().describe("ID of the order that needs to be deleted")
+}
+```
+
+### createuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}
+```
+
+### createuserswithlistinput
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### loginuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("The user name for login").optional(),
+  "password": z.string().describe("The password for login in clear text").optional()
+}
+```
+
+### logoutuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### getuserbyname
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("The name that needs to be fetched. Use user1 for testing")
+}
+```
+
+### updateuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("name that need to be deleted"),
+  "id": z.number().int().optional(),
+  "b_username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}
+```
+
+### deleteuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("The name that needs to be deleted")
+}
+```

--- a/servers/petstore3_swagger_io_api_v3/package.json
+++ b/servers/petstore3_swagger_io_api_v3/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/petstore3_swagger_io_api_v3",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "petstore3_swagger_io_api_v3": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/petstore3_swagger_io_api_v3/src/constants.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/constants.ts
@@ -1,0 +1,24 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/swagger-api/swagger-petstore/refs/heads/master/src/main/resources/openapi.yaml"
+export const SERVER_NAME = "petstore3_swagger_io_api_v3"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/updatepet/index.js",
+  "./tools/addpet/index.js",
+  "./tools/findpetsbystatus/index.js",
+  "./tools/findpetsbytags/index.js",
+  "./tools/getpetbyid/index.js",
+  "./tools/updatepetwithform/index.js",
+  "./tools/deletepet/index.js",
+  "./tools/uploadfile/index.js",
+  "./tools/getinventory/index.js",
+  "./tools/placeorder/index.js",
+  "./tools/getorderbyid/index.js",
+  "./tools/deleteorder/index.js",
+  "./tools/createuser/index.js",
+  "./tools/createuserswithlistinput/index.js",
+  "./tools/loginuser/index.js",
+  "./tools/logoutuser/index.js",
+  "./tools/getuserbyname/index.js",
+  "./tools/updateuser/index.js",
+  "./tools/deleteuser/index.js"
+]

--- a/servers/petstore3_swagger_io_api_v3/src/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import("./server.js").then((module) => {
+  module.runServer().catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/petstore3_swagger_io_api_v3/src/server.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/server.ts
@@ -1,0 +1,31 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer() {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      tools.push(tool)
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/addpet/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/addpet/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "addpet",
+  "toolDescription": "Add a new pet to the store.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "name": "name",
+      "category": "category",
+      "photoUrls": "photoUrls",
+      "tags": "tags",
+      "status": "status"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema-json/properties/category.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema-json/properties/category.json
@@ -1,0 +1,18 @@
+{
+  "x-swagger-router-model": "io.swagger.petstore.model.Category",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 1
+    },
+    "name": {
+      "type": "string",
+      "example": "Dogs"
+    }
+  },
+  "xml": {
+    "name": "category"
+  }
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema-json/root.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 10
+    },
+    "name": {
+      "type": "string",
+      "example": "doggie"
+    },
+    "category": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `category` to the tool, first call the tool `expandSchema` with \"/properties/category\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "photoUrls": {
+      "type": "array",
+      "xml": {
+        "wrapped": true
+      },
+      "items": {
+        "type": "string",
+        "xml": {
+          "name": "photoUrl"
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "xml": {
+        "wrapped": true
+      },
+      "items": {
+        "x-swagger-router-model": "io.swagger.petstore.model.Tag",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "tag"
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "description": "pet status in the store",
+      "enum": [
+        "available",
+        "pending",
+        "sold"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "photoUrls"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema/properties/category.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema/properties/category.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "name": z.string().optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/addpet/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `category` to the tool, first call the tool `expandSchema` with \"/properties/category\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/createuser/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/createuser/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createuser",
+  "toolDescription": "Create user.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "username": "username",
+      "firstName": "firstName",
+      "lastName": "lastName",
+      "email": "email",
+      "password": "password",
+      "phone": "phone",
+      "userStatus": "userStatus"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/createuser/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/createuser/schema-json/root.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 10
+    },
+    "username": {
+      "type": "string",
+      "example": "theUser"
+    },
+    "firstName": {
+      "type": "string",
+      "example": "John"
+    },
+    "lastName": {
+      "type": "string",
+      "example": "James"
+    },
+    "email": {
+      "type": "string",
+      "example": "john@email.com"
+    },
+    "password": {
+      "type": "string",
+      "example": "12345"
+    },
+    "phone": {
+      "type": "string",
+      "example": "12345"
+    },
+    "userStatus": {
+      "type": "integer",
+      "description": "User Status",
+      "format": "int32",
+      "example": 1
+    }
+  },
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/createuser/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/createuser/schema/root.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/createuserswithlistinput/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/createuserswithlistinput/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createuserswithlistinput",
+  "toolDescription": "Creates list of users with given input array.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user/createWithList",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/createuserswithlistinput/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/createuserswithlistinput/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/createuserswithlistinput/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/createuserswithlistinput/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deleteorder/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deleteorder/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteorder",
+  "toolDescription": "Delete purchase order by identifier.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/store/order/{orderId}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "orderId": "orderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deleteorder/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deleteorder/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "description": "ID of the order that needs to be deleted",
+      "type": "integer",
+      "format": "int64"
+    }
+  },
+  "required": [
+    "orderId"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deleteorder/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deleteorder/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "orderId": z.number().int().describe("ID of the order that needs to be deleted")
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deletepet/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deletepet/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletepet",
+  "toolDescription": "Deletes a pet.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet/{petId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "petId": "petId"
+    },
+    "header": {
+      "api_key": "api_key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deletepet/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deletepet/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "petId": {
+      "description": "Pet id to delete",
+      "type": "integer",
+      "format": "int64"
+    },
+    "api_key": {
+      "description": "",
+      "type": "string"
+    }
+  },
+  "required": [
+    "petId"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deletepet/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deletepet/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "petId": z.number().int().describe("Pet id to delete"),
+  "api_key": z.string().optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deleteuser/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deleteuser/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteuser",
+  "toolDescription": "Delete user resource.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user/{username}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "username": "username"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deleteuser/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deleteuser/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "The name that needs to be deleted",
+      "type": "string"
+    }
+  },
+  "required": [
+    "username"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/deleteuser/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/deleteuser/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("The name that needs to be deleted")
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbystatus/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbystatus/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findpetsbystatus",
+  "toolDescription": "Finds Pets by status.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet/findByStatus",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "status": "status"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbystatus/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbystatus/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "description": "Status values that need to be considered for filter",
+      "type": "string",
+      "default": "available",
+      "enum": [
+        "available",
+        "pending",
+        "sold"
+      ]
+    }
+  },
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbystatus/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbystatus/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "status": z.enum(["available","pending","sold"]).describe("Status values that need to be considered for filter").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbytags/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbytags/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findpetsbytags",
+  "toolDescription": "Finds Pets by tags.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet/findByTags",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "tags": "tags"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbytags/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbytags/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "tags": {
+      "description": "Tags to filter by",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbytags/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/findpetsbytags/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tags": z.array(z.string()).describe("Tags to filter by").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getinventory/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getinventory/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinventory",
+  "toolDescription": "Returns pet inventories by status.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/store/inventory",
+  "method": "get",
+  "security": [
+    {
+      "key": "api_key",
+      "value": "<mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getinventory/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getinventory/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getinventory/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getinventory/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getorderbyid/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getorderbyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getorderbyid",
+  "toolDescription": "Find purchase order by ID.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/store/order/{orderId}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "orderId": "orderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getorderbyid/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getorderbyid/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "description": "ID of order that needs to be fetched",
+      "type": "integer",
+      "format": "int64"
+    }
+  },
+  "required": [
+    "orderId"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getorderbyid/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getorderbyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "orderId": z.number().int().describe("ID of order that needs to be fetched")
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getpetbyid/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getpetbyid/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpetbyid",
+  "toolDescription": "Find pet by ID.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet/{petId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "api_key",
+      "value": "<mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "petId": "petId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getpetbyid/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getpetbyid/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "petId": {
+      "description": "ID of pet to return",
+      "type": "integer",
+      "format": "int64"
+    }
+  },
+  "required": [
+    "petId"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getpetbyid/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getpetbyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "petId": z.number().int().describe("ID of pet to return")
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getuserbyname/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getuserbyname/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getuserbyname",
+  "toolDescription": "Get user by user name.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user/{username}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "username": "username"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getuserbyname/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getuserbyname/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "The name that needs to be fetched. Use user1 for testing",
+      "type": "string"
+    }
+  },
+  "required": [
+    "username"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/getuserbyname/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/getuserbyname/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("The name that needs to be fetched. Use user1 for testing")
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/loginuser/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/loginuser/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "loginuser",
+  "toolDescription": "Logs user into the system.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user/login",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "username": "username",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/loginuser/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/loginuser/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "The user name for login",
+      "type": "string"
+    },
+    "password": {
+      "description": "The password for login in clear text",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/loginuser/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/loginuser/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("The user name for login").optional(),
+  "password": z.string().describe("The password for login in clear text").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/logoutuser/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/logoutuser/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "logoutuser",
+  "toolDescription": "Logs out current logged in user session.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user/logout",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/logoutuser/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/logoutuser/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/logoutuser/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/logoutuser/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/placeorder/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/placeorder/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "placeorder",
+  "toolDescription": "Place an order for a pet.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/store/order",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "petId": "petId",
+      "quantity": "quantity",
+      "shipDate": "shipDate",
+      "status": "status",
+      "complete": "complete"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/placeorder/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/placeorder/schema-json/root.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 10
+    },
+    "petId": {
+      "type": "integer",
+      "format": "int64",
+      "example": 198772
+    },
+    "quantity": {
+      "type": "integer",
+      "format": "int32",
+      "example": 7
+    },
+    "shipDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "description": "Order Status",
+      "example": "approved",
+      "enum": [
+        "placed",
+        "approved",
+        "delivered"
+      ]
+    },
+    "complete": {
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/placeorder/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/placeorder/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "petId": z.number().int().optional(),
+  "quantity": z.number().int().optional(),
+  "shipDate": z.string().datetime({ offset: true }).optional(),
+  "status": z.enum(["placed","approved","delivered"]).describe("Order Status").optional(),
+  "complete": z.boolean().optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatepet",
+  "toolDescription": "Update an existing pet.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "name": "name",
+      "category": "category",
+      "photoUrls": "photoUrls",
+      "tags": "tags",
+      "status": "status"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema-json/properties/category.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema-json/properties/category.json
@@ -1,0 +1,18 @@
+{
+  "x-swagger-router-model": "io.swagger.petstore.model.Category",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 1
+    },
+    "name": {
+      "type": "string",
+      "example": "Dogs"
+    }
+  },
+  "xml": {
+    "name": "category"
+  }
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema-json/root.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 10
+    },
+    "name": {
+      "type": "string",
+      "example": "doggie"
+    },
+    "category": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `category` to the tool, first call the tool `expandSchema` with \"/properties/category\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "photoUrls": {
+      "type": "array",
+      "xml": {
+        "wrapped": true
+      },
+      "items": {
+        "type": "string",
+        "xml": {
+          "name": "photoUrl"
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "xml": {
+        "wrapped": true
+      },
+      "items": {
+        "x-swagger-router-model": "io.swagger.petstore.model.Tag",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "tag"
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "description": "pet status in the store",
+      "enum": [
+        "available",
+        "pending",
+        "sold"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "photoUrls"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema/properties/category.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema/properties/category.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "name": z.string().optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepet/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "name": z.string(),
+  "category": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `category` to the tool, first call the tool `expandSchema` with \"/properties/category\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional(),
+  "photoUrls": z.array(z.string()),
+  "tags": z.array(z.object({ "id": z.number().int().optional(), "name": z.string().optional() })).optional(),
+  "status": z.enum(["available","pending","sold"]).describe("pet status in the store").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepetwithform/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepetwithform/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatepetwithform",
+  "toolDescription": "Updates a pet in the store with form data.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet/{petId}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "petId": "petId"
+    },
+    "query": {
+      "name": "name",
+      "status": "status"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepetwithform/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepetwithform/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "petId": {
+      "description": "ID of pet that needs to be updated",
+      "type": "integer",
+      "format": "int64"
+    },
+    "name": {
+      "description": "Name of pet that needs to be updated",
+      "type": "string"
+    },
+    "status": {
+      "description": "Status of pet that needs to be updated",
+      "type": "string"
+    }
+  },
+  "required": [
+    "petId"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updatepetwithform/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updatepetwithform/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "petId": z.number().int().describe("ID of pet that needs to be updated"),
+  "name": z.string().describe("Name of pet that needs to be updated").optional(),
+  "status": z.string().describe("Status of pet that needs to be updated").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updateuser/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updateuser/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updateuser",
+  "toolDescription": "Update user resource.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/user/{username}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "username": "username"
+    },
+    "body": {
+      "id": "id",
+      "username": "b_username",
+      "firstName": "firstName",
+      "lastName": "lastName",
+      "email": "email",
+      "password": "password",
+      "phone": "phone",
+      "userStatus": "userStatus"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updateuser/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updateuser/schema-json/root.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "name that need to be deleted",
+      "type": "string"
+    },
+    "id": {
+      "type": "integer",
+      "format": "int64",
+      "example": 10
+    },
+    "b_username": {
+      "type": "string",
+      "example": "theUser"
+    },
+    "firstName": {
+      "type": "string",
+      "example": "John"
+    },
+    "lastName": {
+      "type": "string",
+      "example": "James"
+    },
+    "email": {
+      "type": "string",
+      "example": "john@email.com"
+    },
+    "password": {
+      "type": "string",
+      "example": "12345"
+    },
+    "phone": {
+      "type": "string",
+      "example": "12345"
+    },
+    "userStatus": {
+      "type": "integer",
+      "description": "User Status",
+      "format": "int32",
+      "example": 1
+    }
+  },
+  "required": [
+    "username"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/updateuser/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/updateuser/schema/root.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("name that need to be deleted"),
+  "id": z.number().int().optional(),
+  "b_username": z.string().optional(),
+  "firstName": z.string().optional(),
+  "lastName": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional(),
+  "phone": z.string().optional(),
+  "userStatus": z.number().int().describe("User Status").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/uploadfile/index.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/uploadfile/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "uploadfile",
+  "toolDescription": "Uploads an image.",
+  "baseUrl": "https://petstore3.swagger.io/api/v3",
+  "path": "/pet/{petId}/uploadImage",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "petId": "petId"
+    },
+    "query": {
+      "additionalMetadata": "additionalMetadata"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore3_swagger_io_api_v3/src/tools/uploadfile/schema-json/root.json
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/uploadfile/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "petId": {
+      "description": "ID of pet to update",
+      "type": "integer",
+      "format": "int64"
+    },
+    "additionalMetadata": {
+      "description": "Additional Metadata",
+      "type": "string"
+    }
+  },
+  "required": [
+    "petId"
+  ]
+}

--- a/servers/petstore3_swagger_io_api_v3/src/tools/uploadfile/schema/root.ts
+++ b/servers/petstore3_swagger_io_api_v3/src/tools/uploadfile/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "petId": z.number().int().describe("ID of pet to update"),
+  "additionalMetadata": z.string().describe("Additional Metadata").optional()
+}

--- a/servers/petstore3_swagger_io_api_v3/tsconfig.json
+++ b/servers/petstore3_swagger_io_api_v3/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `petstore3_swagger_io_api_v3`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/petstore3_swagger_io_api_v3`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "petstore3_swagger_io_api_v3": {
      "command": "npx",
      "args": ["-y", "@open-mcp/petstore3_swagger_io_api_v3"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.