### PR TITLE
Add MCP server `spotify`

### DIFF
--- a/servers/spotify/package.json
+++ b/servers/spotify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mcp/spotify",
-  "version": "0.0.12",
+  "version": "0.0.1",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/servers/spotify/src/index.ts
+++ b/servers/spotify/src/index.ts
@@ -1,17 +1,25 @@
 #!/usr/bin/env node
 
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
 import("./server.js").then((module) => {
   const args = process.argv.slice(2)
-  const toolsArg = args.find((arg) => arg.startsWith("--tools="))
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
 
-  let toolNames: string[] | undefined
-  if (toolsArg) {
-    toolNames = toolsArg
-      .replace("--tools=", "")
-      .split(",")
-      .filter((tool) => tool !== "")
-    toolNames = toolNames.length > 0 ? toolNames : undefined
-  }
+  const toolNames = parseCSV(toolsCSV)
 
   module.runServer({ toolNames }).catch((error) => {
     console.error("Fatal error running server:", error)


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `spotify`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/spotify`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "spotify": {
      "command": "npx",
      "args": ["-y", "@open-mcp/spotify"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.