### PR TITLE
Add MCP server `fakestoreapi_com`

### DIFF
--- a/servers/fakestoreapi_com/.npmignore
+++ b/servers/fakestoreapi_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/fakestoreapi_com/README.md
+++ b/servers/fakestoreapi_com/README.md
@@ -1,0 +1,334 @@
+# @open-mcp/fakestoreapi_com
+
+## Installing
+
+First set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add fakestoreapi_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add fakestoreapi_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add fakestoreapi_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "fakestoreapi_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/fakestoreapi_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/fakestoreapi_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/fakestoreapi_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### getallproducts
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### addproduct
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "title": z.string().optional(),
+  "price": z.number().optional(),
+  "description": z.string().optional(),
+  "category": z.string().optional(),
+  "image": z.string().url().optional()
+}
+```
+
+### getproductbyid
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int()
+}
+```
+
+### updateproduct
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int(),
+  "b_id": z.number().int().optional(),
+  "title": z.string().optional(),
+  "price": z.number().optional(),
+  "description": z.string().optional(),
+  "category": z.string().optional(),
+  "image": z.string().url().optional()
+}
+```
+
+### deleteproduct
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int()
+}
+```
+
+### getallcarts
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### addcart
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "userId": z.number().int().optional(),
+  "products": z.array(z.object({ "id": z.number().int().optional(), "title": z.string().optional(), "price": z.number().optional(), "description": z.string().optional(), "category": z.string().optional(), "image": z.string().url().optional() })).optional()
+}
+```
+
+### getcartbyid
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int()
+}
+```
+
+### updatecart
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int(),
+  "b_id": z.number().int().optional(),
+  "userId": z.number().int().optional(),
+  "products": z.array(z.object({ "id": z.number().int().optional(), "title": z.string().optional(), "price": z.number().optional(), "description": z.string().optional(), "category": z.string().optional(), "image": z.string().url().optional() })).optional()
+}
+```
+
+### deletecart
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int()
+}
+```
+
+### getallusers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### adduser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional()
+}
+```
+
+### getuserbyid
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int()
+}
+```
+
+### updateuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int(),
+  "b_id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional()
+}
+```
+
+### deleteuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "id": z.number().int()
+}
+```
+
+### loginuser
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().optional(),
+  "password": z.string().optional()
+}
+```

--- a/servers/fakestoreapi_com/package.json
+++ b/servers/fakestoreapi_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/fakestoreapi_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "fakestoreapi_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/fakestoreapi_com/src/constants.ts
+++ b/servers/fakestoreapi_com/src/constants.ts
@@ -1,0 +1,21 @@
+export const OPENAPI_URL = "https://fakestoreapi.com/fakestoreapi.json"
+export const SERVER_NAME = "fakestoreapi_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getallproducts/index.js",
+  "./tools/addproduct/index.js",
+  "./tools/getproductbyid/index.js",
+  "./tools/updateproduct/index.js",
+  "./tools/deleteproduct/index.js",
+  "./tools/getallcarts/index.js",
+  "./tools/addcart/index.js",
+  "./tools/getcartbyid/index.js",
+  "./tools/updatecart/index.js",
+  "./tools/deletecart/index.js",
+  "./tools/getallusers/index.js",
+  "./tools/adduser/index.js",
+  "./tools/getuserbyid/index.js",
+  "./tools/updateuser/index.js",
+  "./tools/deleteuser/index.js",
+  "./tools/loginuser/index.js"
+]

--- a/servers/fakestoreapi_com/src/index.ts
+++ b/servers/fakestoreapi_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/fakestoreapi_com/src/server.ts
+++ b/servers/fakestoreapi_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/fakestoreapi_com/src/tools/addcart/index.ts
+++ b/servers/fakestoreapi_com/src/tools/addcart/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "addcart",
+  "toolDescription": "Add a new cart",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/carts",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "userId": "userId",
+      "products": "products"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/addcart/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/addcart/schema-json/root.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "userId": {
+      "type": "integer"
+    },
+    "products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "description": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    }
+  },
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/addcart/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/addcart/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "userId": z.number().int().optional(),
+  "products": z.array(z.object({ "id": z.number().int().optional(), "title": z.string().optional(), "price": z.number().optional(), "description": z.string().optional(), "category": z.string().optional(), "image": z.string().url().optional() })).optional()
+}

--- a/servers/fakestoreapi_com/src/tools/addproduct/index.ts
+++ b/servers/fakestoreapi_com/src/tools/addproduct/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "addproduct",
+  "toolDescription": "Add a new product",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/products",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "title": "title",
+      "price": "price",
+      "description": "description",
+      "category": "category",
+      "image": "image"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/addproduct/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/addproduct/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "title": {
+      "type": "string"
+    },
+    "price": {
+      "type": "number",
+      "format": "float"
+    },
+    "description": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "image": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/addproduct/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/addproduct/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "title": z.string().optional(),
+  "price": z.number().optional(),
+  "description": z.string().optional(),
+  "category": z.string().optional(),
+  "image": z.string().url().optional()
+}

--- a/servers/fakestoreapi_com/src/tools/adduser/index.ts
+++ b/servers/fakestoreapi_com/src/tools/adduser/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "adduser",
+  "toolDescription": "Add a new user",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/users",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "username": "username",
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/adduser/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/adduser/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "username": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/adduser/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/adduser/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional()
+}

--- a/servers/fakestoreapi_com/src/tools/deletecart/index.ts
+++ b/servers/fakestoreapi_com/src/tools/deletecart/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletecart",
+  "toolDescription": "Delete a cart",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/carts/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/deletecart/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/deletecart/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/deletecart/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/deletecart/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int()
+}

--- a/servers/fakestoreapi_com/src/tools/deleteproduct/index.ts
+++ b/servers/fakestoreapi_com/src/tools/deleteproduct/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteproduct",
+  "toolDescription": "Delete a product",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/products/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/deleteproduct/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/deleteproduct/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/deleteproduct/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/deleteproduct/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int()
+}

--- a/servers/fakestoreapi_com/src/tools/deleteuser/index.ts
+++ b/servers/fakestoreapi_com/src/tools/deleteuser/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteuser",
+  "toolDescription": "Delete a user",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/users/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/deleteuser/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/deleteuser/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/deleteuser/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/deleteuser/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int()
+}

--- a/servers/fakestoreapi_com/src/tools/getallcarts/index.ts
+++ b/servers/fakestoreapi_com/src/tools/getallcarts/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getallcarts",
+  "toolDescription": "Get all carts",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/carts",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/getallcarts/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/getallcarts/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/getallcarts/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/getallcarts/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/fakestoreapi_com/src/tools/getallproducts/index.ts
+++ b/servers/fakestoreapi_com/src/tools/getallproducts/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getallproducts",
+  "toolDescription": "Get all products",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/products",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/getallproducts/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/getallproducts/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/getallproducts/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/getallproducts/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/fakestoreapi_com/src/tools/getallusers/index.ts
+++ b/servers/fakestoreapi_com/src/tools/getallusers/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getallusers",
+  "toolDescription": "Get all users",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/users",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/getallusers/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/getallusers/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/getallusers/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/getallusers/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/fakestoreapi_com/src/tools/getcartbyid/index.ts
+++ b/servers/fakestoreapi_com/src/tools/getcartbyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcartbyid",
+  "toolDescription": "Get a single cart",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/carts/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/getcartbyid/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/getcartbyid/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/getcartbyid/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/getcartbyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int()
+}

--- a/servers/fakestoreapi_com/src/tools/getproductbyid/index.ts
+++ b/servers/fakestoreapi_com/src/tools/getproductbyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getproductbyid",
+  "toolDescription": "Get a single product",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/products/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/getproductbyid/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/getproductbyid/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/getproductbyid/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/getproductbyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int()
+}

--- a/servers/fakestoreapi_com/src/tools/getuserbyid/index.ts
+++ b/servers/fakestoreapi_com/src/tools/getuserbyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getuserbyid",
+  "toolDescription": "Get a single user",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/users/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/getuserbyid/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/getuserbyid/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/getuserbyid/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/getuserbyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int()
+}

--- a/servers/fakestoreapi_com/src/tools/loginuser/index.ts
+++ b/servers/fakestoreapi_com/src/tools/loginuser/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "loginuser",
+  "toolDescription": "Login",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/auth/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "username": "username",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/loginuser/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/loginuser/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/fakestoreapi_com/src/tools/loginuser/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/loginuser/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().optional(),
+  "password": z.string().optional()
+}

--- a/servers/fakestoreapi_com/src/tools/updatecart/index.ts
+++ b/servers/fakestoreapi_com/src/tools/updatecart/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatecart",
+  "toolDescription": "Update a cart",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/carts/{id}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "body": {
+      "id": "b_id",
+      "userId": "userId",
+      "products": "products"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/updatecart/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/updatecart/schema-json/root.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "b_id": {
+      "type": "integer"
+    },
+    "userId": {
+      "type": "integer"
+    },
+    "products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "description": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/updatecart/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/updatecart/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int(),
+  "b_id": z.number().int().optional(),
+  "userId": z.number().int().optional(),
+  "products": z.array(z.object({ "id": z.number().int().optional(), "title": z.string().optional(), "price": z.number().optional(), "description": z.string().optional(), "category": z.string().optional(), "image": z.string().url().optional() })).optional()
+}

--- a/servers/fakestoreapi_com/src/tools/updateproduct/index.ts
+++ b/servers/fakestoreapi_com/src/tools/updateproduct/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updateproduct",
+  "toolDescription": "Update a product",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/products/{id}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "body": {
+      "id": "b_id",
+      "title": "title",
+      "price": "price",
+      "description": "description",
+      "category": "category",
+      "image": "image"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/updateproduct/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/updateproduct/schema-json/root.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "b_id": {
+      "type": "integer"
+    },
+    "title": {
+      "type": "string"
+    },
+    "price": {
+      "type": "number",
+      "format": "float"
+    },
+    "description": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "image": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/updateproduct/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/updateproduct/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int(),
+  "b_id": z.number().int().optional(),
+  "title": z.string().optional(),
+  "price": z.number().optional(),
+  "description": z.string().optional(),
+  "category": z.string().optional(),
+  "image": z.string().url().optional()
+}

--- a/servers/fakestoreapi_com/src/tools/updateuser/index.ts
+++ b/servers/fakestoreapi_com/src/tools/updateuser/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updateuser",
+  "toolDescription": "Update a user",
+  "baseUrl": "https://fakestoreapi.com",
+  "path": "/users/{id}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "body": {
+      "id": "b_id",
+      "username": "username",
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fakestoreapi_com/src/tools/updateuser/schema-json/root.json
+++ b/servers/fakestoreapi_com/src/tools/updateuser/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "b_id": {
+      "type": "integer"
+    },
+    "username": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/fakestoreapi_com/src/tools/updateuser/schema/root.ts
+++ b/servers/fakestoreapi_com/src/tools/updateuser/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int(),
+  "b_id": z.number().int().optional(),
+  "username": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional()
+}

--- a/servers/fakestoreapi_com/tsconfig.json
+++ b/servers/fakestoreapi_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `fakestoreapi_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/fakestoreapi_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "fakestoreapi_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/fakestoreapi_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.