### PR TITLE
Add MCP server `llamawrapper_prod_onrender_com`

### DIFF
--- a/servers/llamawrapper_prod_onrender_com/.npmignore
+++ b/servers/llamawrapper_prod_onrender_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/llamawrapper_prod_onrender_com/README.md
+++ b/servers/llamawrapper_prod_onrender_com/README.md
@@ -1,0 +1,508 @@
+# @open-mcp/llamawrapper_prod_onrender_com
+
+## Installing
+
+First set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add llamawrapper_prod_onrender_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add llamawrapper_prod_onrender_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add llamawrapper_prod_onrender_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "llamawrapper_prod_onrender_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/llamawrapper_prod_onrender_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+No environment variables required
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/llamawrapper_prod_onrender_com
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/llamawrapper_prod_onrender_com`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### getprotocol
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "slug": z.string().describe("Used to filter protocols by their slug.")
+}
+```
+
+### getprotocoltvl
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "slug": z.string().describe("Used to filter protocols by their slug.")
+}
+```
+
+### gettopgainers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}
+```
+
+### gettopgrowers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}
+```
+
+### gettoplosers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}
+```
+
+### gettopshrinkers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}
+```
+
+### gethistoricalprotocoltvl
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "slug": z.string().describe("Used to filter protocols by their slug.")
+}
+```
+
+### getslug
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "text": z.string().describe("The text to match against the available slugs.")
+}
+```
+
+### getprotocolfees
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "defillamaId": z.string().describe("The DefiLlamaID of the protocol"),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the fees were collected. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional()
+}
+```
+
+### gettopprotocolfees
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top protocols to return. Default to 10.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the fees were collected. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional(),
+  "chain": z.string().describe("Name of the blockchain or L2 to filter protocol fees by.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional()
+}
+```
+
+### getdefillamaid
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "text": z.string().describe("The name of the protocol")
+}
+```
+
+### getprotocolrevenue
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "defillamaId": z.string().describe("The DefiLlamaID of the protocol"),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional()
+}
+```
+
+### gettopprotocolrevenue
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top protocols to return. Default to 10.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional(),
+  "chain": z.string().describe("Name of the blockchain or L2 to filter protocol revenue by.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional()
+}
+```
+
+### getchaintvl
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "chain": z.string().describe("Name of the chain or L2 to retrieve TVL for.").optional()
+}
+```
+
+### getchaintvlchange
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "chain": z.string().describe("Name of the chain or L2 to retrieve TVL change for."),
+  "time_period": z.enum(["day","week","month"]).describe("Time period for TVL change calculation. Can be day, week or month.").optional()
+}
+```
+
+### getnetbridgeflow
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "chain": z.string().describe("Name of the chain or L2 to retrieve net bridge flow for."),
+  "time_period": z.enum(["day","week","month"]).describe("Time period for net bridge flow calculation. Can be day, week or month.").optional()
+}
+```
+
+### getallnetbridgeflows
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "time_period": z.enum(["day","week","month"]).describe("Time period for net bridge flow calculation. Can be day, week or month.").optional()
+}
+```
+
+### gettopyields
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_pools": z.number().int().gte(1).describe("Number of pools to retrieve. Default is 10.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter pools by.").optional(),
+  "stablecoin": z.boolean().describe("Flag indicating whether to filter for stablecoin yield pools.").optional(),
+  "token": z.string().describe("Token or token pair to filter pools by.").optional(),
+  "single_sided": z.boolean().describe("Flag indicating whether to filter for single-sided yield pools.").optional(),
+  "outlook": z.enum(["stable","up","down"]).describe("Future outlook for the yield of this pool.").optional()
+}
+```
+
+### getfeatures
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### getfeedbackform
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### gettopchaingainers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_chains": z.number().int().describe("The number of top gainers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}
+```
+
+### gettopchaingrowers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_chains": z.number().int().describe("The number of top gainers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}
+```
+
+### gettopchainlosers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_chains": z.number().int().describe("The number of top losers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}
+```
+
+### gettopchainshrinkers
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_chains": z.number().int().describe("The number of top losers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}
+```
+
+### getinteresting
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "time_period": z.enum(["day","week"]).describe("The time period for which to retrieve data. Can be day or week.").optional()
+}
+```
+
+### getdexvolume
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "defillamaId": z.string().describe("The DefiLlamaID of the protocol"),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the trading volume occured. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional()
+}
+```
+
+### gettopdexvolume
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "num_protocols": z.number().int().describe("The number of top protocols to return. Default to 10.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional(),
+  "chain": z.string().describe("Name of the blockchain or L2 to filter protocol revenue by.").optional()
+}
+```

--- a/servers/llamawrapper_prod_onrender_com/package.json
+++ b/servers/llamawrapper_prod_onrender_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/llamawrapper_prod_onrender_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "llamawrapper_prod_onrender_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/llamawrapper_prod_onrender_com/src/constants.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/constants.ts
@@ -1,0 +1,32 @@
+export const OPENAPI_URL = "https://llamawrapper-prod.onrender.com/openapi.yaml"
+export const SERVER_NAME = "llamawrapper_prod_onrender_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getprotocol/index.js",
+  "./tools/getprotocoltvl/index.js",
+  "./tools/gettopgainers/index.js",
+  "./tools/gettopgrowers/index.js",
+  "./tools/gettoplosers/index.js",
+  "./tools/gettopshrinkers/index.js",
+  "./tools/gethistoricalprotocoltvl/index.js",
+  "./tools/getslug/index.js",
+  "./tools/getprotocolfees/index.js",
+  "./tools/gettopprotocolfees/index.js",
+  "./tools/getdefillamaid/index.js",
+  "./tools/getprotocolrevenue/index.js",
+  "./tools/gettopprotocolrevenue/index.js",
+  "./tools/getchaintvl/index.js",
+  "./tools/getchaintvlchange/index.js",
+  "./tools/getnetbridgeflow/index.js",
+  "./tools/getallnetbridgeflows/index.js",
+  "./tools/gettopyields/index.js",
+  "./tools/getfeatures/index.js",
+  "./tools/getfeedbackform/index.js",
+  "./tools/gettopchaingainers/index.js",
+  "./tools/gettopchaingrowers/index.js",
+  "./tools/gettopchainlosers/index.js",
+  "./tools/gettopchainshrinkers/index.js",
+  "./tools/getinteresting/index.js",
+  "./tools/getdexvolume/index.js",
+  "./tools/gettopdexvolume/index.js"
+]

--- a/servers/llamawrapper_prod_onrender_com/src/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/llamawrapper_prod_onrender_com/src/server.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getallnetbridgeflows/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getallnetbridgeflows/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getallnetbridgeflows",
+  "toolDescription": "Get the net bridge flow for all chains and L2s over a given time period.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_all_net_bridge_flows",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getallnetbridgeflows/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getallnetbridgeflows/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "time_period": {
+      "description": "Time period for net bridge flow calculation. Can be day, week or month.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "default": "month"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getallnetbridgeflows/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getallnetbridgeflows/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "time_period": z.enum(["day","week","month"]).describe("Time period for net bridge flow calculation. Can be day, week or month.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvl/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvl/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getchaintvl",
+  "toolDescription": "Get the TVL for a specific chain or L2.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_chain_tvl",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "chain": "chain"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvl/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvl/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "chain": {
+      "description": "Name of the chain or L2 to retrieve TVL for.",
+      "type": "string",
+      "example": "ethereum"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvl/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvl/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "chain": z.string().describe("Name of the chain or L2 to retrieve TVL for.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvlchange/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvlchange/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getchaintvlchange",
+  "toolDescription": "Get the change in TVL for a specific chain or L2 over a given time period.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_chain_tvl_change",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "chain": "chain",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvlchange/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvlchange/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "chain": {
+      "description": "Name of the chain or L2 to retrieve TVL change for.",
+      "type": "string",
+      "example": "ethereum"
+    },
+    "time_period": {
+      "description": "Time period for TVL change calculation. Can be day, week or month.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "default": "month"
+    }
+  },
+  "required": [
+    "chain"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvlchange/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getchaintvlchange/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "chain": z.string().describe("Name of the chain or L2 to retrieve TVL change for."),
+  "time_period": z.enum(["day","week","month"]).describe("Time period for TVL change calculation. Can be day, week or month.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getdefillamaid/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getdefillamaid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getdefillamaid",
+  "toolDescription": "Get the DefiLlamaID of a protocol",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_defillamaId",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "text": "text"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getdefillamaid/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getdefillamaid/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "description": "The name of the protocol",
+      "type": "string",
+      "example": "uniswap"
+    }
+  },
+  "required": [
+    "text"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getdefillamaid/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getdefillamaid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "text": z.string().describe("The name of the protocol")
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getdexvolume/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getdexvolume/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getdexvolume",
+  "toolDescription": "Get the trading volume of a dex",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_dex_volume",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "defillamaId": "defillamaId",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getdexvolume/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getdexvolume/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "defillamaId": {
+      "description": "The DefiLlamaID of the protocol",
+      "type": "string"
+    },
+    "time_period": {
+      "description": "The time period in which the trading volume occured. Can be 'day', 'week', or 'month'. Defaults to 'month'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ]
+    }
+  },
+  "required": [
+    "defillamaId"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getdexvolume/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getdexvolume/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "defillamaId": z.string().describe("The DefiLlamaID of the protocol"),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the trading volume occured. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getfeatures/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getfeatures/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getfeatures",
+  "toolDescription": "Get information about what this plugin can do.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_features",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getfeatures/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getfeatures/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getfeatures/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getfeatures/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getfeedbackform/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getfeedbackform/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getfeedbackform",
+  "toolDescription": "Get link to a form where you can give feedback on the plugin.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_feedback_form",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getfeedbackform/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getfeedbackform/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getfeedbackform/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getfeedbackform/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gethistoricalprotocoltvl/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gethistoricalprotocoltvl/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gethistoricalprotocoltvl",
+  "toolDescription": "Get historical TVL data of a protocl.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/historical_protocol_tvl/{slug}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "slug": "slug"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gethistoricalprotocoltvl/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gethistoricalprotocoltvl/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "slug": {
+      "description": "Used to filter protocols by their slug.",
+      "type": "string",
+      "example": "lido"
+    }
+  },
+  "required": [
+    "slug"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gethistoricalprotocoltvl/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gethistoricalprotocoltvl/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "slug": z.string().describe("Used to filter protocols by their slug.")
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getinteresting/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getinteresting/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinteresting",
+  "toolDescription": "Returns interesting/important data on what is happening on-chain re protocols, chains and yields.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_interesting",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getinteresting/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getinteresting/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "time_period": {
+      "description": "The time period for which to retrieve data. Can be day or week.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week"
+      ],
+      "default": "week"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getinteresting/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getinteresting/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "time_period": z.enum(["day","week"]).describe("The time period for which to retrieve data. Can be day or week.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getnetbridgeflow/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getnetbridgeflow/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getnetbridgeflow",
+  "toolDescription": "Get the net bridge flow for a specific chain or L2 over a given time period.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_net_bridge_flow",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "chain": "chain",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getnetbridgeflow/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getnetbridgeflow/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "chain": {
+      "description": "Name of the chain or L2 to retrieve net bridge flow for.",
+      "type": "string",
+      "example": "ethereum"
+    },
+    "time_period": {
+      "description": "Time period for net bridge flow calculation. Can be day, week or month.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "default": "month"
+    }
+  },
+  "required": [
+    "chain"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getnetbridgeflow/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getnetbridgeflow/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "chain": z.string().describe("Name of the chain or L2 to retrieve net bridge flow for."),
+  "time_period": z.enum(["day","week","month"]).describe("Time period for net bridge flow calculation. Can be day, week or month.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocol/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocol/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprotocol",
+  "toolDescription": "Get descriptive information and current stats of a protocol.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/protocol/{slug}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "slug": "slug"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocol/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocol/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "slug": {
+      "description": "Used to filter protocols by their slug.",
+      "type": "string",
+      "example": "lido"
+    }
+  },
+  "required": [
+    "slug"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocol/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocol/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "slug": z.string().describe("Used to filter protocols by their slug.")
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolfees/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolfees/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprotocolfees",
+  "toolDescription": "Get the fees earned by a protocol",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_protocol_fees",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "defillamaId": "defillamaId",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolfees/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolfees/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "defillamaId": {
+      "description": "The DefiLlamaID of the protocol",
+      "type": "string"
+    },
+    "time_period": {
+      "description": "The time period in which the fees were collected. Can be 'day', 'week', or 'month'. Defaults to 'month'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ]
+    }
+  },
+  "required": [
+    "defillamaId"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolfees/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolfees/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "defillamaId": z.string().describe("The DefiLlamaID of the protocol"),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the fees were collected. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolrevenue/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolrevenue/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprotocolrevenue",
+  "toolDescription": "Get the revenue earned by a protocol",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_protocol_revenue",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "defillamaId": "defillamaId",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolrevenue/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolrevenue/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "defillamaId": {
+      "description": "The DefiLlamaID of the protocol",
+      "type": "string"
+    },
+    "time_period": {
+      "description": "The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ]
+    }
+  },
+  "required": [
+    "defillamaId"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolrevenue/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocolrevenue/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "defillamaId": z.string().describe("The DefiLlamaID of the protocol"),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocoltvl/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocoltvl/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprotocoltvl",
+  "toolDescription": "Get the current TVL of a protocol.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/tvl/{slug}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "slug": "slug"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocoltvl/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocoltvl/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "slug": {
+      "description": "Used to filter protocols by their slug.",
+      "type": "string",
+      "example": "uniswap"
+    }
+  },
+  "required": [
+    "slug"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getprotocoltvl/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getprotocoltvl/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "slug": z.string().describe("Used to filter protocols by their slug.")
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getslug/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getslug/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getslug",
+  "toolDescription": "Get the slug most similar to the given text.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_slug",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "text": "text"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getslug/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getslug/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "description": "The text to match against the available slugs.",
+      "type": "string",
+      "example": "uniswap"
+    }
+  },
+  "required": [
+    "text"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/getslug/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/getslug/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "text": z.string().describe("The text to match against the available slugs.")
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingainers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingainers/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopchaingainers",
+  "toolDescription": "Get the chains that have gained the most TVL.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_chain_gainers",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_chains": "num_chains",
+      "min_tvl": "min_tvl",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingainers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingainers/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "num_chains": {
+      "description": "The number of top gainers you want to see. Defaults to 5.",
+      "type": "integer",
+      "example": 5
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a chain should have to be included. Defaults to 10000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "example": "week"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingainers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingainers/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_chains": z.number().int().describe("The number of top gainers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingrowers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingrowers/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopchaingrowers",
+  "toolDescription": "Get the chains that have the highest percentage growth in TVL",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_chain_growers",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_chains": "num_chains",
+      "min_tvl": "min_tvl",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingrowers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingrowers/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "num_chains": {
+      "description": "The number of top gainers you want to see. Defaults to 5.",
+      "type": "integer",
+      "example": 5
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a chain should have to be included. Defaults to 10000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "example": "week"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingrowers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchaingrowers/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_chains": z.number().int().describe("The number of top gainers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainlosers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainlosers/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopchainlosers",
+  "toolDescription": "Get the chains that have lost the most TVL.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_chain_losers",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_chains": "num_chains",
+      "min_tvl": "min_tvl",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainlosers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainlosers/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "num_chains": {
+      "description": "The number of top losers you want to see. Defaults to 5.",
+      "type": "integer",
+      "example": 5
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a chain should have to be included. Defaults to 10000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "example": "week"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainlosers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainlosers/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_chains": z.number().int().describe("The number of top losers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainshrinkers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainshrinkers/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopchainshrinkers",
+  "toolDescription": "Get the chains that the highest percentage loss in TVL.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_chain_shrinkers",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_chains": "num_chains",
+      "min_tvl": "min_tvl",
+      "time_period": "time_period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainshrinkers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainshrinkers/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "num_chains": {
+      "description": "The number of top losers you want to see. Defaults to 5.",
+      "type": "integer",
+      "example": 5
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a chain should have to be included. Defaults to 10000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ],
+      "example": "week"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainshrinkers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopchainshrinkers/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_chains": z.number().int().describe("The number of top losers you want to see. Defaults to 5.").optional(),
+  "min_tvl": z.number().describe("The minimum TVL that a chain should have to be included. Defaults to 10000.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the change occurred. Can be 'day', 'week', or 'month'. Defaults to 'week'.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopdexvolume/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopdexvolume/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopdexvolume",
+  "toolDescription": "Get the dexes with the highest trading volume.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_dex_volume",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_protocols": "num_protocols",
+      "time_period": "time_period",
+      "chain": "chain"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopdexvolume/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopdexvolume/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top protocols to return. Default to 10.",
+      "type": "integer"
+    },
+    "time_period": {
+      "description": "The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ]
+    },
+    "chain": {
+      "description": "Name of the blockchain or L2 to filter protocol revenue by.",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopdexvolume/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopdexvolume/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top protocols to return. Default to 10.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional(),
+  "chain": z.string().describe("Name of the blockchain or L2 to filter protocol revenue by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopgainers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopgainers/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopgainers",
+  "toolDescription": "Get the protocols that gained the most TVL.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_gainers/{num_protocols}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "num_protocols": "num_protocols"
+    },
+    "query": {
+      "min_tvl": "min_tvl",
+      "time_period": "time_period",
+      "category": "category",
+      "chain": "chain"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopgainers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopgainers/schema-json/root.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top gainers you want to see. Default to 10.",
+      "type": "integer",
+      "example": 10
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a protocol should have to be included. Defaults to 100000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "hour",
+        "day",
+        "week"
+      ],
+      "example": "day"
+    },
+    "category": {
+      "description": "Category to filter protocols by.",
+      "type": "string",
+      "enum": [
+        "liquid staking",
+        "dexes",
+        "lending",
+        "bridge",
+        "CDP",
+        "yield",
+        "services",
+        "derivatives",
+        "yield aggregator",
+        "cross chain",
+        "launchpad",
+        "indexes",
+        "synthetics",
+        "RWA",
+        "liquidity manager",
+        "nft lending",
+        "insurance",
+        "algo-stables",
+        "privacy",
+        "payments",
+        "leveraged farming",
+        "nft marketplace",
+        "options",
+        "options vault",
+        "staking pool",
+        "prediction market",
+        "farm",
+        "uncollateralized lending",
+        "reserve currency",
+        "RWA lending",
+        "gaming",
+        "oracle"
+      ],
+      "example": "liquid staking"
+    },
+    "chain": {
+      "description": "Name of the chain or L2 to filter protocols by.",
+      "type": "string",
+      "example": "ethereum"
+    }
+  },
+  "required": [
+    "num_protocols"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopgainers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopgainers/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopgrowers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopgrowers/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopgrowers",
+  "toolDescription": "Get the protocols that had the highest percentage growth in TVL.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_growers/{num_protocols}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "num_protocols": "num_protocols"
+    },
+    "query": {
+      "min_tvl": "min_tvl",
+      "time_period": "time_period",
+      "category": "category",
+      "chain": "chain"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopgrowers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopgrowers/schema-json/root.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top gainers you want to see. Default to 10.",
+      "type": "integer",
+      "example": 10
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a protocol should have to be included. Defaults to 100000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "hour",
+        "day",
+        "week"
+      ],
+      "example": "day"
+    },
+    "category": {
+      "description": "Category to filter protocols by.",
+      "type": "string",
+      "enum": [
+        "liquid staking",
+        "dexes",
+        "lending",
+        "bridge",
+        "CDP",
+        "yield",
+        "services",
+        "derivatives",
+        "yield aggregator",
+        "cross chain",
+        "launchpad",
+        "indexes",
+        "synthetics",
+        "RWA",
+        "liquidity manager",
+        "nft lending",
+        "insurance",
+        "algo-stables",
+        "privacy",
+        "payments",
+        "leveraged farming",
+        "nft marketplace",
+        "options",
+        "options vault",
+        "staking pool",
+        "prediction market",
+        "farm",
+        "uncollateralized lending",
+        "reserve currency",
+        "RWA lending",
+        "gaming",
+        "oracle"
+      ],
+      "example": "liquid staking"
+    },
+    "chain": {
+      "description": "Name of the chain or L2 to filter protocols by.",
+      "type": "string",
+      "example": "ethereum"
+    }
+  },
+  "required": [
+    "num_protocols"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopgrowers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopgrowers/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettoplosers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettoplosers/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettoplosers",
+  "toolDescription": "Get the protocols that lost the most TVl.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_losers/{num_protocols}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "num_protocols": "num_protocols"
+    },
+    "query": {
+      "min_tvl": "min_tvl",
+      "time_period": "time_period",
+      "category": "category",
+      "chain": "chain"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettoplosers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettoplosers/schema-json/root.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top gainers you want to see. Default to 10.",
+      "type": "integer",
+      "example": 10
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a protocol should have to be included. Defaults to 100000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "hour",
+        "day",
+        "week"
+      ],
+      "example": "day"
+    },
+    "category": {
+      "description": "Category to filter protocols by.",
+      "type": "string",
+      "enum": [
+        "liquid staking",
+        "dexes",
+        "lending",
+        "bridge",
+        "CDP",
+        "yield",
+        "services",
+        "derivatives",
+        "yield aggregator",
+        "cross chain",
+        "launchpad",
+        "indexes",
+        "synthetics",
+        "RWA",
+        "liquidity manager",
+        "nft lending",
+        "insurance",
+        "algo-stables",
+        "privacy",
+        "payments",
+        "leveraged farming",
+        "nft marketplace",
+        "options",
+        "options vault",
+        "staking pool",
+        "prediction market",
+        "farm",
+        "uncollateralized lending",
+        "reserve currency",
+        "RWA lending",
+        "gaming",
+        "oracle"
+      ],
+      "example": "liquid staking"
+    },
+    "chain": {
+      "description": "Name of the chain or L2 to filter protocols by.",
+      "type": "string",
+      "example": "ethereum"
+    }
+  },
+  "required": [
+    "num_protocols"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettoplosers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettoplosers/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolfees/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolfees/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopprotocolfees",
+  "toolDescription": "Get the protocols that have earned the most fees.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_protocol_fees",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_protocols": "num_protocols",
+      "time_period": "time_period",
+      "chain": "chain",
+      "category": "category"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolfees/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolfees/schema-json/root.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top protocols to return. Default to 10.",
+      "type": "integer"
+    },
+    "time_period": {
+      "description": "The time period in which the fees were collected. Can be 'day', 'week', or 'month'. Defaults to 'month'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ]
+    },
+    "chain": {
+      "description": "Name of the blockchain or L2 to filter protocol fees by.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Category to filter protocols by.",
+      "type": "string",
+      "enum": [
+        "liquid staking",
+        "dexes",
+        "lending",
+        "bridge",
+        "CDP",
+        "yield",
+        "services",
+        "derivatives",
+        "yield aggregator",
+        "cross chain",
+        "launchpad",
+        "indexes",
+        "synthetics",
+        "RWA",
+        "liquidity manager",
+        "nft lending",
+        "insurance",
+        "algo-stables",
+        "privacy",
+        "payments",
+        "leveraged farming",
+        "nft marketplace",
+        "options",
+        "options vault",
+        "staking pool",
+        "prediction market",
+        "farm",
+        "uncollateralized lending",
+        "reserve currency",
+        "RWA lending",
+        "gaming",
+        "oracle"
+      ],
+      "example": "liquid staking"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolfees/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolfees/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top protocols to return. Default to 10.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the fees were collected. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional(),
+  "chain": z.string().describe("Name of the blockchain or L2 to filter protocol fees by.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolrevenue/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolrevenue/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopprotocolrevenue",
+  "toolDescription": "Get the protocols that have earned the most revenue.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_protocol_revenue",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_protocols": "num_protocols",
+      "time_period": "time_period",
+      "chain": "chain",
+      "category": "category"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolrevenue/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolrevenue/schema-json/root.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top protocols to return. Default to 10.",
+      "type": "integer"
+    },
+    "time_period": {
+      "description": "The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.",
+      "type": "string",
+      "enum": [
+        "day",
+        "week",
+        "month"
+      ]
+    },
+    "chain": {
+      "description": "Name of the blockchain or L2 to filter protocol revenue by.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Category to filter protocols by.",
+      "type": "string",
+      "enum": [
+        "liquid staking",
+        "dexes",
+        "lending",
+        "bridge",
+        "CDP",
+        "yield",
+        "services",
+        "derivatives",
+        "yield aggregator",
+        "cross chain",
+        "launchpad",
+        "indexes",
+        "synthetics",
+        "RWA",
+        "liquidity manager",
+        "nft lending",
+        "insurance",
+        "algo-stables",
+        "privacy",
+        "payments",
+        "leveraged farming",
+        "nft marketplace",
+        "options",
+        "options vault",
+        "staking pool",
+        "prediction market",
+        "farm",
+        "uncollateralized lending",
+        "reserve currency",
+        "RWA lending",
+        "gaming",
+        "oracle"
+      ],
+      "example": "liquid staking"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolrevenue/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopprotocolrevenue/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top protocols to return. Default to 10.").optional(),
+  "time_period": z.enum(["day","week","month"]).describe("The time period in which the revenue was earned. Can be 'day', 'week', or 'month'. Defaults to 'month'.").optional(),
+  "chain": z.string().describe("Name of the blockchain or L2 to filter protocol revenue by.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopshrinkers/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopshrinkers/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopshrinkers",
+  "toolDescription": "Get the protocols that had the highest percentage loss in terms of TVl.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/top_shrinkers/{num_protocols}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "num_protocols": "num_protocols"
+    },
+    "query": {
+      "min_tvl": "min_tvl",
+      "time_period": "time_period",
+      "category": "category",
+      "chain": "chain"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopshrinkers/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopshrinkers/schema-json/root.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "num_protocols": {
+      "description": "The number of top gainers you want to see. Default to 10.",
+      "type": "integer",
+      "example": 10
+    },
+    "min_tvl": {
+      "description": "The minimum TVL that a protocol should have to be included. Defaults to 100000.",
+      "type": "number",
+      "format": "float",
+      "example": 1000000
+    },
+    "time_period": {
+      "description": "The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.",
+      "type": "string",
+      "enum": [
+        "hour",
+        "day",
+        "week"
+      ],
+      "example": "day"
+    },
+    "category": {
+      "description": "Category to filter protocols by.",
+      "type": "string",
+      "enum": [
+        "liquid staking",
+        "dexes",
+        "lending",
+        "bridge",
+        "CDP",
+        "yield",
+        "services",
+        "derivatives",
+        "yield aggregator",
+        "cross chain",
+        "launchpad",
+        "indexes",
+        "synthetics",
+        "RWA",
+        "liquidity manager",
+        "nft lending",
+        "insurance",
+        "algo-stables",
+        "privacy",
+        "payments",
+        "leveraged farming",
+        "nft marketplace",
+        "options",
+        "options vault",
+        "staking pool",
+        "prediction market",
+        "farm",
+        "uncollateralized lending",
+        "reserve currency",
+        "RWA lending",
+        "gaming",
+        "oracle"
+      ],
+      "example": "liquid staking"
+    },
+    "chain": {
+      "description": "Name of the chain or L2 to filter protocols by.",
+      "type": "string",
+      "example": "ethereum"
+    }
+  },
+  "required": [
+    "num_protocols"
+  ]
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopshrinkers/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopshrinkers/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_protocols": z.number().int().describe("The number of top gainers you want to see. Default to 10."),
+  "min_tvl": z.number().describe("The minimum TVL that a protocol should have to be included. Defaults to 100000.").optional(),
+  "time_period": z.enum(["hour","day","week"]).describe("The time period in which the change occured. Can be 'hour', 'day', or 'week'. Defaults to 'week'.").optional(),
+  "category": z.enum(["liquid staking","dexes","lending","bridge","CDP","yield","services","derivatives","yield aggregator","cross chain","launchpad","indexes","synthetics","RWA","liquidity manager","nft lending","insurance","algo-stables","privacy","payments","leveraged farming","nft marketplace","options","options vault","staking pool","prediction market","farm","uncollateralized lending","reserve currency","RWA lending","gaming","oracle"]).describe("Category to filter protocols by.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter protocols by.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopyields/index.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopyields/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettopyields",
+  "toolDescription": "Get the top yielding pools.",
+  "baseUrl": "https://llamawrapper-prod.onrender.com",
+  "path": "/get_top_yields",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "num_pools": "num_pools",
+      "chain": "chain",
+      "stablecoin": "stablecoin",
+      "token": "token",
+      "single_sided": "single_sided",
+      "outlook": "outlook"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopyields/schema-json/root.json
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopyields/schema-json/root.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "num_pools": {
+      "description": "Number of pools to retrieve. Default is 10.",
+      "type": "integer",
+      "minimum": 1,
+      "default": 10
+    },
+    "chain": {
+      "description": "Name of the chain or L2 to filter pools by.",
+      "type": "string",
+      "example": "ethereum"
+    },
+    "stablecoin": {
+      "description": "Flag indicating whether to filter for stablecoin yield pools.",
+      "type": "boolean"
+    },
+    "token": {
+      "description": "Token or token pair to filter pools by.",
+      "type": "string"
+    },
+    "single_sided": {
+      "description": "Flag indicating whether to filter for single-sided yield pools.",
+      "type": "boolean"
+    },
+    "outlook": {
+      "description": "Future outlook for the yield of this pool.",
+      "type": "string",
+      "enum": [
+        "stable",
+        "up",
+        "down"
+      ],
+      "example": "up"
+    }
+  },
+  "required": []
+}

--- a/servers/llamawrapper_prod_onrender_com/src/tools/gettopyields/schema/root.ts
+++ b/servers/llamawrapper_prod_onrender_com/src/tools/gettopyields/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "num_pools": z.number().int().gte(1).describe("Number of pools to retrieve. Default is 10.").optional(),
+  "chain": z.string().describe("Name of the chain or L2 to filter pools by.").optional(),
+  "stablecoin": z.boolean().describe("Flag indicating whether to filter for stablecoin yield pools.").optional(),
+  "token": z.string().describe("Token or token pair to filter pools by.").optional(),
+  "single_sided": z.boolean().describe("Flag indicating whether to filter for single-sided yield pools.").optional(),
+  "outlook": z.enum(["stable","up","down"]).describe("Future outlook for the yield of this pool.").optional()
+}

--- a/servers/llamawrapper_prod_onrender_com/tsconfig.json
+++ b/servers/llamawrapper_prod_onrender_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `llamawrapper_prod_onrender_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/llamawrapper_prod_onrender_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "llamawrapper_prod_onrender_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/llamawrapper_prod_onrender_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.