### PR TITLE
Add MCP server `api_val_town`

### DIFF
--- a/servers/api_val_town/.npmignore
+++ b/servers/api_val_town/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_val_town/README.md
+++ b/servers/api_val_town/README.md
@@ -1,0 +1,535 @@
+# @open-mcp/api_val_town
+
+## Installing
+
+First set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_val_town \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_val_town \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_val_town \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_val_town": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_val_town"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Customizing the base URL
+
+Set the environment variable `OPEN_MCP_BASE_URL` to override each tool's base URL. This is useful if your OpenAPI spec defines a relative server URL.
+
+## Other environment variables
+
+- `API_KEY`
+
+## Inspector
+
+Needs access to port 3000 for running a proxy server, will fail if http://localhost:3000 is already busy.
+
+```bash
+npx -y @modelcontextprotocol/inspector npx -y @open-mcp/api_val_town
+```
+
+- Open http://localhost:5173
+- Transport type: `STDIO`
+- Command: `npx`
+- Arguments: `-y @open-mcp/api_val_town`
+- Click `Environment Variables` to add
+- Click `Connect`
+
+It should say _MCP Server running on stdio_ in red.
+
+- Click `List Tools`
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+```ts
+{
+  toolName: z.string(),
+  jsonPointers: z.array(z.string().startsWith("/").describe("The pointer to the JSON schema object which needs expanding")).describe("A list of JSON pointers"),
+}
+```
+
+### searchvals
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response"),
+  "query": z.string().min(1).max(256).describe("Search query")
+}
+```
+
+### aliasusername
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("Username of the user who you are looking for")
+}
+```
+
+### meget
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{}
+```
+
+### blobslist
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "prefix": z.string().describe("If specified, only include blobs that start with this string").optional()
+}
+```
+
+### blobsget
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "key": z.string().min(1).max(512).describe("Key that uniquely identifies this blob")
+}
+```
+
+### blobsstore
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "key": z.string().min(1).max(512).describe("Key that uniquely identifies this blob")
+}
+```
+
+### blobsdelete
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "key": z.string().min(1).max(512).describe("Key that uniquely identifies this blob")
+}
+```
+
+### usersget
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "user_id": z.string().uuid().describe("User Id")
+}
+```
+
+### sqliteexecute
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "statement": z.union([z.string().describe("Simple SQL statement to run in SQLite"), z.object({ "sql": z.string().describe("SQL statement, with ? placeholders for arguments"), "args": z.union([z.array(z.any().describe("A value to be used as a parameter")), z.record(z.any().describe("A value to be used as a parameter"))]).describe("List of arguments to be used in the given statement") }).describe("A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference")])
+}
+```
+
+### sqlitebatch
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "statements": z.array(z.union([z.string().describe("Simple SQL statement to run in SQLite"), z.object({ "sql": z.string().describe("SQL statement, with ? placeholders for arguments"), "args": z.union([z.array(z.any().describe("A value to be used as a parameter")), z.record(z.any().describe("A value to be used as a parameter"))]).describe("List of arguments to be used in the given statement") }).describe("A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference")])),
+  "mode": z.enum(["write","read","deferred"]).optional()
+}
+```
+
+### runget
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "valname": z.string().regex(new RegExp("^[^.]+.[^.]+$")).describe("Name of the val, in concatenated style, like username.valname"),
+  "args": z.string().describe("An argument that will be passed to the function as a JavaScript value").optional()
+}
+```
+
+### runpost
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "valname": z.string().regex(new RegExp("^[^.]+.[^.]+$")).describe("Name of the val, in concatenated style, like username.valname"),
+  "args": z.array(z.any()).optional()
+}
+```
+
+### emailssend
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "subject": z.string().describe("The subject line of the email").optional(),
+  "from": z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]).optional(),
+  "headers": z.record(z.any()).describe("[EXPANDABLE PARAMETER]:\nA set of headers to include the email that you send").optional(),
+  "to": z.union([z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]), z.array(z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]))]).describe("A single email or list of emails for one of the address fields").optional(),
+  "cc": z.union([z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]), z.array(z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]))]).describe("A single email or list of emails for one of the address fields").optional(),
+  "bcc": z.union([z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]), z.array(z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]))]).describe("A single email or list of emails for one of the address fields").optional(),
+  "text": z.string().describe("Text content of the email, for email clients that may not support HTML").optional(),
+  "html": z.string().describe("HTML content of the email. Can be specified alongside text").optional(),
+  "attachments": z.array(z.object({ "content": z.string(), "filename": z.string(), "type": z.string().optional(), "disposition": z.string().optional(), "contentId": z.string().optional() })).describe("A list of attachments to add to the email").optional(),
+  "replyToList": z.union([z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name"), z.array(z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name"))]).describe("A reply-to list of email addresses").optional()
+}
+```
+
+### valsget2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val")
+}
+```
+
+### projectsdelete2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val")
+}
+```
+
+### valslist2
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}
+```
+
+### valscreate2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "name": z.string().regex(new RegExp("^[a-zA-Z][a-zA-Z0-9\\-_]*$")).min(1).max(48),
+  "description": z.string().max(64).optional(),
+  "privacy": z.enum(["public","unlisted","private"])
+}
+```
+
+### branchesget2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("Id of a branch")
+}
+```
+
+### branchesdelete2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("Id of a branch")
+}
+```
+
+### brancheslist2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}
+```
+
+### branchescreate2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "name": z.string().regex(new RegExp("^[a-zA-Z0-9\\-_.]+$")).min(1).max(48),
+  "branchId": z.string().uuid().describe("The branch ID to fork from. If this is not specified, the new branch will be forked from main.").optional()
+}
+```
+
+### valfilesget2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "version": z.number().int().gte(0).describe("Specific branch version to query").optional(),
+  "branch_id": z.string().uuid().describe("Id to query").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "recursive": z.boolean().describe("Whether to recursively act on all files in the project"),
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}
+```
+
+### filescreate2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("The specified branch of the resource. Defaults to main if not provided.").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.")
+}
+```
+
+### filesdelete2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("The specified branch of the resource. Defaults to main if not provided.").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "recursive": z.boolean().describe("Whether to recursively act on all files in the project")
+}
+```
+
+### filecontentupdate2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("The specified branch of the resource. Defaults to main if not provided.").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "content": z.string().min(0).max(80000).describe("File and val content. An empty string will create an empty file. When creating a directory, the content should be null or undefined.").optional(),
+  "type": z.enum(["file","interval","http","email","script"]).optional(),
+  "parent_path": z.union([z.string().describe("Path to the directory you'd like to move this file to (e.g. 'folder1/folder2')"), z.null()]).optional(),
+  "name": z.string().regex(new RegExp("^[a-zA-Z0-9\\-_.]+$")).min(1).max(48).optional()
+}
+```
+
+### filescontentget2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "version": z.number().int().gte(0).describe("Specific branch version to query").optional(),
+  "branch_id": z.string().uuid().describe("Id to query").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "If-Match": z.string().optional(),
+  "If-Unmodified-Since": z.string().optional(),
+  "If-None-Match": z.string().optional(),
+  "If-Modified-Since": z.string().optional(),
+  "Cache-Control": z.string().optional()
+}
+```
+
+### aliasval2
+
+**Environment variables**
+
+
+
+**Input schema**
+
+```ts
+{
+  "username": z.string().describe("Username of the user whose val you are looking for"),
+  "val_name": z.string().describe("Name of the val you’re looking for")
+}
+```
+
+### mevals2
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+```ts
+{
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}
+```

--- a/servers/api_val_town/package.json
+++ b/servers/api_val_town/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_val_town",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_val_town": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_val_town/src/constants.ts
+++ b/servers/api_val_town/src/constants.ts
@@ -1,0 +1,33 @@
+export const OPENAPI_URL = "https://api.val.town/openapi.json"
+export const SERVER_NAME = "api_val_town"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/searchvals/index.js",
+  "./tools/aliasusername/index.js",
+  "./tools/meget/index.js",
+  "./tools/blobslist/index.js",
+  "./tools/blobsget/index.js",
+  "./tools/blobsstore/index.js",
+  "./tools/blobsdelete/index.js",
+  "./tools/usersget/index.js",
+  "./tools/sqliteexecute/index.js",
+  "./tools/sqlitebatch/index.js",
+  "./tools/runget/index.js",
+  "./tools/runpost/index.js",
+  "./tools/emailssend/index.js",
+  "./tools/valsget2/index.js",
+  "./tools/projectsdelete2/index.js",
+  "./tools/valslist2/index.js",
+  "./tools/valscreate2/index.js",
+  "./tools/branchesget2/index.js",
+  "./tools/branchesdelete2/index.js",
+  "./tools/brancheslist2/index.js",
+  "./tools/branchescreate2/index.js",
+  "./tools/valfilesget2/index.js",
+  "./tools/filescreate2/index.js",
+  "./tools/filesdelete2/index.js",
+  "./tools/filecontentupdate2/index.js",
+  "./tools/filescontentget2/index.js",
+  "./tools/aliasval2/index.js",
+  "./tools/mevals2/index.js"
+]

--- a/servers/api_val_town/src/index.ts
+++ b/servers/api_val_town/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_val_town/src/server.ts
+++ b/servers/api_val_town/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_val_town/src/tools/aliasusername/index.ts
+++ b/servers/api_val_town/src/tools/aliasusername/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "aliasusername",
+  "toolDescription": "Get basic details about a user, given their username",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/alias/{username}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "username": "username"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/aliasusername/schema-json/root.json
+++ b/servers/api_val_town/src/tools/aliasusername/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "Username of the user who you are looking for",
+      "type": "string"
+    }
+  },
+  "required": [
+    "username"
+  ]
+}

--- a/servers/api_val_town/src/tools/aliasusername/schema/root.ts
+++ b/servers/api_val_town/src/tools/aliasusername/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("Username of the user who you are looking for")
+}

--- a/servers/api_val_town/src/tools/aliasval2/index.ts
+++ b/servers/api_val_town/src/tools/aliasval2/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "aliasval2",
+  "toolDescription": "Get a val",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/alias/vals/{username}/{val_name}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "username": "username",
+      "val_name": "val_name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/aliasval2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/aliasval2/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "Username of the user whose val you are looking for",
+      "type": "string"
+    },
+    "val_name": {
+      "description": "Name of the val you’re looking for",
+      "type": "string"
+    }
+  },
+  "required": [
+    "username",
+    "val_name"
+  ]
+}

--- a/servers/api_val_town/src/tools/aliasval2/schema/root.ts
+++ b/servers/api_val_town/src/tools/aliasval2/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("Username of the user whose val you are looking for"),
+  "val_name": z.string().describe("Name of the val you’re looking for")
+}

--- a/servers/api_val_town/src/tools/blobsdelete/index.ts
+++ b/servers/api_val_town/src/tools/blobsdelete/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "blobsdelete",
+  "toolDescription": "Delete a blob",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/blob/{key}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "key": "key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/blobsdelete/schema-json/root.json
+++ b/servers/api_val_town/src/tools/blobsdelete/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "description": "Key that uniquely identifies this blob",
+      "minLength": 1,
+      "maxLength": 512,
+      "type": "string"
+    }
+  },
+  "required": [
+    "key"
+  ]
+}

--- a/servers/api_val_town/src/tools/blobsdelete/schema/root.ts
+++ b/servers/api_val_town/src/tools/blobsdelete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key": z.string().min(1).max(512).describe("Key that uniquely identifies this blob")
+}

--- a/servers/api_val_town/src/tools/blobsget/index.ts
+++ b/servers/api_val_town/src/tools/blobsget/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "blobsget",
+  "toolDescription": "Get a blob’s contents.",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/blob/{key}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "key": "key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/blobsget/schema-json/root.json
+++ b/servers/api_val_town/src/tools/blobsget/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "description": "Key that uniquely identifies this blob",
+      "minLength": 1,
+      "maxLength": 512,
+      "type": "string"
+    }
+  },
+  "required": [
+    "key"
+  ]
+}

--- a/servers/api_val_town/src/tools/blobsget/schema/root.ts
+++ b/servers/api_val_town/src/tools/blobsget/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key": z.string().min(1).max(512).describe("Key that uniquely identifies this blob")
+}

--- a/servers/api_val_town/src/tools/blobslist/index.ts
+++ b/servers/api_val_town/src/tools/blobslist/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "blobslist",
+  "toolDescription": "List blobs in your account",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/blob",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "prefix": "prefix"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/blobslist/schema-json/root.json
+++ b/servers/api_val_town/src/tools/blobslist/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "prefix": {
+      "description": "If specified, only include blobs that start with this string",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_val_town/src/tools/blobslist/schema/root.ts
+++ b/servers/api_val_town/src/tools/blobslist/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prefix": z.string().describe("If specified, only include blobs that start with this string").optional()
+}

--- a/servers/api_val_town/src/tools/blobsstore/index.ts
+++ b/servers/api_val_town/src/tools/blobsstore/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "blobsstore",
+  "toolDescription": "Store data in blob storage",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/blob/{key}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "key": "key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/blobsstore/schema-json/root.json
+++ b/servers/api_val_town/src/tools/blobsstore/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "description": "Key that uniquely identifies this blob",
+      "minLength": 1,
+      "maxLength": 512,
+      "type": "string"
+    }
+  },
+  "required": [
+    "key"
+  ]
+}

--- a/servers/api_val_town/src/tools/blobsstore/schema/root.ts
+++ b/servers/api_val_town/src/tools/blobsstore/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key": z.string().min(1).max(512).describe("Key that uniquely identifies this blob")
+}

--- a/servers/api_val_town/src/tools/branchescreate2/index.ts
+++ b/servers/api_val_town/src/tools/branchescreate2/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "branchescreate2",
+  "toolDescription": "Create a new branch",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/branches",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "body": {
+      "name": "name",
+      "branchId": "branchId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/branchescreate2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/branchescreate2/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "name": {
+      "minLength": 1,
+      "maxLength": 48,
+      "pattern": "^[a-zA-Z0-9\\-_.]+$",
+      "type": "string"
+    },
+    "branchId": {
+      "format": "uuid",
+      "description": "The branch ID to fork from. If this is not specified, the new branch will be forked from main.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id",
+    "name"
+  ]
+}

--- a/servers/api_val_town/src/tools/branchescreate2/schema/root.ts
+++ b/servers/api_val_town/src/tools/branchescreate2/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "name": z.string().regex(new RegExp("^[a-zA-Z0-9\\-_.]+$")).min(1).max(48),
+  "branchId": z.string().uuid().describe("The branch ID to fork from. If this is not specified, the new branch will be forked from main.").optional()
+}

--- a/servers/api_val_town/src/tools/branchesdelete2/index.ts
+++ b/servers/api_val_town/src/tools/branchesdelete2/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "branchesdelete2",
+  "toolDescription": "Delete a branch",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/branches/{branch_id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id",
+      "branch_id": "branch_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/branchesdelete2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/branchesdelete2/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "branch_id": {
+      "description": "Id of a branch",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id",
+    "branch_id"
+  ]
+}

--- a/servers/api_val_town/src/tools/branchesdelete2/schema/root.ts
+++ b/servers/api_val_town/src/tools/branchesdelete2/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("Id of a branch")
+}

--- a/servers/api_val_town/src/tools/branchesget2/index.ts
+++ b/servers/api_val_town/src/tools/branchesget2/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "branchesget2",
+  "toolDescription": "Get a branch by id",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/branches/{branch_id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id",
+      "branch_id": "branch_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/branchesget2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/branchesget2/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "branch_id": {
+      "description": "Id of a branch",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id",
+    "branch_id"
+  ]
+}

--- a/servers/api_val_town/src/tools/branchesget2/schema/root.ts
+++ b/servers/api_val_town/src/tools/branchesget2/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("Id of a branch")
+}

--- a/servers/api_val_town/src/tools/brancheslist2/index.ts
+++ b/servers/api_val_town/src/tools/brancheslist2/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "brancheslist2",
+  "toolDescription": "List all branches for a val",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/branches",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "query": {
+      "offset": "offset",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/brancheslist2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/brancheslist2/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "offset": {
+      "description": "Number of items to skip in order to deliver paginated results",
+      "minimum": 0,
+      "default": 0,
+      "type": "integer"
+    },
+    "limit": {
+      "description": "Maximum items to return in each paginated response",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "val_id",
+    "offset",
+    "limit"
+  ]
+}

--- a/servers/api_val_town/src/tools/brancheslist2/schema/root.ts
+++ b/servers/api_val_town/src/tools/brancheslist2/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}

--- a/servers/api_val_town/src/tools/emailssend/index.ts
+++ b/servers/api_val_town/src/tools/emailssend/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "emailssend",
+  "toolDescription": "Send emails",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/email",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "subject": "subject",
+      "from": "from",
+      "headers": "headers",
+      "to": "to",
+      "cc": "cc",
+      "bcc": "bcc",
+      "text": "text",
+      "html": "html",
+      "attachments": "attachments",
+      "replyToList": "replyToList"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/emailssend/schema-json/properties/headers.json
+++ b/servers/api_val_town/src/tools/emailssend/schema-json/properties/headers.json
@@ -1,0 +1,8 @@
+{
+  "description": "A set of headers to include the email that you send",
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  },
+  "properties": {}
+}

--- a/servers/api_val_town/src/tools/emailssend/schema-json/root.json
+++ b/servers/api_val_town/src/tools/emailssend/schema-json/root.json
@@ -1,0 +1,292 @@
+{
+  "type": "object",
+  "properties": {
+    "subject": {
+      "description": "The subject line of the email",
+      "type": "string"
+    },
+    "from": {
+      "title": "EmailData",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "title": "EmailNameAndAddress",
+          "description": "An email address and name",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "email"
+          ]
+        }
+      ]
+    },
+    "headers": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `headers` to the tool, first call the tool `expandSchema` with \"/properties/headers\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>A set of headers to include the email that you send</property-description>",
+      "additionalProperties": true
+    },
+    "to": {
+      "title": "EmailDataInput",
+      "description": "A single email or list of emails for one of the address fields",
+      "anyOf": [
+        {
+          "title": "EmailData",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "title": "EmailNameAndAddress",
+              "description": "An email address and name",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "email"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "EmailDataList",
+          "type": "array",
+          "items": {
+            "title": "EmailData",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "title": "EmailNameAndAddress",
+                "description": "An email address and name",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "cc": {
+      "title": "EmailDataInput",
+      "description": "A single email or list of emails for one of the address fields",
+      "anyOf": [
+        {
+          "title": "EmailData",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "title": "EmailNameAndAddress",
+              "description": "An email address and name",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "email"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "EmailDataList",
+          "type": "array",
+          "items": {
+            "title": "EmailData",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "title": "EmailNameAndAddress",
+                "description": "An email address and name",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "bcc": {
+      "title": "EmailDataInput",
+      "description": "A single email or list of emails for one of the address fields",
+      "anyOf": [
+        {
+          "title": "EmailData",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "title": "EmailNameAndAddress",
+              "description": "An email address and name",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "email"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "EmailDataList",
+          "type": "array",
+          "items": {
+            "title": "EmailData",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "title": "EmailNameAndAddress",
+                "description": "An email address and name",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "text": {
+      "description": "Text content of the email, for email clients that may not support HTML",
+      "type": "string"
+    },
+    "html": {
+      "description": "HTML content of the email. Can be specified alongside text",
+      "type": "string"
+    },
+    "attachments": {
+      "description": "A list of attachments to add to the email",
+      "type": "array",
+      "items": {
+        "title": "AttachmentObject",
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "disposition": {
+            "type": "string"
+          },
+          "contentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "filename"
+        ]
+      }
+    },
+    "replyToList": {
+      "title": "ReplyToList",
+      "description": "A reply-to list of email addresses",
+      "anyOf": [
+        {
+          "title": "EmailNameAndAddress",
+          "description": "An email address and name",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "email"
+          ]
+        },
+        {
+          "title": "EmailList",
+          "type": "array",
+          "items": {
+            "title": "EmailNameAndAddress",
+            "description": "An email address and name",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "required": []
+}

--- a/servers/api_val_town/src/tools/emailssend/schema/properties/headers.ts
+++ b/servers/api_val_town/src/tools/emailssend/schema/properties/headers.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_val_town/src/tools/emailssend/schema/root.ts
+++ b/servers/api_val_town/src/tools/emailssend/schema/root.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "subject": z.string().describe("The subject line of the email").optional(),
+  "from": z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]).optional(),
+  "headers": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `headers` to the tool, first call the tool `expandSchema` with \"/properties/headers\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>A set of headers to include the email that you send</property-description>").optional(),
+  "to": z.union([z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]), z.array(z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]))]).describe("A single email or list of emails for one of the address fields").optional(),
+  "cc": z.union([z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]), z.array(z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]))]).describe("A single email or list of emails for one of the address fields").optional(),
+  "bcc": z.union([z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]), z.array(z.union([z.string(), z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name")]))]).describe("A single email or list of emails for one of the address fields").optional(),
+  "text": z.string().describe("Text content of the email, for email clients that may not support HTML").optional(),
+  "html": z.string().describe("HTML content of the email. Can be specified alongside text").optional(),
+  "attachments": z.array(z.object({ "content": z.string(), "filename": z.string(), "type": z.string().optional(), "disposition": z.string().optional(), "contentId": z.string().optional() })).describe("A list of attachments to add to the email").optional(),
+  "replyToList": z.union([z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name"), z.array(z.object({ "name": z.string().optional(), "email": z.string() }).describe("An email address and name"))]).describe("A reply-to list of email addresses").optional()
+}

--- a/servers/api_val_town/src/tools/filecontentupdate2/index.ts
+++ b/servers/api_val_town/src/tools/filecontentupdate2/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "filecontentupdate2",
+  "toolDescription": "Update a file's content",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/files",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "query": {
+      "branch_id": "branch_id",
+      "path": "path"
+    },
+    "body": {
+      "content": "content",
+      "type": "type",
+      "parent_path": "parent_path",
+      "name": "name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/filecontentupdate2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/filecontentupdate2/schema-json/root.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "branch_id": {
+      "description": "The specified branch of the resource. Defaults to main if not provided.",
+      "format": "uuid",
+      "type": "string"
+    },
+    "path": {
+      "description": "Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.",
+      "type": "string"
+    },
+    "content": {
+      "minLength": 0,
+      "maxLength": 80000,
+      "description": "File and val content. An empty string will create an empty file. When creating a directory, the content should be null or undefined.",
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "file",
+        "interval",
+        "http",
+        "email",
+        "script"
+      ]
+    },
+    "parent_path": {
+      "anyOf": [
+        {
+          "description": "Path to the directory you'd like to move this file to (e.g. 'folder1/folder2')",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "name": {
+      "minLength": 1,
+      "maxLength": 48,
+      "pattern": "^[a-zA-Z0-9\\-_.]+$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id",
+    "path"
+  ]
+}

--- a/servers/api_val_town/src/tools/filecontentupdate2/schema/root.ts
+++ b/servers/api_val_town/src/tools/filecontentupdate2/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("The specified branch of the resource. Defaults to main if not provided.").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "content": z.string().min(0).max(80000).describe("File and val content. An empty string will create an empty file. When creating a directory, the content should be null or undefined.").optional(),
+  "type": z.enum(["file","interval","http","email","script"]).optional(),
+  "parent_path": z.union([z.string().describe("Path to the directory you'd like to move this file to (e.g. 'folder1/folder2')"), z.null()]).optional(),
+  "name": z.string().regex(new RegExp("^[a-zA-Z0-9\\-_.]+$")).min(1).max(48).optional()
+}

--- a/servers/api_val_town/src/tools/filescontentget2/index.ts
+++ b/servers/api_val_town/src/tools/filescontentget2/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "filescontentget2",
+  "toolDescription": "Download file content",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/files/content",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "query": {
+      "version": "version",
+      "branch_id": "branch_id",
+      "path": "path"
+    },
+    "header": {
+      "If-Match": "If-Match",
+      "If-Unmodified-Since": "If-Unmodified-Since",
+      "If-None-Match": "If-None-Match",
+      "If-Modified-Since": "If-Modified-Since",
+      "Cache-Control": "Cache-Control"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/filescontentget2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/filescontentget2/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "version": {
+      "description": "Specific branch version to query",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "branch_id": {
+      "description": "Id to query",
+      "format": "uuid",
+      "type": "string"
+    },
+    "path": {
+      "description": "Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.",
+      "type": "string"
+    },
+    "If-Match": {
+      "type": "string"
+    },
+    "If-Unmodified-Since": {
+      "type": "string"
+    },
+    "If-None-Match": {
+      "type": "string"
+    },
+    "If-Modified-Since": {
+      "type": "string"
+    },
+    "Cache-Control": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id",
+    "path"
+  ]
+}

--- a/servers/api_val_town/src/tools/filescontentget2/schema/root.ts
+++ b/servers/api_val_town/src/tools/filescontentget2/schema/root.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "version": z.number().int().gte(0).describe("Specific branch version to query").optional(),
+  "branch_id": z.string().uuid().describe("Id to query").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "If-Match": z.string().optional(),
+  "If-Unmodified-Since": z.string().optional(),
+  "If-None-Match": z.string().optional(),
+  "If-Modified-Since": z.string().optional(),
+  "Cache-Control": z.string().optional()
+}

--- a/servers/api_val_town/src/tools/filescreate2/index.ts
+++ b/servers/api_val_town/src/tools/filescreate2/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "filescreate2",
+  "toolDescription": "Create a new file, project val or directory",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/files",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "query": {
+      "branch_id": "branch_id",
+      "path": "path"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/filescreate2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/filescreate2/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "branch_id": {
+      "description": "The specified branch of the resource. Defaults to main if not provided.",
+      "format": "uuid",
+      "type": "string"
+    },
+    "path": {
+      "description": "Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id",
+    "path"
+  ]
+}

--- a/servers/api_val_town/src/tools/filescreate2/schema/root.ts
+++ b/servers/api_val_town/src/tools/filescreate2/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("The specified branch of the resource. Defaults to main if not provided.").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.")
+}

--- a/servers/api_val_town/src/tools/filesdelete2/index.ts
+++ b/servers/api_val_town/src/tools/filesdelete2/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "filesdelete2",
+  "toolDescription": "Deletes a file or a directory. To delete a directory and all of its children, use the recursive flag. To delete all files, pass in an empty path and the recursive flag.",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/files",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "query": {
+      "branch_id": "branch_id",
+      "path": "path",
+      "recursive": "recursive"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/filesdelete2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/filesdelete2/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "branch_id": {
+      "description": "The specified branch of the resource. Defaults to main if not provided.",
+      "format": "uuid",
+      "type": "string"
+    },
+    "path": {
+      "description": "Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.",
+      "type": "string"
+    },
+    "recursive": {
+      "description": "Whether to recursively act on all files in the project",
+      "default": false,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "val_id",
+    "path",
+    "recursive"
+  ]
+}

--- a/servers/api_val_town/src/tools/filesdelete2/schema/root.ts
+++ b/servers/api_val_town/src/tools/filesdelete2/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "branch_id": z.string().uuid().describe("The specified branch of the resource. Defaults to main if not provided.").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "recursive": z.boolean().describe("Whether to recursively act on all files in the project")
+}

--- a/servers/api_val_town/src/tools/meget/index.ts
+++ b/servers/api_val_town/src/tools/meget/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "meget",
+  "toolDescription": "Get profile information for the current user",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/me",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/meget/schema-json/root.json
+++ b/servers/api_val_town/src/tools/meget/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_val_town/src/tools/meget/schema/root.ts
+++ b/servers/api_val_town/src/tools/meget/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_val_town/src/tools/mevals2/index.ts
+++ b/servers/api_val_town/src/tools/mevals2/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "mevals2",
+  "toolDescription": "[BETA] List all of a user's vals for authenticated users",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/me/vals",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "offset": "offset",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/mevals2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/mevals2/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "offset": {
+      "description": "Number of items to skip in order to deliver paginated results",
+      "minimum": 0,
+      "default": 0,
+      "type": "integer"
+    },
+    "limit": {
+      "description": "Maximum items to return in each paginated response",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "offset",
+    "limit"
+  ]
+}

--- a/servers/api_val_town/src/tools/mevals2/schema/root.ts
+++ b/servers/api_val_town/src/tools/mevals2/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}

--- a/servers/api_val_town/src/tools/projectsdelete2/index.ts
+++ b/servers/api_val_town/src/tools/projectsdelete2/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "projectsdelete2",
+  "toolDescription": "Delete a project",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/projectsdelete2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/projectsdelete2/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id"
+  ]
+}

--- a/servers/api_val_town/src/tools/projectsdelete2/schema/root.ts
+++ b/servers/api_val_town/src/tools/projectsdelete2/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val")
+}

--- a/servers/api_val_town/src/tools/runget/index.ts
+++ b/servers/api_val_town/src/tools/runget/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "runget",
+  "toolDescription": "Run a val, specify any parameters in a querystring",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/run/{valname}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "valname": "valname"
+    },
+    "query": {
+      "args": "args"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/runget/schema-json/root.json
+++ b/servers/api_val_town/src/tools/runget/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "valname": {
+      "description": "Name of the val, in concatenated style, like username.valname",
+      "pattern": "^[^.]+.[^.]+$",
+      "type": "string"
+    },
+    "args": {
+      "description": "An argument that will be passed to the function as a JavaScript value",
+      "type": "string"
+    }
+  },
+  "required": [
+    "valname"
+  ]
+}

--- a/servers/api_val_town/src/tools/runget/schema/root.ts
+++ b/servers/api_val_town/src/tools/runget/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "valname": z.string().regex(new RegExp("^[^.]+.[^.]+$")).describe("Name of the val, in concatenated style, like username.valname"),
+  "args": z.string().describe("An argument that will be passed to the function as a JavaScript value").optional()
+}

--- a/servers/api_val_town/src/tools/runpost/index.ts
+++ b/servers/api_val_town/src/tools/runpost/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "runpost",
+  "toolDescription": "Run a val, with arguments in the request body",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/run/{valname}",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "valname": "valname"
+    },
+    "body": {
+      "args": "args"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/runpost/schema-json/root.json
+++ b/servers/api_val_town/src/tools/runpost/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "valname": {
+      "description": "Name of the val, in concatenated style, like username.valname",
+      "pattern": "^[^.]+.[^.]+$",
+      "type": "string"
+    },
+    "args": {
+      "type": "array",
+      "items": {}
+    }
+  },
+  "required": [
+    "valname"
+  ]
+}

--- a/servers/api_val_town/src/tools/runpost/schema/root.ts
+++ b/servers/api_val_town/src/tools/runpost/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "valname": z.string().regex(new RegExp("^[^.]+.[^.]+$")).describe("Name of the val, in concatenated style, like username.valname"),
+  "args": z.array(z.any()).optional()
+}

--- a/servers/api_val_town/src/tools/searchvals/index.ts
+++ b/servers/api_val_town/src/tools/searchvals/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "searchvals",
+  "toolDescription": "Search for vals across the platform",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/search/vals",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "offset": "offset",
+      "limit": "limit",
+      "query": "query"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/searchvals/schema-json/root.json
+++ b/servers/api_val_town/src/tools/searchvals/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "offset": {
+      "description": "Number of items to skip in order to deliver paginated results",
+      "minimum": 0,
+      "default": 0,
+      "type": "integer"
+    },
+    "limit": {
+      "description": "Maximum items to return in each paginated response",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20,
+      "type": "integer"
+    },
+    "query": {
+      "description": "Search query",
+      "minLength": 1,
+      "maxLength": 256,
+      "type": "string"
+    }
+  },
+  "required": [
+    "offset",
+    "limit",
+    "query"
+  ]
+}

--- a/servers/api_val_town/src/tools/searchvals/schema/root.ts
+++ b/servers/api_val_town/src/tools/searchvals/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response"),
+  "query": z.string().min(1).max(256).describe("Search query")
+}

--- a/servers/api_val_town/src/tools/sqlitebatch/index.ts
+++ b/servers/api_val_town/src/tools/sqlitebatch/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sqlitebatch",
+  "toolDescription": "Execute a batch of SQLite statements and return results for all of them",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/sqlite/batch",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "statements": "statements",
+      "mode": "mode"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/sqlitebatch/schema-json/root.json
+++ b/servers/api_val_town/src/tools/sqlitebatch/schema-json/root.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "properties": {
+    "statements": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "description": "Simple SQL statement to run in SQLite",
+            "type": "string"
+          },
+          {
+            "title": "ParameterizedQuery",
+            "description": "A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference",
+            "type": "object",
+            "properties": {
+              "sql": {
+                "description": "SQL statement, with ? placeholders for arguments",
+                "type": "string"
+              },
+              "args": {
+                "title": "StatementArg",
+                "description": "List of arguments to be used in the given statement",
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "title": "TursoValue",
+                      "description": "A value to be used as a parameter"
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": {
+                      "title": "TursoValue",
+                      "description": "A value to be used as a parameter"
+                    }
+                  }
+                ]
+              }
+            },
+            "required": [
+              "sql",
+              "args"
+            ]
+          }
+        ]
+      }
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "write",
+        "read",
+        "deferred"
+      ]
+    }
+  },
+  "required": [
+    "statements"
+  ]
+}

--- a/servers/api_val_town/src/tools/sqlitebatch/schema/root.ts
+++ b/servers/api_val_town/src/tools/sqlitebatch/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "statements": z.array(z.union([z.string().describe("Simple SQL statement to run in SQLite"), z.object({ "sql": z.string().describe("SQL statement, with ? placeholders for arguments"), "args": z.union([z.array(z.any().describe("A value to be used as a parameter")), z.record(z.any().describe("A value to be used as a parameter"))]).describe("List of arguments to be used in the given statement") }).describe("A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference")])),
+  "mode": z.enum(["write","read","deferred"]).optional()
+}

--- a/servers/api_val_town/src/tools/sqliteexecute/index.ts
+++ b/servers/api_val_town/src/tools/sqliteexecute/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sqliteexecute",
+  "toolDescription": "Execute a single SQLite statement and return results",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/sqlite/execute",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "statement": "statement"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/sqliteexecute/schema-json/root.json
+++ b/servers/api_val_town/src/tools/sqliteexecute/schema-json/root.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "statement": {
+      "anyOf": [
+        {
+          "description": "Simple SQL statement to run in SQLite",
+          "type": "string"
+        },
+        {
+          "title": "ParameterizedQuery",
+          "description": "A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference",
+          "type": "object",
+          "properties": {
+            "sql": {
+              "description": "SQL statement, with ? placeholders for arguments",
+              "type": "string"
+            },
+            "args": {
+              "title": "StatementArg",
+              "description": "List of arguments to be used in the given statement",
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "title": "TursoValue",
+                    "description": "A value to be used as a parameter"
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": {
+                    "title": "TursoValue",
+                    "description": "A value to be used as a parameter"
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "sql",
+            "args"
+          ]
+        }
+      ]
+    }
+  },
+  "required": [
+    "statement"
+  ]
+}

--- a/servers/api_val_town/src/tools/sqliteexecute/schema/root.ts
+++ b/servers/api_val_town/src/tools/sqliteexecute/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "statement": z.union([z.string().describe("Simple SQL statement to run in SQLite"), z.object({ "sql": z.string().describe("SQL statement, with ? placeholders for arguments"), "args": z.union([z.array(z.any().describe("A value to be used as a parameter")), z.record(z.any().describe("A value to be used as a parameter"))]).describe("List of arguments to be used in the given statement") }).describe("A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference")])
+}

--- a/servers/api_val_town/src/tools/usersget/index.ts
+++ b/servers/api_val_town/src/tools/usersget/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "usersget",
+  "toolDescription": "Get basic information about a user",
+  "baseUrl": "https://api.val.town",
+  "path": "/v1/users/{user_id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "user_id": "user_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/usersget/schema-json/root.json
+++ b/servers/api_val_town/src/tools/usersget/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "user_id": {
+      "description": "User Id",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "user_id"
+  ]
+}

--- a/servers/api_val_town/src/tools/usersget/schema/root.ts
+++ b/servers/api_val_town/src/tools/usersget/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "user_id": z.string().uuid().describe("User Id")
+}

--- a/servers/api_val_town/src/tools/valfilesget2/index.ts
+++ b/servers/api_val_town/src/tools/valfilesget2/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "valfilesget2",
+  "toolDescription": "Get metadata for files and directories in a val. If path is an empty string, returns files at the root directory.",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}/files",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    },
+    "query": {
+      "version": "version",
+      "branch_id": "branch_id",
+      "path": "path",
+      "recursive": "recursive",
+      "offset": "offset",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/valfilesget2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/valfilesget2/schema-json/root.json
@@ -1,0 +1,49 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    },
+    "version": {
+      "description": "Specific branch version to query",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "branch_id": {
+      "description": "Id to query",
+      "format": "uuid",
+      "type": "string"
+    },
+    "path": {
+      "description": "Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory.",
+      "type": "string"
+    },
+    "recursive": {
+      "description": "Whether to recursively act on all files in the project",
+      "default": false,
+      "type": "boolean"
+    },
+    "offset": {
+      "description": "Number of items to skip in order to deliver paginated results",
+      "minimum": 0,
+      "default": 0,
+      "type": "integer"
+    },
+    "limit": {
+      "description": "Maximum items to return in each paginated response",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "val_id",
+    "path",
+    "recursive",
+    "offset",
+    "limit"
+  ]
+}

--- a/servers/api_val_town/src/tools/valfilesget2/schema/root.ts
+++ b/servers/api_val_town/src/tools/valfilesget2/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val"),
+  "version": z.number().int().gte(0).describe("Specific branch version to query").optional(),
+  "branch_id": z.string().uuid().describe("Id to query").optional(),
+  "path": z.string().describe("Path to a file or directory (e.g. 'dir/subdir/file.ts'). Pass in an empty string to represent the root directory."),
+  "recursive": z.boolean().describe("Whether to recursively act on all files in the project"),
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}

--- a/servers/api_val_town/src/tools/valscreate2/index.ts
+++ b/servers/api_val_town/src/tools/valscreate2/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "valscreate2",
+  "toolDescription": "Create a new val",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "description": "description",
+      "privacy": "privacy"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/valscreate2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/valscreate2/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "minLength": 1,
+      "maxLength": 48,
+      "pattern": "^[a-zA-Z][a-zA-Z0-9\\-_]*$",
+      "type": "string"
+    },
+    "description": {
+      "maxLength": 64,
+      "type": "string"
+    },
+    "privacy": {
+      "type": "string",
+      "enum": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "privacy"
+  ]
+}

--- a/servers/api_val_town/src/tools/valscreate2/schema/root.ts
+++ b/servers/api_val_town/src/tools/valscreate2/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string().regex(new RegExp("^[a-zA-Z][a-zA-Z0-9\\-_]*$")).min(1).max(48),
+  "description": z.string().max(64).optional(),
+  "privacy": z.enum(["public","unlisted","private"])
+}

--- a/servers/api_val_town/src/tools/valsget2/index.ts
+++ b/servers/api_val_town/src/tools/valsget2/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "valsget2",
+  "toolDescription": "Get a val by id",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals/{val_id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "val_id": "val_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/valsget2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/valsget2/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "val_id": {
+      "description": "Id of a val",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "val_id"
+  ]
+}

--- a/servers/api_val_town/src/tools/valsget2/schema/root.ts
+++ b/servers/api_val_town/src/tools/valsget2/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "val_id": z.string().uuid().describe("Id of a val")
+}

--- a/servers/api_val_town/src/tools/valslist2/index.ts
+++ b/servers/api_val_town/src/tools/valslist2/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "valslist2",
+  "toolDescription": "Lists all public vals",
+  "baseUrl": "https://api.val.town",
+  "path": "/v2/vals",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "offset": "offset",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_val_town/src/tools/valslist2/schema-json/root.json
+++ b/servers/api_val_town/src/tools/valslist2/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "offset": {
+      "description": "Number of items to skip in order to deliver paginated results",
+      "minimum": 0,
+      "default": 0,
+      "type": "integer"
+    },
+    "limit": {
+      "description": "Maximum items to return in each paginated response",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "offset",
+    "limit"
+  ]
+}

--- a/servers/api_val_town/src/tools/valslist2/schema/root.ts
+++ b/servers/api_val_town/src/tools/valslist2/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "offset": z.number().int().gte(0).describe("Number of items to skip in order to deliver paginated results"),
+  "limit": z.number().int().gte(1).lte(100).describe("Maximum items to return in each paginated response")
+}

--- a/servers/api_val_town/tsconfig.json
+++ b/servers/api_val_town/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_val_town`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_val_town`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_val_town": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_val_town"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.