### PR TITLE
Add MCP server `petstore_swagger_io_v2`

### DIFF
--- a/servers/petstore_swagger_io_v2/.npmignore
+++ b/servers/petstore_swagger_io_v2/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/petstore_swagger_io_v2/README.md
+++ b/servers/petstore_swagger_io_v2/README.md
@@ -1,0 +1,135 @@
+# @open-mcp/petstore_swagger_io_v2
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "petstore_swagger_io_v2": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/petstore_swagger_io_v2@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/petstore_swagger_io_v2@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add petstore_swagger_io_v2 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add petstore_swagger_io_v2 \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add petstore_swagger_io_v2 \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "petstore_swagger_io_v2": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/petstore_swagger_io_v2"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### findpets
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `tags` (array)
+- `limit` (integer)
+
+### addpet
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `name` (string)
+- `tag` (string)
+
+### find_pet_by_id
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (integer)
+
+### deletepet
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (integer)

--- a/servers/petstore_swagger_io_v2/package.json
+++ b/servers/petstore_swagger_io_v2/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/petstore_swagger_io_v2",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "petstore_swagger_io_v2": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/petstore_swagger_io_v2/src/constants.ts
+++ b/servers/petstore_swagger_io_v2/src/constants.ts
@@ -1,0 +1,9 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/OAI/learn.openapis.org/refs/heads/main/examples/v3.0/petstore-expanded.yaml"
+export const SERVER_NAME = "petstore_swagger_io_v2"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/findpets/index.js",
+  "./tools/addpet/index.js",
+  "./tools/find_pet_by_id/index.js",
+  "./tools/deletepet/index.js"
+]

--- a/servers/petstore_swagger_io_v2/src/index.ts
+++ b/servers/petstore_swagger_io_v2/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/petstore_swagger_io_v2/src/server.ts
+++ b/servers/petstore_swagger_io_v2/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/petstore_swagger_io_v2/src/tools/addpet/index.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/addpet/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "addpet",
+  "toolDescription": "Creates a new pet in the store. Duplicates are allowed",
+  "baseUrl": "https://petstore.swagger.io/v2",
+  "path": "/pets",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "tag": "tag"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore_swagger_io_v2/src/tools/addpet/schema-json/root.json
+++ b/servers/petstore_swagger_io_v2/src/tools/addpet/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "tag": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/servers/petstore_swagger_io_v2/src/tools/addpet/schema/root.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/addpet/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string(),
+  "tag": z.string().optional()
+}

--- a/servers/petstore_swagger_io_v2/src/tools/deletepet/index.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/deletepet/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletepet",
+  "toolDescription": "deletes a single pet based on the ID supplied",
+  "baseUrl": "https://petstore.swagger.io/v2",
+  "path": "/pets/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore_swagger_io_v2/src/tools/deletepet/schema-json/root.json
+++ b/servers/petstore_swagger_io_v2/src/tools/deletepet/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of pet to delete",
+      "type": "integer",
+      "format": "int64"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/petstore_swagger_io_v2/src/tools/deletepet/schema/root.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/deletepet/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("ID of pet to delete")
+}

--- a/servers/petstore_swagger_io_v2/src/tools/find_pet_by_id/index.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/find_pet_by_id/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "find_pet_by_id",
+  "toolDescription": "Returns a user based on a single ID, if the user does not have access to the pet",
+  "baseUrl": "https://petstore.swagger.io/v2",
+  "path": "/pets/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore_swagger_io_v2/src/tools/find_pet_by_id/schema-json/root.json
+++ b/servers/petstore_swagger_io_v2/src/tools/find_pet_by_id/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of pet to fetch",
+      "type": "integer",
+      "format": "int64"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/petstore_swagger_io_v2/src/tools/find_pet_by_id/schema/root.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/find_pet_by_id/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("ID of pet to fetch")
+}

--- a/servers/petstore_swagger_io_v2/src/tools/findpets/index.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/findpets/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findpets",
+  "toolDescription": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum n",
+  "baseUrl": "https://petstore.swagger.io/v2",
+  "path": "/pets",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "tags": "tags",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/petstore_swagger_io_v2/src/tools/findpets/schema-json/root.json
+++ b/servers/petstore_swagger_io_v2/src/tools/findpets/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "tags": {
+      "description": "tags to filter by",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "limit": {
+      "description": "maximum number of results to return",
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "required": []
+}

--- a/servers/petstore_swagger_io_v2/src/tools/findpets/schema/root.ts
+++ b/servers/petstore_swagger_io_v2/src/tools/findpets/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tags": z.array(z.string()).describe("tags to filter by").optional(),
+  "limit": z.number().int().describe("maximum number of results to return").optional()
+}

--- a/servers/petstore_swagger_io_v2/tsconfig.json
+++ b/servers/petstore_swagger_io_v2/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `petstore_swagger_io_v2`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/petstore_swagger_io_v2`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "petstore_swagger_io_v2": {
      "command": "npx",
      "args": ["-y", "@open-mcp/petstore_swagger_io_v2"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.