### PR TITLE
Add MCP server `fincar-server`

### DIFF
--- a/servers/fincar-server/.npmignore
+++ b/servers/fincar-server/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/fincar-server/README.md
+++ b/servers/fincar-server/README.md
@@ -1,0 +1,298 @@
+# @open-mcp/fincar-server
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "fincar-server": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/fincar-server@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/fincar-server@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add fincar-server \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add fincar-server \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add fincar-server \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "fincar-server": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/fincar-server"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_v1_packages
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+
+### get_v1_packages_packageid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `packageId` (integer)
+
+### get_v1_businesses
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+
+### post_v1_businesses
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+- `businessId` (integer)
+- `name` (string)
+- `abn` (string)
+- `acn` (string)
+- `industryType` (string)
+- `businessSize` (string)
+- `streetAddress` (string)
+- `suburb` (string)
+- `state` (string)
+- `postcode` (string)
+- `country` (string)
+- `contactEmail` (string)
+- `phoneNumber` (string)
+- `website` (string)
+- `participantsCount` (integer)
+- `packagesEnrolled` (array)
+- `status` (integer)
+- `createdAt` (string)
+- `updatedAt` (string)
+
+### get_v1_businesses_businessid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `businessId` (integer)
+
+### put_v1_businesses_businessid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `businessId` (integer)
+- `id` (integer)
+- `b_businessId` (integer)
+- `name` (string)
+- `abn` (string)
+- `acn` (string)
+- `industryType` (string)
+- `businessSize` (string)
+- `streetAddress` (string)
+- `suburb` (string)
+- `state` (string)
+- `postcode` (string)
+- `country` (string)
+- `contactEmail` (string)
+- `phoneNumber` (string)
+- `website` (string)
+- `participantsCount` (integer)
+- `packagesEnrolled` (array)
+- `status` (integer)
+- `createdAt` (string)
+- `updatedAt` (string)
+
+### delete_v1_businesses_businessid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `businessId` (integer)
+
+### get_v1_businesses_businessid_participants
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `businessId` (integer)
+- `limit` (integer)
+- `offset` (integer)
+
+### post_v1_businesses_businessid_participants
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `businessId` (string)
+- `id` (integer)
+- `participantId` (integer)
+- `employeeId` (string)
+- `name` (string)
+- `email` (string)
+- `employmentStatus` (string)
+- `employmentStartDate` (string)
+- `department` (string)
+- `streetAddress` (string)
+- `suburb` (string)
+- `state` (string)
+- `postcode` (string)
+- `country` (string)
+- `phoneNumber` (string)
+- `salary` (number)
+- `status` (integer)
+- `createdAt` (string)
+- `updatedAt` (string)
+
+### get_v1_businesses_businessid_participants_participantid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `participantId` (string)
+- `businessId` (string)
+
+### put_v1_businesses_businessid_participants_participantid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `participantId` (string)
+- `businessId` (string)
+- `id` (integer)
+- `b_participantId` (integer)
+- `employeeId` (string)
+- `name` (string)
+- `email` (string)
+- `employmentStatus` (string)
+- `employmentStartDate` (string)
+- `department` (string)
+- `streetAddress` (string)
+- `suburb` (string)
+- `state` (string)
+- `postcode` (string)
+- `country` (string)
+- `phoneNumber` (string)
+- `salary` (number)
+- `status` (integer)
+- `createdAt` (string)
+- `updatedAt` (string)
+
+### delete_v1_businesses_businessid_participants_participantid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `participantId` (string)
+- `businessId` (string)

--- a/servers/fincar-server/package.json
+++ b/servers/fincar-server/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/fincar-server",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "fincar-server": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/fincar-server/src/constants.ts
+++ b/servers/fincar-server/src/constants.ts
@@ -1,0 +1,17 @@
+export const OPENAPI_URL = "https://partners.fincar.com.au/assets/api/fc_openapi.yaml"
+export const SERVER_NAME = "fincar-server"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_v1_packages/index.js",
+  "./tools/get_v1_packages_packageid_/index.js",
+  "./tools/get_v1_businesses/index.js",
+  "./tools/post_v1_businesses/index.js",
+  "./tools/get_v1_businesses_businessid_/index.js",
+  "./tools/put_v1_businesses_businessid_/index.js",
+  "./tools/delete_v1_businesses_businessid_/index.js",
+  "./tools/get_v1_businesses_businessid_participants/index.js",
+  "./tools/post_v1_businesses_businessid_participants/index.js",
+  "./tools/get_v1_businesses_businessid_participants_participantid_/index.js",
+  "./tools/put_v1_businesses_businessid_participants_participantid_/index.js",
+  "./tools/delete_v1_businesses_businessid_participants_participantid_/index.js"
+]

--- a/servers/fincar-server/src/index.ts
+++ b/servers/fincar-server/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/fincar-server/src/server.ts
+++ b/servers/fincar-server/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/fincar-server/src/tools/delete_v1_businesses_businessid_/index.ts
+++ b/servers/fincar-server/src/tools/delete_v1_businesses_businessid_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_v1_businesses_businessid_",
+  "toolDescription": "Delete a business",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "businessId": "businessId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/delete_v1_businesses_businessid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/delete_v1_businesses_businessid_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "businessId": {
+      "description": "ID of the business to delete",
+      "type": "integer",
+      "example": 2001
+    }
+  },
+  "required": [
+    "businessId"
+  ]
+}

--- a/servers/fincar-server/src/tools/delete_v1_businesses_businessid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/delete_v1_businesses_businessid_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "businessId": z.number().int().describe("ID of the business to delete")
+}

--- a/servers/fincar-server/src/tools/delete_v1_businesses_businessid_participants_participantid_/index.ts
+++ b/servers/fincar-server/src/tools/delete_v1_businesses_businessid_participants_participantid_/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_v1_businesses_businessid_participants_participantid_",
+  "toolDescription": "Delete a participant",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}/participants/{participantId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "participantId": "participantId",
+      "businessId": "businessId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/delete_v1_businesses_businessid_participants_participantid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/delete_v1_businesses_businessid_participants_participantid_/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "participantId": {
+      "type": "string"
+    },
+    "businessId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "participantId",
+    "businessId"
+  ]
+}

--- a/servers/fincar-server/src/tools/delete_v1_businesses_businessid_participants_participantid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/delete_v1_businesses_businessid_participants_participantid_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "participantId": z.string(),
+  "businessId": z.string()
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses/index.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_businesses",
+  "toolDescription": "List businesses",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/get_v1_businesses/schema-json/root.json
+++ b/servers/fincar-server/src/tools/get_v1_businesses/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Maximum number of results to return",
+      "type": "integer",
+      "example": 10
+    },
+    "offset": {
+      "description": "Number of results to skip",
+      "type": "integer",
+      "example": 0
+    }
+  },
+  "required": []
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses/schema/root.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.number().int().describe("Maximum number of results to return").optional(),
+  "offset": z.number().int().describe("Number of results to skip").optional()
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_/index.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_businesses_businessid_",
+  "toolDescription": "Show business details",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "businessId": "businessId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "businessId": {
+      "description": "ID of the business to retrieve",
+      "type": "integer",
+      "example": 2001
+    }
+  },
+  "required": [
+    "businessId"
+  ]
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "businessId": z.number().int().describe("ID of the business to retrieve")
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants/index.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_businesses_businessid_participants",
+  "toolDescription": "List enrolled participants",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}/participants",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "businessId": "businessId"
+    },
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants/schema-json/root.json
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "businessId": {
+      "description": "ID of the business to retrieve participants for",
+      "type": "integer",
+      "example": 2001
+    },
+    "limit": {
+      "description": "Maximum number of results to return",
+      "type": "integer",
+      "example": 10
+    },
+    "offset": {
+      "description": "Number of results to skip",
+      "type": "integer",
+      "example": 0
+    }
+  },
+  "required": [
+    "businessId"
+  ]
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants/schema/root.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "businessId": z.number().int().describe("ID of the business to retrieve participants for"),
+  "limit": z.number().int().describe("Maximum number of results to return").optional(),
+  "offset": z.number().int().describe("Number of results to skip").optional()
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants_participantid_/index.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants_participantid_/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_businesses_businessid_participants_participantid_",
+  "toolDescription": "Show participant details",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}/participants/{participantId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "participantId": "participantId",
+      "businessId": "businessId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants_participantid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants_participantid_/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "participantId": {
+      "type": "string"
+    },
+    "businessId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "participantId",
+    "businessId"
+  ]
+}

--- a/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants_participantid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/get_v1_businesses_businessid_participants_participantid_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "participantId": z.string(),
+  "businessId": z.string()
+}

--- a/servers/fincar-server/src/tools/get_v1_packages/index.ts
+++ b/servers/fincar-server/src/tools/get_v1_packages/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_packages",
+  "toolDescription": "List Fincar packages",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/packages",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/get_v1_packages/schema-json/root.json
+++ b/servers/fincar-server/src/tools/get_v1_packages/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Maximum number of results to return",
+      "type": "integer",
+      "example": 10
+    },
+    "offset": {
+      "description": "Number of results to skip",
+      "type": "integer",
+      "example": 0
+    }
+  },
+  "required": []
+}

--- a/servers/fincar-server/src/tools/get_v1_packages/schema/root.ts
+++ b/servers/fincar-server/src/tools/get_v1_packages/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.number().int().describe("Maximum number of results to return").optional(),
+  "offset": z.number().int().describe("Number of results to skip").optional()
+}

--- a/servers/fincar-server/src/tools/get_v1_packages_packageid_/index.ts
+++ b/servers/fincar-server/src/tools/get_v1_packages_packageid_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_packages_packageid_",
+  "toolDescription": "Show package details",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/packages/{packageId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "packageId": "packageId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/get_v1_packages_packageid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/get_v1_packages_packageid_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "packageId": {
+      "description": "ID of the package to retrieve",
+      "type": "integer",
+      "example": 101
+    }
+  },
+  "required": [
+    "packageId"
+  ]
+}

--- a/servers/fincar-server/src/tools/get_v1_packages_packageid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/get_v1_packages_packageid_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "packageId": z.number().int().describe("ID of the package to retrieve")
+}

--- a/servers/fincar-server/src/tools/post_v1_businesses/index.ts
+++ b/servers/fincar-server/src/tools/post_v1_businesses/index.ts
@@ -1,0 +1,45 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_businesses",
+  "toolDescription": "Create a new business",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "id": "id",
+      "businessId": "businessId",
+      "name": "name",
+      "abn": "abn",
+      "acn": "acn",
+      "industryType": "industryType",
+      "businessSize": "businessSize",
+      "streetAddress": "streetAddress",
+      "suburb": "suburb",
+      "state": "state",
+      "postcode": "postcode",
+      "country": "country",
+      "contactEmail": "contactEmail",
+      "phoneNumber": "phoneNumber",
+      "website": "website",
+      "participantsCount": "participantsCount",
+      "packagesEnrolled": "packagesEnrolled",
+      "status": "status",
+      "createdAt": "createdAt",
+      "updatedAt": "updatedAt"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/post_v1_businesses/schema-json/root.json
+++ b/servers/fincar-server/src/tools/post_v1_businesses/schema-json/root.json
@@ -1,0 +1,131 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "example": 10
+    },
+    "businessId": {
+      "type": "integer",
+      "example": 2001
+    },
+    "name": {
+      "type": "string",
+      "example": "ACME Pty Ltd"
+    },
+    "abn": {
+      "type": "string",
+      "pattern": "^\\d{11}$",
+      "example": "12345678901",
+      "description": "Australian Business Number"
+    },
+    "acn": {
+      "type": "string",
+      "pattern": "^\\d{9}$",
+      "example": "123456789",
+      "description": "Australian Company Number"
+    },
+    "industryType": {
+      "type": "string",
+      "enum": [
+        "AGRICULTURE",
+        "MINING",
+        "MANUFACTURING",
+        "CONSTRUCTION",
+        "RETAIL",
+        "HOSPITALITY",
+        "FINANCE",
+        "TECHNOLOGY",
+        "HEALTHCARE",
+        "EDUCATION",
+        "OTHER"
+      ],
+      "example": "TECHNOLOGY"
+    },
+    "businessSize": {
+      "type": "string",
+      "enum": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE",
+        "ENTERPRISE"
+      ],
+      "example": "MEDIUM",
+      "description": "Business size category based on employee count"
+    },
+    "streetAddress": {
+      "type": "string",
+      "example": "123 Example Street"
+    },
+    "suburb": {
+      "type": "string",
+      "example": "Sydney"
+    },
+    "state": {
+      "type": "string",
+      "example": "NSW"
+    },
+    "postcode": {
+      "type": "string",
+      "example": "2000"
+    },
+    "country": {
+      "type": "string",
+      "example": "Australia"
+    },
+    "contactEmail": {
+      "type": "string",
+      "format": "email",
+      "example": "contact@acme.com.au"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "example": "+61 2 1234 5678"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri",
+      "example": "https://www.acme.com.au"
+    },
+    "participantsCount": {
+      "type": "integer",
+      "example": 25
+    },
+    "packagesEnrolled": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "example": [
+        101,
+        102
+      ]
+    },
+    "status": {
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "example": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T08:00:00Z"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T11:15:00Z"
+    }
+  },
+  "required": [
+    "name",
+    "abn",
+    "industryType",
+    "businessSize",
+    "contactEmail"
+  ]
+}

--- a/servers/fincar-server/src/tools/post_v1_businesses/schema/root.ts
+++ b/servers/fincar-server/src/tools/post_v1_businesses/schema/root.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().optional(),
+  "businessId": z.number().int().optional(),
+  "name": z.string(),
+  "abn": z.string().regex(new RegExp("^\\d{11}$")).describe("Australian Business Number"),
+  "acn": z.string().regex(new RegExp("^\\d{9}$")).describe("Australian Company Number").optional(),
+  "industryType": z.enum(["AGRICULTURE","MINING","MANUFACTURING","CONSTRUCTION","RETAIL","HOSPITALITY","FINANCE","TECHNOLOGY","HEALTHCARE","EDUCATION","OTHER"]),
+  "businessSize": z.enum(["SMALL","MEDIUM","LARGE","ENTERPRISE"]).describe("Business size category based on employee count"),
+  "streetAddress": z.string().optional(),
+  "suburb": z.string().optional(),
+  "state": z.string().optional(),
+  "postcode": z.string().optional(),
+  "country": z.string().optional(),
+  "contactEmail": z.string().email(),
+  "phoneNumber": z.string().optional(),
+  "website": z.string().url().optional(),
+  "participantsCount": z.number().int().optional(),
+  "packagesEnrolled": z.array(z.number().int()).optional(),
+  "status": z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
+  "createdAt": z.string().datetime({ offset: true }).optional(),
+  "updatedAt": z.string().datetime({ offset: true }).optional()
+}

--- a/servers/fincar-server/src/tools/post_v1_businesses_businessid_participants/index.ts
+++ b/servers/fincar-server/src/tools/post_v1_businesses_businessid_participants/index.ts
@@ -1,0 +1,46 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_businesses_businessid_participants",
+  "toolDescription": "Create a participant",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}/participants",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "businessId": "businessId"
+    },
+    "body": {
+      "id": "id",
+      "participantId": "participantId",
+      "employeeId": "employeeId",
+      "name": "name",
+      "email": "email",
+      "employmentStatus": "employmentStatus",
+      "employmentStartDate": "employmentStartDate",
+      "department": "department",
+      "streetAddress": "streetAddress",
+      "suburb": "suburb",
+      "state": "state",
+      "postcode": "postcode",
+      "country": "country",
+      "phoneNumber": "phoneNumber",
+      "salary": "salary",
+      "status": "status",
+      "createdAt": "createdAt",
+      "updatedAt": "updatedAt"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/post_v1_businesses_businessid_participants/schema-json/root.json
+++ b/servers/fincar-server/src/tools/post_v1_businesses_businessid_participants/schema-json/root.json
@@ -1,0 +1,106 @@
+{
+  "type": "object",
+  "properties": {
+    "businessId": {
+      "type": "string"
+    },
+    "id": {
+      "type": "integer",
+      "example": 1001
+    },
+    "participantId": {
+      "type": "integer",
+      "example": 30001
+    },
+    "employeeId": {
+      "type": "string",
+      "example": "E12345"
+    },
+    "name": {
+      "type": "string",
+      "example": "John Doe"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "example": "john.doe@example.com"
+    },
+    "employmentStatus": {
+      "type": "string",
+      "enum": [
+        "FULL_TIME",
+        "PART_TIME",
+        "CASUAL",
+        "CONTRACT"
+      ],
+      "example": "FULL_TIME",
+      "description": "Current employment status"
+    },
+    "employmentStartDate": {
+      "type": "string",
+      "format": "date",
+      "example": "2023-01-15",
+      "description": "Date when employment started"
+    },
+    "department": {
+      "type": "string",
+      "example": "Finance",
+      "description": "Department or business unit"
+    },
+    "streetAddress": {
+      "type": "string",
+      "example": "456 Another Street"
+    },
+    "suburb": {
+      "type": "string",
+      "example": "Melbourne"
+    },
+    "state": {
+      "type": "string",
+      "example": "VIC"
+    },
+    "postcode": {
+      "type": "string",
+      "example": "3000"
+    },
+    "country": {
+      "type": "string",
+      "example": "Australia"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "example": "+61 3 9876 5432"
+    },
+    "salary": {
+      "type": "number",
+      "example": 75000
+    },
+    "status": {
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "example": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T09:30:00Z"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T10:45:00Z"
+    }
+  },
+  "required": [
+    "businessId",
+    "name",
+    "email",
+    "employmentStatus",
+    "employmentStartDate",
+    "department"
+  ]
+}

--- a/servers/fincar-server/src/tools/post_v1_businesses_businessid_participants/schema/root.ts
+++ b/servers/fincar-server/src/tools/post_v1_businesses_businessid_participants/schema/root.ts
@@ -1,0 +1,23 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "businessId": z.string(),
+  "id": z.number().int().optional(),
+  "participantId": z.number().int().optional(),
+  "employeeId": z.string().optional(),
+  "name": z.string(),
+  "email": z.string().email(),
+  "employmentStatus": z.enum(["FULL_TIME","PART_TIME","CASUAL","CONTRACT"]).describe("Current employment status"),
+  "employmentStartDate": z.string().date().describe("Date when employment started"),
+  "department": z.string().describe("Department or business unit"),
+  "streetAddress": z.string().optional(),
+  "suburb": z.string().optional(),
+  "state": z.string().optional(),
+  "postcode": z.string().optional(),
+  "country": z.string().optional(),
+  "phoneNumber": z.string().optional(),
+  "salary": z.number().optional(),
+  "status": z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
+  "createdAt": z.string().datetime({ offset: true }).optional(),
+  "updatedAt": z.string().datetime({ offset: true }).optional()
+}

--- a/servers/fincar-server/src/tools/put_v1_businesses_businessid_/index.ts
+++ b/servers/fincar-server/src/tools/put_v1_businesses_businessid_/index.ts
@@ -1,0 +1,48 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_v1_businesses_businessid_",
+  "toolDescription": "Update business details",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "businessId": "businessId"
+    },
+    "body": {
+      "id": "id",
+      "businessId": "b_businessId",
+      "name": "name",
+      "abn": "abn",
+      "acn": "acn",
+      "industryType": "industryType",
+      "businessSize": "businessSize",
+      "streetAddress": "streetAddress",
+      "suburb": "suburb",
+      "state": "state",
+      "postcode": "postcode",
+      "country": "country",
+      "contactEmail": "contactEmail",
+      "phoneNumber": "phoneNumber",
+      "website": "website",
+      "participantsCount": "participantsCount",
+      "packagesEnrolled": "packagesEnrolled",
+      "status": "status",
+      "createdAt": "createdAt",
+      "updatedAt": "updatedAt"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/put_v1_businesses_businessid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/put_v1_businesses_businessid_/schema-json/root.json
@@ -1,0 +1,137 @@
+{
+  "type": "object",
+  "properties": {
+    "businessId": {
+      "description": "ID of the business to update",
+      "type": "integer",
+      "example": 2001
+    },
+    "id": {
+      "type": "integer",
+      "example": 10
+    },
+    "b_businessId": {
+      "type": "integer",
+      "example": 2001
+    },
+    "name": {
+      "type": "string",
+      "example": "ACME Pty Ltd"
+    },
+    "abn": {
+      "type": "string",
+      "pattern": "^\\d{11}$",
+      "example": "12345678901",
+      "description": "Australian Business Number"
+    },
+    "acn": {
+      "type": "string",
+      "pattern": "^\\d{9}$",
+      "example": "123456789",
+      "description": "Australian Company Number"
+    },
+    "industryType": {
+      "type": "string",
+      "enum": [
+        "AGRICULTURE",
+        "MINING",
+        "MANUFACTURING",
+        "CONSTRUCTION",
+        "RETAIL",
+        "HOSPITALITY",
+        "FINANCE",
+        "TECHNOLOGY",
+        "HEALTHCARE",
+        "EDUCATION",
+        "OTHER"
+      ],
+      "example": "TECHNOLOGY"
+    },
+    "businessSize": {
+      "type": "string",
+      "enum": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE",
+        "ENTERPRISE"
+      ],
+      "example": "MEDIUM",
+      "description": "Business size category based on employee count"
+    },
+    "streetAddress": {
+      "type": "string",
+      "example": "123 Example Street"
+    },
+    "suburb": {
+      "type": "string",
+      "example": "Sydney"
+    },
+    "state": {
+      "type": "string",
+      "example": "NSW"
+    },
+    "postcode": {
+      "type": "string",
+      "example": "2000"
+    },
+    "country": {
+      "type": "string",
+      "example": "Australia"
+    },
+    "contactEmail": {
+      "type": "string",
+      "format": "email",
+      "example": "contact@acme.com.au"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "example": "+61 2 1234 5678"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri",
+      "example": "https://www.acme.com.au"
+    },
+    "participantsCount": {
+      "type": "integer",
+      "example": 25
+    },
+    "packagesEnrolled": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "example": [
+        101,
+        102
+      ]
+    },
+    "status": {
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "example": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T08:00:00Z"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T11:15:00Z"
+    }
+  },
+  "required": [
+    "businessId",
+    "name",
+    "abn",
+    "industryType",
+    "businessSize",
+    "contactEmail"
+  ]
+}

--- a/servers/fincar-server/src/tools/put_v1_businesses_businessid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/put_v1_businesses_businessid_/schema/root.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "businessId": z.number().int().describe("ID of the business to update"),
+  "id": z.number().int().optional(),
+  "b_businessId": z.number().int().optional(),
+  "name": z.string(),
+  "abn": z.string().regex(new RegExp("^\\d{11}$")).describe("Australian Business Number"),
+  "acn": z.string().regex(new RegExp("^\\d{9}$")).describe("Australian Company Number").optional(),
+  "industryType": z.enum(["AGRICULTURE","MINING","MANUFACTURING","CONSTRUCTION","RETAIL","HOSPITALITY","FINANCE","TECHNOLOGY","HEALTHCARE","EDUCATION","OTHER"]),
+  "businessSize": z.enum(["SMALL","MEDIUM","LARGE","ENTERPRISE"]).describe("Business size category based on employee count"),
+  "streetAddress": z.string().optional(),
+  "suburb": z.string().optional(),
+  "state": z.string().optional(),
+  "postcode": z.string().optional(),
+  "country": z.string().optional(),
+  "contactEmail": z.string().email(),
+  "phoneNumber": z.string().optional(),
+  "website": z.string().url().optional(),
+  "participantsCount": z.number().int().optional(),
+  "packagesEnrolled": z.array(z.number().int()).optional(),
+  "status": z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
+  "createdAt": z.string().datetime({ offset: true }).optional(),
+  "updatedAt": z.string().datetime({ offset: true }).optional()
+}

--- a/servers/fincar-server/src/tools/put_v1_businesses_businessid_participants_participantid_/index.ts
+++ b/servers/fincar-server/src/tools/put_v1_businesses_businessid_participants_participantid_/index.ts
@@ -1,0 +1,47 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_v1_businesses_businessid_participants_participantid_",
+  "toolDescription": "Update participant details",
+  "baseUrl": "https://api.fincar.com.au/sandbox",
+  "path": "/v1/businesses/{businessId}/participants/{participantId}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "participantId": "participantId",
+      "businessId": "businessId"
+    },
+    "body": {
+      "id": "id",
+      "participantId": "b_participantId",
+      "employeeId": "employeeId",
+      "name": "name",
+      "email": "email",
+      "employmentStatus": "employmentStatus",
+      "employmentStartDate": "employmentStartDate",
+      "department": "department",
+      "streetAddress": "streetAddress",
+      "suburb": "suburb",
+      "state": "state",
+      "postcode": "postcode",
+      "country": "country",
+      "phoneNumber": "phoneNumber",
+      "salary": "salary",
+      "status": "status",
+      "createdAt": "createdAt",
+      "updatedAt": "updatedAt"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/fincar-server/src/tools/put_v1_businesses_businessid_participants_participantid_/schema-json/root.json
+++ b/servers/fincar-server/src/tools/put_v1_businesses_businessid_participants_participantid_/schema-json/root.json
@@ -1,0 +1,110 @@
+{
+  "type": "object",
+  "properties": {
+    "participantId": {
+      "type": "string"
+    },
+    "businessId": {
+      "type": "string"
+    },
+    "id": {
+      "type": "integer",
+      "example": 1001
+    },
+    "b_participantId": {
+      "type": "integer",
+      "example": 30001
+    },
+    "employeeId": {
+      "type": "string",
+      "example": "E12345"
+    },
+    "name": {
+      "type": "string",
+      "example": "John Doe"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "example": "john.doe@example.com"
+    },
+    "employmentStatus": {
+      "type": "string",
+      "enum": [
+        "FULL_TIME",
+        "PART_TIME",
+        "CASUAL",
+        "CONTRACT"
+      ],
+      "example": "FULL_TIME",
+      "description": "Current employment status"
+    },
+    "employmentStartDate": {
+      "type": "string",
+      "format": "date",
+      "example": "2023-01-15",
+      "description": "Date when employment started"
+    },
+    "department": {
+      "type": "string",
+      "example": "Finance",
+      "description": "Department or business unit"
+    },
+    "streetAddress": {
+      "type": "string",
+      "example": "456 Another Street"
+    },
+    "suburb": {
+      "type": "string",
+      "example": "Melbourne"
+    },
+    "state": {
+      "type": "string",
+      "example": "VIC"
+    },
+    "postcode": {
+      "type": "string",
+      "example": "3000"
+    },
+    "country": {
+      "type": "string",
+      "example": "Australia"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "example": "+61 3 9876 5432"
+    },
+    "salary": {
+      "type": "number",
+      "example": 75000
+    },
+    "status": {
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "example": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T09:30:00Z"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2024-02-14T10:45:00Z"
+    }
+  },
+  "required": [
+    "participantId",
+    "businessId",
+    "name",
+    "email",
+    "employmentStatus",
+    "employmentStartDate",
+    "department"
+  ]
+}

--- a/servers/fincar-server/src/tools/put_v1_businesses_businessid_participants_participantid_/schema/root.ts
+++ b/servers/fincar-server/src/tools/put_v1_businesses_businessid_participants_participantid_/schema/root.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "participantId": z.string(),
+  "businessId": z.string(),
+  "id": z.number().int().optional(),
+  "b_participantId": z.number().int().optional(),
+  "employeeId": z.string().optional(),
+  "name": z.string(),
+  "email": z.string().email(),
+  "employmentStatus": z.enum(["FULL_TIME","PART_TIME","CASUAL","CONTRACT"]).describe("Current employment status"),
+  "employmentStartDate": z.string().date().describe("Date when employment started"),
+  "department": z.string().describe("Department or business unit"),
+  "streetAddress": z.string().optional(),
+  "suburb": z.string().optional(),
+  "state": z.string().optional(),
+  "postcode": z.string().optional(),
+  "country": z.string().optional(),
+  "phoneNumber": z.string().optional(),
+  "salary": z.number().optional(),
+  "status": z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
+  "createdAt": z.string().datetime({ offset: true }).optional(),
+  "updatedAt": z.string().datetime({ offset: true }).optional()
+}

--- a/servers/fincar-server/tsconfig.json
+++ b/servers/fincar-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `fincar-server`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/fincar-server`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "fincar-server": {
      "command": "npx",
      "args": ["-y", "@open-mcp/fincar-server"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.