### PR TITLE
Add MCP server `staging_adh_disc_me_cloud_okadoc_api`

### DIFF
--- a/servers/staging_adh_disc_me_cloud_okadoc_api/.npmignore
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/README.md
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/README.md
@@ -1,0 +1,183 @@
+# @open-mcp/staging_adh_disc_me_cloud_okadoc_api
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "staging_adh_disc_me_cloud_okadoc_api": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/staging_adh_disc_me_cloud_okadoc_api@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/staging_adh_disc_me_cloud_okadoc_api@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add staging_adh_disc_me_cloud_okadoc_api \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add staging_adh_disc_me_cloud_okadoc_api \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add staging_adh_disc_me_cloud_okadoc_api \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "staging_adh_disc_me_cloud_okadoc_api": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/staging_adh_disc_me_cloud_okadoc_api"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### listproviders
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `okadoc-auth-key` (string)
+
+### listproviderservices
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `doctorID` (string)
+- `facilityID` (string)
+- `okadoc-auth-key` (string)
+
+### findprovideravailabilitiesstg
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `doctorID` (string)
+- `facilityID` (string)
+- `from` (string)
+- `to` (string)
+- `okadoc-auth-key` (string)
+
+### findpatient
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `document_type_id` (string)
+- `patient_document_id` (string)
+- `mobile_number` (string)
+- `birthday` (string)
+- `okadoc-auth-key` (string)
+
+### bookappointmentstgexistingpatient
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `okadoc-auth-key` (string)
+
+### cancelappointmentstg
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `okadoc-auth-key` (string)
+
+### rescheduleappointmentstg
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `okadoc-auth-key` (string)
+
+### updatepaymentstatusstg
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `okadoc-auth-key` (string)

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/package.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/staging_adh_disc_me_cloud_okadoc_api",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "staging_adh_disc_me_cloud_okadoc_api": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/constants.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/constants.ts
@@ -1,0 +1,13 @@
+export const OPENAPI_URL = "https://gist.githubusercontent.com/serkansepil/d809be72fd878e86c9901fa457123095/raw/5a74e2e4a4fb7cdbbc502df15296e7c01accd1e7/aa.yaml"
+export const SERVER_NAME = "staging_adh_disc_me_cloud_okadoc_api"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/listproviders/index.js",
+  "./tools/listproviderservices/index.js",
+  "./tools/findprovideravailabilitiesstg/index.js",
+  "./tools/findpatient/index.js",
+  "./tools/bookappointmentstgexistingpatient/index.js",
+  "./tools/cancelappointmentstg/index.js",
+  "./tools/rescheduleappointmentstg/index.js",
+  "./tools/updatepaymentstatusstg/index.js"
+]

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/server.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/bookappointmentstgexistingpatient/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/bookappointmentstgexistingpatient/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "bookappointmentstgexistingpatient",
+  "toolDescription": "Book Appointment Stg Existing Patient",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/book",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/bookappointmentstgexistingpatient/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/bookappointmentstgexistingpatient/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": "04Yumurta92Helva!"
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/bookappointmentstgexistingpatient/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/bookappointmentstgexistingpatient/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/cancelappointmentstg/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/cancelappointmentstg/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cancelappointmentstg",
+  "toolDescription": "Cancel Appointment Stg",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/cancel",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/cancelappointmentstg/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/cancelappointmentstg/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": "04Yumurta92Helva!"
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/cancelappointmentstg/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/cancelappointmentstg/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findpatient/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findpatient/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findpatient",
+  "toolDescription": "Find Patient",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/findPatient",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "document_type_id": "document_type_id",
+      "patient_document_id": "patient_document_id",
+      "mobile_number": "mobile_number",
+      "birthday": "birthday"
+    },
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findpatient/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findpatient/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "document_type_id": {
+      "type": "string",
+      "example": "0"
+    },
+    "patient_document_id": {
+      "type": "string",
+      "example": "518254452520657938"
+    },
+    "mobile_number": {
+      "type": "string",
+      "example": "%2b97100091904"
+    },
+    "birthday": {
+      "type": "string",
+      "example": "1986-05-20"
+    },
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": ""
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findpatient/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findpatient/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "document_type_id": z.string().optional(),
+  "patient_document_id": z.string().optional(),
+  "mobile_number": z.string().optional(),
+  "birthday": z.string().optional(),
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findprovideravailabilitiesstg/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findprovideravailabilitiesstg/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findprovideravailabilitiesstg",
+  "toolDescription": "Find Provider Availabilities Stg",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/availability",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "doctorID": "doctorID",
+      "facilityID": "facilityID",
+      "from": "from",
+      "to": "to"
+    },
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findprovideravailabilitiesstg/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findprovideravailabilitiesstg/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "doctorID": {
+      "type": "string",
+      "example": "112"
+    },
+    "facilityID": {
+      "type": "string",
+      "example": "5"
+    },
+    "from": {
+      "type": "string",
+      "example": "2025-05-15"
+    },
+    "to": {
+      "type": "string",
+      "example": "2025-05-19"
+    },
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": ""
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findprovideravailabilitiesstg/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/findprovideravailabilitiesstg/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "doctorID": z.string().optional(),
+  "facilityID": z.string().optional(),
+  "from": z.string().optional(),
+  "to": z.string().optional(),
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviders/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviders/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "listproviders",
+  "toolDescription": "List Providers",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/doctors",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviders/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviders/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": "04Yumurta92Helva!"
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviders/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviders/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviderservices/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviderservices/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "listproviderservices",
+  "toolDescription": "List Provider Services",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/services",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "doctorID": "doctorID",
+      "facilityID": "facilityID"
+    },
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviderservices/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviderservices/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "doctorID": {
+      "type": "string",
+      "example": "112"
+    },
+    "facilityID": {
+      "type": "string",
+      "example": "5"
+    },
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": "04Yumurta92Helva!"
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviderservices/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/listproviderservices/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "doctorID": z.string().optional(),
+  "facilityID": z.string().optional(),
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/rescheduleappointmentstg/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/rescheduleappointmentstg/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "rescheduleappointmentstg",
+  "toolDescription": "Reschedule Appointment Stg",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/reschedule",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/rescheduleappointmentstg/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/rescheduleappointmentstg/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": "04Yumurta92Helva!"
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/rescheduleappointmentstg/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/rescheduleappointmentstg/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/updatepaymentstatusstg/index.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/updatepaymentstatusstg/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatepaymentstatusstg",
+  "toolDescription": "Update Payment Status Stg",
+  "baseUrl": "https://staging-adh.disc-me.cloud/okadoc/api",
+  "path": "/updatePaymentStatus",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "okadoc-auth-key": "okadoc-auth-key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/updatepaymentstatusstg/schema-json/root.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/updatepaymentstatusstg/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "okadoc-auth-key": {
+      "type": "string",
+      "example": "04Yumurta92Helva!"
+    }
+  },
+  "required": []
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/updatepaymentstatusstg/schema/root.ts
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/src/tools/updatepaymentstatusstg/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "okadoc-auth-key": z.string().optional()
+}

--- a/servers/staging_adh_disc_me_cloud_okadoc_api/tsconfig.json
+++ b/servers/staging_adh_disc_me_cloud_okadoc_api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `staging_adh_disc_me_cloud_okadoc_api`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/staging_adh_disc_me_cloud_okadoc_api`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "staging_adh_disc_me_cloud_okadoc_api": {
      "command": "npx",
      "args": ["-y", "@open-mcp/staging_adh_disc_me_cloud_okadoc_api"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.