### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,285 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### getmunicipality
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `insee` (string)
+
+### getdocument
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getzoneurba
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getsecteurcc
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getprescriptionsurf
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getprescriptionlin
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getprescriptionpct
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getinfosurf
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getinfolin
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getinfopct
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+
+### getactesup
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `partition` (string)
+
+### getassiettesups
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+- `categorie` (string)
+
+### getassiettesupl
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+- `categorie` (string)
+
+### getassiettesupp
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+- `categorie` (string)
+
+### getgenerateursups
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+- `categorie` (string)
+
+### getgenerateursupl
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+- `categorie` (string)
+
+### getgenerateursupp
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `geom` (string)
+- `partition` (string)
+- `categorie` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,22 @@
+export const OPENAPI_URL = "https://apicarto.ign.fr/api/doc/gpu.yml"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getmunicipality/index.js",
+  "./tools/getdocument/index.js",
+  "./tools/getzoneurba/index.js",
+  "./tools/getsecteurcc/index.js",
+  "./tools/getprescriptionsurf/index.js",
+  "./tools/getprescriptionlin/index.js",
+  "./tools/getprescriptionpct/index.js",
+  "./tools/getinfosurf/index.js",
+  "./tools/getinfolin/index.js",
+  "./tools/getinfopct/index.js",
+  "./tools/getactesup/index.js",
+  "./tools/getassiettesups/index.js",
+  "./tools/getassiettesupl/index.js",
+  "./tools/getassiettesupp/index.js",
+  "./tools/getgenerateursups/index.js",
+  "./tools/getgenerateursupl/index.js",
+  "./tools/getgenerateursupp/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/getactesup/index.ts
+++ b/servers/api_example_com/src/tools/getactesup/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getactesup",
+  "toolDescription": "Récupération des actes des servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/acte-sup",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getactesup/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getactesup/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "partition": {
+      "description": "Partition GPU du document",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getactesup/schema/root.ts
+++ b/servers/api_example_com/src/tools/getactesup/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "partition": z.string().describe("Partition GPU du document").optional()
+}

--- a/servers/api_example_com/src/tools/getassiettesupl/index.ts
+++ b/servers/api_example_com/src/tools/getassiettesupl/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getassiettesupl",
+  "toolDescription": "Récupération des assiettes linéaires de servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/assiette-sup-l",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition",
+      "categorie": "categorie"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getassiettesupl/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getassiettesupl/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document",
+      "type": "string"
+    },
+    "categorie": {
+      "description": "Categorie",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getassiettesupl/schema/root.ts
+++ b/servers/api_example_com/src/tools/getassiettesupl/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document").optional(),
+  "categorie": z.string().describe("Categorie").optional()
+}

--- a/servers/api_example_com/src/tools/getassiettesupp/index.ts
+++ b/servers/api_example_com/src/tools/getassiettesupp/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getassiettesupp",
+  "toolDescription": "Récupération des assiettes ponctuelles de servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/assiette-sup-p",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition",
+      "categorie": "categorie"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getassiettesupp/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getassiettesupp/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document",
+      "type": "string"
+    },
+    "categorie": {
+      "description": "Categorie",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getassiettesupp/schema/root.ts
+++ b/servers/api_example_com/src/tools/getassiettesupp/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document").optional(),
+  "categorie": z.string().describe("Categorie").optional()
+}

--- a/servers/api_example_com/src/tools/getassiettesups/index.ts
+++ b/servers/api_example_com/src/tools/getassiettesups/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getassiettesups",
+  "toolDescription": "Récupération des assiettes surfaciques de servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/assiette-sup-s",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition",
+      "categorie": "categorie"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getassiettesups/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getassiettesups/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document",
+      "type": "string"
+    },
+    "categorie": {
+      "description": "Categorie",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getassiettesups/schema/root.ts
+++ b/servers/api_example_com/src/tools/getassiettesups/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document").optional(),
+  "categorie": z.string().describe("Categorie").optional()
+}

--- a/servers/api_example_com/src/tools/getdocument/index.ts
+++ b/servers/api_example_com/src/tools/getdocument/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getdocument",
+  "toolDescription": "Récupération de l'emprise d'un document",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/document",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getdocument/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getdocument/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getdocument/schema/root.ts
+++ b/servers/api_example_com/src/tools/getdocument/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getgenerateursupl/index.ts
+++ b/servers/api_example_com/src/tools/getgenerateursupl/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getgenerateursupl",
+  "toolDescription": "Récupération des générateurs linéaires des servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/generateur-sup-l",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition",
+      "categorie": "categorie"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getgenerateursupl/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getgenerateursupl/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format",
+      "type": "string"
+    },
+    "categorie": {
+      "description": "Categorie",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getgenerateursupl/schema/root.ts
+++ b/servers/api_example_com/src/tools/getgenerateursupl/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format").optional(),
+  "categorie": z.string().describe("Categorie").optional()
+}

--- a/servers/api_example_com/src/tools/getgenerateursupp/index.ts
+++ b/servers/api_example_com/src/tools/getgenerateursupp/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getgenerateursupp",
+  "toolDescription": "Récupération des générateurs ponctuels des servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/generateur-sup-p",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition",
+      "categorie": "categorie"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getgenerateursupp/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getgenerateursupp/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    },
+    "categorie": {
+      "description": "Categorie",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getgenerateursupp/schema/root.ts
+++ b/servers/api_example_com/src/tools/getgenerateursupp/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional(),
+  "categorie": z.string().describe("Categorie").optional()
+}

--- a/servers/api_example_com/src/tools/getgenerateursups/index.ts
+++ b/servers/api_example_com/src/tools/getgenerateursups/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getgenerateursups",
+  "toolDescription": "Récupération des générateurs surfaciques des servitudes d’utilité publique",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/generateur-sup-s",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition",
+      "categorie": "categorie"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getgenerateursups/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getgenerateursups/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document",
+      "type": "string"
+    },
+    "categorie": {
+      "description": "Categorie",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getgenerateursups/schema/root.ts
+++ b/servers/api_example_com/src/tools/getgenerateursups/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document").optional(),
+  "categorie": z.string().describe("Categorie").optional()
+}

--- a/servers/api_example_com/src/tools/getinfolin/index.ts
+++ b/servers/api_example_com/src/tools/getinfolin/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinfolin",
+  "toolDescription": "Récupération des informations linéaires d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/info-lin",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getinfolin/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getinfolin/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getinfolin/schema/root.ts
+++ b/servers/api_example_com/src/tools/getinfolin/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getinfopct/index.ts
+++ b/servers/api_example_com/src/tools/getinfopct/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinfopct",
+  "toolDescription": "Récupération des informations ponctuelles d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/info-pct",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getinfopct/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getinfopct/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getinfopct/schema/root.ts
+++ b/servers/api_example_com/src/tools/getinfopct/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getinfosurf/index.ts
+++ b/servers/api_example_com/src/tools/getinfosurf/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinfosurf",
+  "toolDescription": "Récupération des informations surfaciques d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/info-surf",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getinfosurf/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getinfosurf/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getinfosurf/schema/root.ts
+++ b/servers/api_example_com/src/tools/getinfosurf/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getmunicipality/index.ts
+++ b/servers/api_example_com/src/tools/getmunicipality/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getmunicipality",
+  "toolDescription": "Récupération des informations sur une commune (est au RNU? est supprimée?)",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/municipality",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "insee": "insee"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getmunicipality/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getmunicipality/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "insee": {
+      "description": "Code insee de la commune",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getmunicipality/schema/root.ts
+++ b/servers/api_example_com/src/tools/getmunicipality/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "insee": z.string().describe("Code insee de la commune").optional()
+}

--- a/servers/api_example_com/src/tools/getprescriptionlin/index.ts
+++ b/servers/api_example_com/src/tools/getprescriptionlin/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprescriptionlin",
+  "toolDescription": "Récupération des prescriptions linéaires d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/prescription-lin",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getprescriptionlin/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getprescriptionlin/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getprescriptionlin/schema/root.ts
+++ b/servers/api_example_com/src/tools/getprescriptionlin/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getprescriptionpct/index.ts
+++ b/servers/api_example_com/src/tools/getprescriptionpct/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprescriptionpct",
+  "toolDescription": "Récupération des prescriptions ponctuelles d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/prescription-pct",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getprescriptionpct/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getprescriptionpct/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getprescriptionpct/schema/root.ts
+++ b/servers/api_example_com/src/tools/getprescriptionpct/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getprescriptionsurf/index.ts
+++ b/servers/api_example_com/src/tools/getprescriptionsurf/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getprescriptionsurf",
+  "toolDescription": "Récupération des prescriptions surfaciques d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/prescription-surf",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getprescriptionsurf/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getprescriptionsurf/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getprescriptionsurf/schema/root.ts
+++ b/servers/api_example_com/src/tools/getprescriptionsurf/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getsecteurcc/index.ts
+++ b/servers/api_example_com/src/tools/getsecteurcc/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getsecteurcc",
+  "toolDescription": "Récupération des secteurs d’une carte communale",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/secteur-cc",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getsecteurcc/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getsecteurcc/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getsecteurcc/schema/root.ts
+++ b/servers/api_example_com/src/tools/getsecteurcc/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/src/tools/getzoneurba/index.ts
+++ b/servers/api_example_com/src/tools/getzoneurba/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getzoneurba",
+  "toolDescription": "Récupération des zonages d’un document d’urbanisme",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/gpu/zone-urba",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "geom": "geom",
+      "partition": "partition"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getzoneurba/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getzoneurba/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "geom": {
+      "description": "Géométrie GeoJSON utilisée pour la recherche",
+      "type": "string"
+    },
+    "partition": {
+      "description": "Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getzoneurba/schema/root.ts
+++ b/servers/api_example_com/src/tools/getzoneurba/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "geom": z.string().describe("Géométrie GeoJSON utilisée pour la recherche").optional(),
+  "partition": z.string().describe("Partition GPU du document au format <DU/PSMV>_<INSEE/SIREN>").optional()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.