### PR TITLE
Add MCP server `localhost_2025`

### DIFF
--- a/servers/localhost_2025/.npmignore
+++ b/servers/localhost_2025/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/localhost_2025/README.md
+++ b/servers/localhost_2025/README.md
@@ -1,0 +1,270 @@
+# @open-mcp/localhost_2025
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "localhost_2025": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/localhost_2025@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/localhost_2025@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add localhost_2025 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add localhost_2025 \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add localhost_2025 \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "localhost_2025": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/localhost_2025"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### getrecord
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+
+### create
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `userId` (string)
+- `title` (string)
+- `content` (string)
+- `url` (string)
+- `status` (integer)
+- `redirectType` (integer)
+- `redirectUrl` (string)
+
+### delete
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+
+### getpagelist
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `pageable` (object)
+- `pageDTO` (object)
+
+### completions
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `model` (string)
+- `messages` (array)
+- `frequency_penalty` (integer)
+- `n` (integer)
+- `presence_penalty` (integer)
+- `stream` (boolean)
+- `temperature` (integer)
+- `top_p` (integer)
+
+### upload
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### login
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `username` (string)
+- `password` (string)
+- `grantType` (string)
+
+### getrecord_1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+
+### update
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+- `b_id` (string)
+- `userId` (string)
+- `phoneNumber` (string)
+- `name` (string)
+- `contractAmount` (number)
+- `approvalStatus` (integer)
+
+### create_1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `userId` (string)
+- `phoneNumber` (string)
+- `name` (string)
+- `contractAmount` (number)
+- `approvalStatus` (integer)
+
+### delete_1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+
+### audit
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `id` (integer)
+- `b_id` (string)
+- `userId` (string)
+- `phoneNumber` (string)
+- `name` (string)
+- `contractAmount` (number)
+- `approvalStatus` (integer)
+
+### getpagelist_1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `pageable` (object)
+- `pageDTO` (object)
+
+### ad
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `prompt` (string)
+- `deviceId` (string)

--- a/servers/localhost_2025/package.json
+++ b/servers/localhost_2025/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/localhost_2025",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "localhost_2025": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/localhost_2025/src/constants.ts
+++ b/servers/localhost_2025/src/constants.ts
@@ -1,0 +1,19 @@
+export const OPENAPI_URL = "http://59.110.30.185:2025/swagger/micronaut-ai-prod-1.0.0.yml"
+export const SERVER_NAME = "localhost_2025"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getrecord/index.js",
+  "./tools/create/index.js",
+  "./tools/delete/index.js",
+  "./tools/getpagelist/index.js",
+  "./tools/completions/index.js",
+  "./tools/upload/index.js",
+  "./tools/login/index.js",
+  "./tools/getrecord_1/index.js",
+  "./tools/update/index.js",
+  "./tools/create_1/index.js",
+  "./tools/delete_1/index.js",
+  "./tools/audit/index.js",
+  "./tools/getpagelist_1/index.js",
+  "./tools/ad/index.js"
+]

--- a/servers/localhost_2025/src/index.ts
+++ b/servers/localhost_2025/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/localhost_2025/src/server.ts
+++ b/servers/localhost_2025/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/localhost_2025/src/tools/ad/index.ts
+++ b/servers/localhost_2025/src/tools/ad/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "ad",
+  "toolDescription": "[查询]推荐广告",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/recommend/ad",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "prompt": "prompt",
+      "deviceId": "deviceId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/ad/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/ad/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "prompt": {
+      "type": "string",
+      "description": "关键词[重庆有哪些美食]",
+      "nullable": true,
+      "example": "重庆有哪些美食"
+    },
+    "deviceId": {
+      "type": "string",
+      "description": "设备ID[123456]",
+      "nullable": true,
+      "example": "123456"
+    }
+  },
+  "required": [
+    "prompt",
+    "deviceId"
+  ]
+}

--- a/servers/localhost_2025/src/tools/ad/schema/root.ts
+++ b/servers/localhost_2025/src/tools/ad/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prompt": z.string().nullable().describe("关键词[重庆有哪些美食]"),
+  "deviceId": z.string().nullable().describe("设备ID[123456]")
+}

--- a/servers/localhost_2025/src/tools/audit/index.ts
+++ b/servers/localhost_2025/src/tools/audit/index.ts
@@ -1,0 +1,34 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "audit",
+  "toolDescription": "[更新]审核记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/pre_order/audit",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    },
+    "body": {
+      "id": "b_id",
+      "userId": "userId",
+      "phoneNumber": "phoneNumber",
+      "name": "name",
+      "contractAmount": "contractAmount",
+      "approvalStatus": "approvalStatus"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/audit/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/audit/schema-json/root.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "唯一ID",
+      "type": "integer",
+      "format": "int64",
+      "x-not-null-message": "[id]不能为空"
+    },
+    "b_id": {
+      "type": "string",
+      "description": "唯一标识符[111111]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "userId": {
+      "type": "string",
+      "description": "用户ID[22222]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "description": "手机号码[17011112222]",
+      "nullable": true,
+      "example": "17011112222"
+    },
+    "name": {
+      "type": "string",
+      "description": "名字[张三丰]",
+      "nullable": true,
+      "example": "张三丰"
+    },
+    "contractAmount": {
+      "type": "number",
+      "description": "合同金额[1999]",
+      "nullable": true,
+      "example": 1
+    },
+    "approvalStatus": {
+      "type": "integer",
+      "description": "审核状态[1-待审核,2-审核通过,3-已驳回]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/localhost_2025/src/tools/audit/schema/root.ts
+++ b/servers/localhost_2025/src/tools/audit/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("唯一ID"),
+  "b_id": z.string().nullable().describe("唯一标识符[111111]").optional(),
+  "userId": z.string().nullable().describe("用户ID[22222]").optional(),
+  "phoneNumber": z.string().nullable().describe("手机号码[17011112222]").optional(),
+  "name": z.string().nullable().describe("名字[张三丰]").optional(),
+  "contractAmount": z.number().nullable().describe("合同金额[1999]").optional(),
+  "approvalStatus": z.number().int().nullable().describe("审核状态[1-待审核,2-审核通过,3-已驳回]").optional()
+}

--- a/servers/localhost_2025/src/tools/completions/index.ts
+++ b/servers/localhost_2025/src/tools/completions/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "completions",
+  "toolDescription": "[chat]生成式AI聊天",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/chat/completions",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "model": "model",
+      "messages": "messages",
+      "frequency_penalty": "frequency_penalty",
+      "n": "n",
+      "presence_penalty": "presence_penalty",
+      "stream": "stream",
+      "temperature": "temperature",
+      "top_p": "top_p"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/completions/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/completions/schema-json/root.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string"
+    },
+    "messages": {
+      "type": "array",
+      "items": {
+        "required": [
+          "role"
+        ],
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      }
+    },
+    "frequency_penalty": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "n": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "presence_penalty": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "stream": {
+      "type": "boolean"
+    },
+    "temperature": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "top_p": {
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "required": [
+    "model",
+    "messages",
+    "frequency_penalty",
+    "n",
+    "presence_penalty",
+    "stream",
+    "temperature",
+    "top_p"
+  ]
+}

--- a/servers/localhost_2025/src/tools/completions/schema/root.ts
+++ b/servers/localhost_2025/src/tools/completions/schema/root.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "model": z.string(),
+  "messages": z.array(z.object({ "role": z.string(), "content": z.string().nullable().optional() })),
+  "frequency_penalty": z.number().int(),
+  "n": z.number().int(),
+  "presence_penalty": z.number().int(),
+  "stream": z.boolean(),
+  "temperature": z.number().int(),
+  "top_p": z.number().int()
+}

--- a/servers/localhost_2025/src/tools/create/index.ts
+++ b/servers/localhost_2025/src/tools/create/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create",
+  "toolDescription": "[新增]创建单条记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/ad",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "userId": "userId",
+      "title": "title",
+      "content": "content",
+      "url": "url",
+      "status": "status",
+      "redirectType": "redirectType",
+      "redirectUrl": "redirectUrl"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/create/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/create/schema-json/root.json
@@ -1,0 +1,74 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "type": "string",
+      "description": "用户ID[22222]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "title": {
+      "maxLength": 1024,
+      "minLength": 2,
+      "pattern": "\\S*",
+      "type": "string",
+      "description": "标题[成都冬瓜火锅]",
+      "example": "成都冬瓜火锅",
+      "x-pattern-message": "[标题]不符合规则",
+      "x-size-message": "[标题]长度范围2-64"
+    },
+    "content": {
+      "maxLength": 1024,
+      "minLength": 2,
+      "pattern": "\\S*",
+      "type": "string",
+      "description": "标题[成都冬瓜火锅]",
+      "example": "成都冬瓜火锅",
+      "x-pattern-message": "[标题]不符合规则",
+      "x-size-message": "[标题]长度范围2-64"
+    },
+    "url": {
+      "maxLength": 1024,
+      "minLength": 2,
+      "pattern": "\\S*",
+      "type": "string",
+      "description": "广告图片[https://picsum.photos/400/300?random=1]",
+      "example": "https://picsum.photos/400/300?random=1",
+      "x-pattern-message": "[广告图片]不符合规则",
+      "x-size-message": "[广告图片]长度范围2-1024"
+    },
+    "status": {
+      "type": "integer",
+      "description": "审核状态[1-待审核,2-审核通过,3-已驳回]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    },
+    "redirectType": {
+      "type": "integer",
+      "description": "跳转链接类型[1-站点,2-app]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    },
+    "redirectUrl": {
+      "maxLength": 1024,
+      "minLength": 2,
+      "pattern": "\\S*",
+      "type": "string",
+      "description": "链接[weixin://dl/business/?t=1641024000&appid=wx35eba38d6762427a&path=pages/index/index%3Fid%3D123&ENV_VERSION=develop]",
+      "example": "weixin://dl/business/?t=1641024000&appid=wx35eba38d6762427a&path=pages/index/index%3Fid%3D123&ENV_VERSION=develop",
+      "x-pattern-message": "[链接]不符合规则",
+      "x-size-message": "[链接]长度范围2-64"
+    }
+  },
+  "required": [
+    "userId",
+    "title",
+    "content",
+    "url",
+    "status",
+    "redirectType",
+    "redirectUrl"
+  ]
+}

--- a/servers/localhost_2025/src/tools/create/schema/root.ts
+++ b/servers/localhost_2025/src/tools/create/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().nullable().describe("用户ID[22222]"),
+  "title": z.string().regex(new RegExp("\\S*")).min(2).max(1024).describe("标题[成都冬瓜火锅]"),
+  "content": z.string().regex(new RegExp("\\S*")).min(2).max(1024).describe("标题[成都冬瓜火锅]"),
+  "url": z.string().regex(new RegExp("\\S*")).min(2).max(1024).describe("广告图片[https://picsum.photos/400/300?random=1]"),
+  "status": z.number().int().nullable().describe("审核状态[1-待审核,2-审核通过,3-已驳回]"),
+  "redirectType": z.number().int().nullable().describe("跳转链接类型[1-站点,2-app]"),
+  "redirectUrl": z.string().regex(new RegExp("\\S*")).min(2).max(1024).describe("链接[weixin://dl/business/?t=1641024000&appid=wx35eba38d6762427a&path=pages/index/index%3Fid%3D123&ENV_VERSION=develop]")
+}

--- a/servers/localhost_2025/src/tools/create_1/index.ts
+++ b/servers/localhost_2025/src/tools/create_1/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_1",
+  "toolDescription": "[新增]创建单条记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/pre_order",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "userId": "userId",
+      "phoneNumber": "phoneNumber",
+      "name": "name",
+      "contractAmount": "contractAmount",
+      "approvalStatus": "approvalStatus"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/create_1/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/create_1/schema-json/root.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "type": "string",
+      "description": "用户ID[22222]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "phoneNumber": {
+      "maxLength": 64,
+      "minLength": 2,
+      "pattern": "\\S*",
+      "type": "string",
+      "description": "手机号码[17011112222]",
+      "example": "17011112222",
+      "x-pattern-message": "[手机号码]不符合规则",
+      "x-size-message": "[手机号码]长度范围2-64"
+    },
+    "name": {
+      "maxLength": 64,
+      "minLength": 2,
+      "pattern": "\\S*",
+      "type": "string",
+      "description": "名字[张三丰]",
+      "example": "张三丰",
+      "x-pattern-message": "[名字]不符合规则",
+      "x-size-message": "[名字]长度范围2-64"
+    },
+    "contractAmount": {
+      "type": "number",
+      "description": "合同金额[1999]",
+      "nullable": true,
+      "example": 1
+    },
+    "approvalStatus": {
+      "type": "integer",
+      "description": "审核状态[1-待审核,2-审核通过,3-已驳回]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    }
+  },
+  "required": [
+    "userId",
+    "phoneNumber",
+    "name",
+    "contractAmount",
+    "approvalStatus"
+  ]
+}

--- a/servers/localhost_2025/src/tools/create_1/schema/root.ts
+++ b/servers/localhost_2025/src/tools/create_1/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().nullable().describe("用户ID[22222]"),
+  "phoneNumber": z.string().regex(new RegExp("\\S*")).min(2).max(64).describe("手机号码[17011112222]"),
+  "name": z.string().regex(new RegExp("\\S*")).min(2).max(64).describe("名字[张三丰]"),
+  "contractAmount": z.number().nullable().describe("合同金额[1999]"),
+  "approvalStatus": z.number().int().nullable().describe("审核状态[1-待审核,2-审核通过,3-已驳回]")
+}

--- a/servers/localhost_2025/src/tools/delete/index.ts
+++ b/servers/localhost_2025/src/tools/delete/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete",
+  "toolDescription": "[删除]彻底删除单条记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/ad",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/delete/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/delete/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "唯一ID",
+      "type": "integer",
+      "format": "int64",
+      "x-not-null-message": "[id]不能为空"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/localhost_2025/src/tools/delete/schema/root.ts
+++ b/servers/localhost_2025/src/tools/delete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("唯一ID")
+}

--- a/servers/localhost_2025/src/tools/delete_1/index.ts
+++ b/servers/localhost_2025/src/tools/delete_1/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_1",
+  "toolDescription": "[删除]彻底删除单条记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/pre_order",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/delete_1/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/delete_1/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "唯一ID",
+      "type": "integer",
+      "format": "int64",
+      "x-not-null-message": "[id]不能为空"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/localhost_2025/src/tools/delete_1/schema/root.ts
+++ b/servers/localhost_2025/src/tools/delete_1/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("唯一ID")
+}

--- a/servers/localhost_2025/src/tools/getpagelist/index.ts
+++ b/servers/localhost_2025/src/tools/getpagelist/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpagelist",
+  "toolDescription": "[查询]分页查询记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/ad/page",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "pageable": "pageable",
+      "pageDTO": "pageDTO"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/getpagelist/schema-json/properties/pageDTO.json
+++ b/servers/localhost_2025/src/tools/getpagelist/schema-json/properties/pageDTO.json
@@ -1,0 +1,55 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "唯一标识符[1111]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "userId": {
+      "type": "string",
+      "description": "用户ID[22222]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "title": {
+      "type": "string",
+      "description": "标题[成都冬瓜火锅]",
+      "nullable": true,
+      "example": "成都冬瓜火锅"
+    },
+    "content": {
+      "type": "string",
+      "description": "标题[成都冬瓜火锅]",
+      "nullable": true,
+      "example": "成都冬瓜火锅"
+    },
+    "url": {
+      "type": "string",
+      "description": "广告图片[https://picsum.photos/400/300?random=1]",
+      "nullable": true,
+      "example": "https://picsum.photos/400/300?random=1"
+    },
+    "status": {
+      "type": "integer",
+      "description": "审核状态[1-待审核,2-审核通过,3-已驳回]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    },
+    "redirectType": {
+      "type": "integer",
+      "description": "跳转链接类型[1-站点,2-app]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    },
+    "redirectUrl": {
+      "type": "string",
+      "description": "链接[weixin://dl/business/?t=1641024000&appid=wx35eba38d6762427a&path=pages/index/index%3Fid%3D123&ENV_VERSION=develop]",
+      "nullable": true,
+      "example": "weixin://dl/business/?t=1641024000&appid=wx35eba38d6762427a&path=pages/index/index%3Fid%3D123&ENV_VERSION=develop"
+    }
+  }
+}

--- a/servers/localhost_2025/src/tools/getpagelist/schema-json/properties/pageable.json
+++ b/servers/localhost_2025/src/tools/getpagelist/schema-json/properties/pageable.json
@@ -1,0 +1,51 @@
+{
+  "required": [
+    "page",
+    "size"
+  ],
+  "type": "object",
+  "properties": {
+    "page": {
+      "minimum": 0,
+      "exclusiveMinimum": true,
+      "required": [
+        "true"
+      ],
+      "type": "integer",
+      "description": "页码[1]",
+      "format": "int32",
+      "example": 1,
+      "default": 1,
+      "x-minimum-message": "[页码]必须大于1"
+    },
+    "size": {
+      "minimum": 0,
+      "exclusiveMinimum": true,
+      "required": [
+        "true"
+      ],
+      "type": "integer",
+      "description": "分页大小[20]",
+      "format": "int32",
+      "example": 20,
+      "default": 20,
+      "x-minimum-message": "[分页大小]必须大于2"
+    },
+    "sort": {
+      "required": [
+        "false"
+      ],
+      "type": "array",
+      "description": "id,DESC|id,ASC",
+      "example": "id,DESC",
+      "items": {
+        "required": [
+          "false"
+        ],
+        "type": "string",
+        "description": "id,DESC|id,ASC",
+        "example": "id,DESC"
+      }
+    }
+  }
+}

--- a/servers/localhost_2025/src/tools/getpagelist/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/getpagelist/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "pageable": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "pageDTO": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageDTO` to the tool, first call the tool `expandSchema` with \"/properties/pageDTO\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "pageable",
+    "pageDTO"
+  ]
+}

--- a/servers/localhost_2025/src/tools/getpagelist/schema/properties/pageDTO.ts
+++ b/servers/localhost_2025/src/tools/getpagelist/schema/properties/pageDTO.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().nullable().describe("唯一标识符[1111]").optional(),
+  "userId": z.string().nullable().describe("用户ID[22222]").optional(),
+  "title": z.string().nullable().describe("标题[成都冬瓜火锅]").optional(),
+  "content": z.string().nullable().describe("标题[成都冬瓜火锅]").optional(),
+  "url": z.string().nullable().describe("广告图片[https://picsum.photos/400/300?random=1]").optional(),
+  "status": z.number().int().nullable().describe("审核状态[1-待审核,2-审核通过,3-已驳回]").optional(),
+  "redirectType": z.number().int().nullable().describe("跳转链接类型[1-站点,2-app]").optional(),
+  "redirectUrl": z.string().nullable().describe("链接[weixin://dl/business/?t=1641024000&appid=wx35eba38d6762427a&path=pages/index/index%3Fid%3D123&ENV_VERSION=develop]").optional()
+}

--- a/servers/localhost_2025/src/tools/getpagelist/schema/properties/pageable.ts
+++ b/servers/localhost_2025/src/tools/getpagelist/schema/properties/pageable.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().int().gt(0).describe("页码[1]"),
+  "size": z.number().int().gt(0).describe("分页大小[20]"),
+  "sort": z.array(z.string().describe("id,DESC|id,ASC")).describe("id,DESC|id,ASC").optional()
+}

--- a/servers/localhost_2025/src/tools/getpagelist/schema/root.ts
+++ b/servers/localhost_2025/src/tools/getpagelist/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pageable": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>"),
+  "pageDTO": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageDTO` to the tool, first call the tool `expandSchema` with \"/properties/pageDTO\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/localhost_2025/src/tools/getpagelist_1/index.ts
+++ b/servers/localhost_2025/src/tools/getpagelist_1/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpagelist_1",
+  "toolDescription": "[查询]分页查询记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/pre_order/page",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "pageable": "pageable",
+      "pageDTO": "pageDTO"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/getpagelist_1/schema-json/properties/pageDTO.json
+++ b/servers/localhost_2025/src/tools/getpagelist_1/schema-json/properties/pageDTO.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "唯一标识符[111111]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "userId": {
+      "type": "string",
+      "description": "用户ID[22222]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "description": "手机号码[17011112222]",
+      "nullable": true,
+      "example": "17011112222"
+    },
+    "name": {
+      "type": "string",
+      "description": "名字[张三丰]",
+      "nullable": true,
+      "example": "张三丰"
+    },
+    "contractAmount": {
+      "type": "number",
+      "description": "合同金额[1999]",
+      "nullable": true,
+      "example": 1
+    },
+    "approvalStatus": {
+      "type": "integer",
+      "description": "审核状态[1-待审核,2-审核通过,3-已驳回]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    }
+  }
+}

--- a/servers/localhost_2025/src/tools/getpagelist_1/schema-json/properties/pageable.json
+++ b/servers/localhost_2025/src/tools/getpagelist_1/schema-json/properties/pageable.json
@@ -1,0 +1,51 @@
+{
+  "required": [
+    "page",
+    "size"
+  ],
+  "type": "object",
+  "properties": {
+    "page": {
+      "minimum": 0,
+      "exclusiveMinimum": true,
+      "required": [
+        "true"
+      ],
+      "type": "integer",
+      "description": "页码[1]",
+      "format": "int32",
+      "example": 1,
+      "default": 1,
+      "x-minimum-message": "[页码]必须大于1"
+    },
+    "size": {
+      "minimum": 0,
+      "exclusiveMinimum": true,
+      "required": [
+        "true"
+      ],
+      "type": "integer",
+      "description": "分页大小[20]",
+      "format": "int32",
+      "example": 20,
+      "default": 20,
+      "x-minimum-message": "[分页大小]必须大于2"
+    },
+    "sort": {
+      "required": [
+        "false"
+      ],
+      "type": "array",
+      "description": "id,DESC|id,ASC",
+      "example": "id,DESC",
+      "items": {
+        "required": [
+          "false"
+        ],
+        "type": "string",
+        "description": "id,DESC|id,ASC",
+        "example": "id,DESC"
+      }
+    }
+  }
+}

--- a/servers/localhost_2025/src/tools/getpagelist_1/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/getpagelist_1/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "pageable": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "pageDTO": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageDTO` to the tool, first call the tool `expandSchema` with \"/properties/pageDTO\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "pageable",
+    "pageDTO"
+  ]
+}

--- a/servers/localhost_2025/src/tools/getpagelist_1/schema/properties/pageDTO.ts
+++ b/servers/localhost_2025/src/tools/getpagelist_1/schema/properties/pageDTO.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().nullable().describe("唯一标识符[111111]").optional(),
+  "userId": z.string().nullable().describe("用户ID[22222]").optional(),
+  "phoneNumber": z.string().nullable().describe("手机号码[17011112222]").optional(),
+  "name": z.string().nullable().describe("名字[张三丰]").optional(),
+  "contractAmount": z.number().nullable().describe("合同金额[1999]").optional(),
+  "approvalStatus": z.number().int().nullable().describe("审核状态[1-待审核,2-审核通过,3-已驳回]").optional()
+}

--- a/servers/localhost_2025/src/tools/getpagelist_1/schema/properties/pageable.ts
+++ b/servers/localhost_2025/src/tools/getpagelist_1/schema/properties/pageable.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().int().gt(0).describe("页码[1]"),
+  "size": z.number().int().gt(0).describe("分页大小[20]"),
+  "sort": z.array(z.string().describe("id,DESC|id,ASC")).describe("id,DESC|id,ASC").optional()
+}

--- a/servers/localhost_2025/src/tools/getpagelist_1/schema/root.ts
+++ b/servers/localhost_2025/src/tools/getpagelist_1/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pageable": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>"),
+  "pageDTO": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageDTO` to the tool, first call the tool `expandSchema` with \"/properties/pageDTO\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/localhost_2025/src/tools/getrecord/index.ts
+++ b/servers/localhost_2025/src/tools/getrecord/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getrecord",
+  "toolDescription": "[查询]id查询单条记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/ad",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/getrecord/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/getrecord/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "唯一ID",
+      "type": "integer",
+      "format": "int64",
+      "x-not-null-message": "[id]不能为空"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/localhost_2025/src/tools/getrecord/schema/root.ts
+++ b/servers/localhost_2025/src/tools/getrecord/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("唯一ID")
+}

--- a/servers/localhost_2025/src/tools/getrecord_1/index.ts
+++ b/servers/localhost_2025/src/tools/getrecord_1/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getrecord_1",
+  "toolDescription": "[查询]id查询单条记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/pre_order",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/getrecord_1/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/getrecord_1/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "唯一ID",
+      "type": "integer",
+      "format": "int64",
+      "x-not-null-message": "[id]不能为空"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/localhost_2025/src/tools/getrecord_1/schema/root.ts
+++ b/servers/localhost_2025/src/tools/getrecord_1/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("唯一ID")
+}

--- a/servers/localhost_2025/src/tools/login/index.ts
+++ b/servers/localhost_2025/src/tools/login/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "login",
+  "toolDescription": "[登录]密码登录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/oauth2/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "username": "username",
+      "password": "password",
+      "grantType": "grantType"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/login/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/login/schema-json/root.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "maxLength": 20,
+      "minLength": 5,
+      "pattern": "^[a-zA-Z0-9_-]{5,20}$",
+      "type": "string",
+      "description": "用户名称",
+      "example": "15100000000",
+      "x-pattern-message": "[用户名称]限制5-20位字母和数字",
+      "x-size-message": "[用户名称]5-20位"
+    },
+    "password": {
+      "maxLength": 20,
+      "minLength": 6,
+      "pattern": "^[a-zA-Z0-9_-]{6,32}$",
+      "type": "string",
+      "description": "密码",
+      "nullable": true,
+      "example": "a151000",
+      "x-pattern-message": "[密码]限制5-32位字母和数字",
+      "x-size-message": "[密码]限制6-32位"
+    },
+    "grantType": {
+      "minLength": 1,
+      "type": "string",
+      "description": "授权模式",
+      "example": "password",
+      "enum": [
+        "password",
+        "verify_code",
+        "refresh_token",
+        "wx_cp",
+        "wx_mp",
+        "wx_ma",
+        "wx_app"
+      ],
+      "x-size-message": "[grantType]不能为空"
+    }
+  },
+  "required": [
+    "username",
+    "password",
+    "grantType"
+  ]
+}

--- a/servers/localhost_2025/src/tools/login/schema/root.ts
+++ b/servers/localhost_2025/src/tools/login/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().regex(new RegExp("^[a-zA-Z0-9_-]{5,20}$")).min(5).max(20).describe("用户名称"),
+  "password": z.string().regex(new RegExp("^[a-zA-Z0-9_-]{6,32}$")).min(6).max(20).nullable().describe("密码"),
+  "grantType": z.enum(["password","verify_code","refresh_token","wx_cp","wx_mp","wx_ma","wx_app"]).describe("授权模式")
+}

--- a/servers/localhost_2025/src/tools/update/index.ts
+++ b/servers/localhost_2025/src/tools/update/index.ts
@@ -1,0 +1,34 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "update",
+  "toolDescription": "[更新]更新记录",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/pre_order",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    },
+    "body": {
+      "id": "b_id",
+      "userId": "userId",
+      "phoneNumber": "phoneNumber",
+      "name": "name",
+      "contractAmount": "contractAmount",
+      "approvalStatus": "approvalStatus"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/update/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/update/schema-json/root.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "唯一ID",
+      "type": "integer",
+      "format": "int64",
+      "x-not-null-message": "[id]不能为空"
+    },
+    "b_id": {
+      "type": "string",
+      "description": "唯一标识符[111111]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "userId": {
+      "type": "string",
+      "description": "用户ID[22222]",
+      "nullable": true,
+      "example": "1339468674200637453"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "description": "手机号码[17011112222]",
+      "nullable": true,
+      "example": "17011112222"
+    },
+    "name": {
+      "type": "string",
+      "description": "名字[张三丰]",
+      "nullable": true,
+      "example": "张三丰"
+    },
+    "contractAmount": {
+      "type": "number",
+      "description": "合同金额[1999]",
+      "nullable": true,
+      "example": 1
+    },
+    "approvalStatus": {
+      "type": "integer",
+      "description": "审核状态[1-待审核,2-审核通过,3-已驳回]",
+      "format": "int32",
+      "nullable": true,
+      "example": 1
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/localhost_2025/src/tools/update/schema/root.ts
+++ b/servers/localhost_2025/src/tools/update/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("唯一ID"),
+  "b_id": z.string().nullable().describe("唯一标识符[111111]").optional(),
+  "userId": z.string().nullable().describe("用户ID[22222]").optional(),
+  "phoneNumber": z.string().nullable().describe("手机号码[17011112222]").optional(),
+  "name": z.string().nullable().describe("名字[张三丰]").optional(),
+  "contractAmount": z.number().nullable().describe("合同金额[1999]").optional(),
+  "approvalStatus": z.number().int().nullable().describe("审核状态[1-待审核,2-审核通过,3-已驳回]").optional()
+}

--- a/servers/localhost_2025/src/tools/upload/index.ts
+++ b/servers/localhost_2025/src/tools/upload/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "upload",
+  "toolDescription": "[新增]上传图片文件",
+  "baseUrl": "http://localhost:2025",
+  "path": "/v1/file",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/localhost_2025/src/tools/upload/schema-json/root.json
+++ b/servers/localhost_2025/src/tools/upload/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/localhost_2025/src/tools/upload/schema/root.ts
+++ b/servers/localhost_2025/src/tools/upload/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/localhost_2025/tsconfig.json
+++ b/servers/localhost_2025/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `localhost_2025`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/localhost_2025`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "localhost_2025": {
      "command": "npx",
      "args": ["-y", "@open-mcp/localhost_2025"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.