### PR TITLE
Add MCP server `www_wrike_com_app_wrike_v2_web`

### DIFF
--- a/servers/www_wrike_com_app_wrike_v2_web/.npmignore
+++ b/servers/www_wrike_com_app_wrike_v2_web/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/www_wrike_com_app_wrike_v2_web/README.md
+++ b/servers/www_wrike_com_app_wrike_v2_web/README.md
@@ -1,0 +1,373 @@
+# @open-mcp/www_wrike_com_app_wrike_v2_web
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "www_wrike_com_app_wrike_v2_web": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/www_wrike_com_app_wrike_v2_web@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/www_wrike_com_app_wrike_v2_web@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add www_wrike_com_app_wrike_v2_web \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add www_wrike_com_app_wrike_v2_web \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add www_wrike_com_app_wrike_v2_web \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "www_wrike_com_app_wrike_v2_web": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/www_wrike_com_app_wrike_v2_web"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### finddatabases
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `Pagination` (object)
+- `databaseIds` (array)
+
+### databasepost
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `requestId` (string)
+- `title` (string)
+- `databaseRecordName` (string)
+- `parentFolderId` (string)
+
+### finddatabase
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+
+### deletedatabase
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+
+### updatedatabase
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `title` (string)
+- `parentFolderId` (string)
+
+### findfolderdatabases
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `folderId` (string)
+- `Pagination` (object)
+- `databaseIds` (array)
+
+### findfields
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `Pagination` (object)
+- `fieldIds` (array)
+
+### createfield
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+
+### findfield
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `fieldId` (string)
+
+### deletefield
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `fieldId` (string)
+
+### updatefield
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `fieldId` (string)
+
+### findfolders
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `Pagination` (object)
+- `folderIds` (array)
+- `withDescendants` (boolean)
+
+### folderspost
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `requestId` (string)
+- `title` (string)
+- `parentFolderId` (string)
+
+### findfolder
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `folderId` (string)
+
+### deletefolder
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `folderId` (string)
+
+### updatefolder
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `folderId` (string)
+- `title` (string)
+- `parentFolderId` (string)
+
+### findsubfolders
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `folderId` (string)
+- `Pagination` (object)
+- `folderIds` (array)
+
+### findrecords
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `Pagination` (object)
+- `recordIds` (array)
+- `filter` (string)
+- `searchQuery` (string)
+- `fieldIds` (array)
+
+### createrecords
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `fieldIds` (array)
+- `requestId` (string)
+- `data` (array)
+
+### deleterecords
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `recordIds` (array)
+
+### updaterecords
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `fieldIds` (array)
+
+### findrecord
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `recordId` (string)
+- `fieldIds` (array)
+
+### updaterecord
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `databaseId` (string)
+- `recordId` (string)
+- `fieldIds` (array)
+- `title` (string)
+- `fieldValues` (object)
+
+### getrootfolder
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `spaceId` (string)

--- a/servers/www_wrike_com_app_wrike_v2_web/package.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/www_wrike_com_app_wrike_v2_web",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "www_wrike_com_app_wrike_v2_web": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/constants.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/constants.ts
@@ -1,0 +1,29 @@
+export const OPENAPI_URL = "https://developers.wrike.com/uploads/256c09c4-0c36-47f9-918a-b9f639de61c6/datahub-public-api-swagger-schema.yml"
+export const SERVER_NAME = "www_wrike_com_app_wrike_v2_web"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/finddatabases/index.js",
+  "./tools/databasepost/index.js",
+  "./tools/finddatabase/index.js",
+  "./tools/deletedatabase/index.js",
+  "./tools/updatedatabase/index.js",
+  "./tools/findfolderdatabases/index.js",
+  "./tools/findfields/index.js",
+  "./tools/createfield/index.js",
+  "./tools/findfield/index.js",
+  "./tools/deletefield/index.js",
+  "./tools/updatefield/index.js",
+  "./tools/findfolders/index.js",
+  "./tools/folderspost/index.js",
+  "./tools/findfolder/index.js",
+  "./tools/deletefolder/index.js",
+  "./tools/updatefolder/index.js",
+  "./tools/findsubfolders/index.js",
+  "./tools/findrecords/index.js",
+  "./tools/createrecords/index.js",
+  "./tools/deleterecords/index.js",
+  "./tools/updaterecords/index.js",
+  "./tools/findrecord/index.js",
+  "./tools/updaterecord/index.js",
+  "./tools/getrootfolder/index.js"
+]

--- a/servers/www_wrike_com_app_wrike_v2_web/src/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/www_wrike_com_app_wrike_v2_web/src/server.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/createfield/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/createfield/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createfield",
+  "toolDescription": "Create a new database field (property)",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/fields",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/createfield/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/createfield/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/createfield/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/createfield/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/createrecords/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/createrecords/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createrecords",
+  "toolDescription": "Create some new records",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/records",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    },
+    "query": {
+      "fieldIds": "fieldIds"
+    },
+    "body": {
+      "requestId": "requestId",
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/createrecords/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/createrecords/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "fieldIds": {
+      "description": "Columns (properties) to be loaded in the result",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "requestId": {
+      "type": "string",
+      "description": "Should be any unique value, e.g. UUID, current timestamp etc"
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "required": [
+          "fieldValues",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "fieldValues": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "databaseId",
+    "requestId",
+    "data"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/createrecords/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/createrecords/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "fieldIds": z.array(z.string()).describe("Columns (properties) to be loaded in the result").optional(),
+  "requestId": z.string().describe("Should be any unique value, e.g. UUID, current timestamp etc"),
+  "data": z.array(z.object({ "title": z.string(), "fieldValues": z.record(z.any()) }))
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/databasepost/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/databasepost/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "databasepost",
+  "toolDescription": "Create a new database within a given folder",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "requestId": "requestId",
+      "title": "title",
+      "databaseRecordName": "databaseRecordName",
+      "parentFolderId": "parentFolderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/databasepost/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/databasepost/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "requestId": {
+      "type": "string",
+      "description": "Should  be any unique value, e.g. UUID, current timestamp etc"
+    },
+    "title": {
+      "type": "string"
+    },
+    "databaseRecordName": {
+      "type": "string"
+    },
+    "parentFolderId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "requestId",
+    "title",
+    "parentFolderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/databasepost/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/databasepost/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "requestId": z.string().describe("Should  be any unique value, e.g. UUID, current timestamp etc"),
+  "title": z.string(),
+  "databaseRecordName": z.string().optional(),
+  "parentFolderId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletedatabase/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletedatabase/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletedatabase",
+  "toolDescription": "Delete an existing database",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletedatabase/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletedatabase/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletedatabase/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletedatabase/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefield/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefield/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletefield",
+  "toolDescription": "Delete an existing database field (property)",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/fields/{fieldId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId",
+      "fieldId": "fieldId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefield/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefield/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "fieldId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId",
+    "fieldId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefield/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefield/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "fieldId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefolder/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefolder/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletefolder",
+  "toolDescription": "Delete an existing folder",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders/{folderId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "folderId": "folderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefolder/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefolder/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "folderId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "folderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefolder/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deletefolder/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "folderId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deleterecords/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deleterecords/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleterecords",
+  "toolDescription": "Delete several existing database records",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/records",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    },
+    "query": {
+      "recordIds": "recordIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deleterecords/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deleterecords/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "recordIds": {
+      "description": "Records to delete",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "databaseId",
+    "recordIds"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/deleterecords/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/deleterecords/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "recordIds": z.array(z.string()).describe("Records to delete")
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabase/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabase/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "finddatabase",
+  "toolDescription": "Get one specific database",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabase/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabase/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabase/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabase/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "finddatabases",
+  "toolDescription": "Get databases by ids",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "Pagination": "Pagination",
+      "databaseIds": "databaseIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema-json/properties/Pagination.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema-json/properties/Pagination.json
@@ -1,0 +1,16 @@
+{
+  "description": "Pagination parameter",
+  "type": "object",
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "limit": {
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+      "format": "int32",
+      "default": 100
+    }
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "Pagination": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>",
+      "additionalProperties": true
+    },
+    "databaseIds": {
+      "description": "Databases filter parameter",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "databaseIds"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema/properties/Pagination.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema/properties/Pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "nextPageToken": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/finddatabases/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "Pagination": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>").optional(),
+  "databaseIds": z.array(z.string()).describe("Databases filter parameter")
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfield/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfield/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findfield",
+  "toolDescription": "Get a given database field (property)",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/fields/{fieldId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId",
+      "fieldId": "fieldId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfield/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfield/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "fieldId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId",
+    "fieldId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfield/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfield/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "fieldId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findfields",
+  "toolDescription": "Get the database columns (properties)",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/fields",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    },
+    "query": {
+      "Pagination": "Pagination",
+      "fieldIds": "fieldIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema-json/properties/Pagination.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema-json/properties/Pagination.json
@@ -1,0 +1,16 @@
+{
+  "description": "Pagination parameter",
+  "type": "object",
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "limit": {
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+      "format": "int32",
+      "default": 100
+    }
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "Pagination": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>",
+      "additionalProperties": true
+    },
+    "fieldIds": {
+      "description": "Columns filter parameter",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema/properties/Pagination.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema/properties/Pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "nextPageToken": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfields/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "Pagination": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>").optional(),
+  "fieldIds": z.array(z.string()).describe("Columns filter parameter").optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolder/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolder/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findfolder",
+  "toolDescription": "Get one specific folder",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders/{folderId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "folderId": "folderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolder/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolder/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "folderId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "folderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolder/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolder/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "folderId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findfolderdatabases",
+  "toolDescription": "Get the folder's databases",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders/{folderId}/databases",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "folderId": "folderId"
+    },
+    "query": {
+      "Pagination": "Pagination",
+      "databaseIds": "databaseIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema-json/properties/Pagination.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema-json/properties/Pagination.json
@@ -1,0 +1,16 @@
+{
+  "description": "Pagination parameter",
+  "type": "object",
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "limit": {
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+      "format": "int32",
+      "default": 100
+    }
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "folderId": {
+      "type": "string"
+    },
+    "Pagination": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>",
+      "additionalProperties": true
+    },
+    "databaseIds": {
+      "description": "Databases filter parameter",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "folderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema/properties/Pagination.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema/properties/Pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "nextPageToken": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolderdatabases/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "folderId": z.string(),
+  "Pagination": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>").optional(),
+  "databaseIds": z.array(z.string()).describe("Databases filter parameter").optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findfolders",
+  "toolDescription": "Get folders by ids",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "Pagination": "Pagination",
+      "folderIds": "folderIds",
+      "withDescendants": "withDescendants"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema-json/properties/Pagination.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema-json/properties/Pagination.json
@@ -1,0 +1,16 @@
+{
+  "description": "Pagination parameter",
+  "type": "object",
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "limit": {
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+      "format": "int32",
+      "default": 100
+    }
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "Pagination": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>",
+      "additionalProperties": true
+    },
+    "folderIds": {
+      "description": "Folders filter parameter",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "withDescendants": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "folderIds"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema/properties/Pagination.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema/properties/Pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "nextPageToken": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findfolders/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "Pagination": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>").optional(),
+  "folderIds": z.array(z.string()).describe("Folders filter parameter"),
+  "withDescendants": z.boolean().optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecord/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecord/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findrecord",
+  "toolDescription": "Get a given list item along with requested column values",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/records/{recordId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId",
+      "recordId": "recordId"
+    },
+    "query": {
+      "fieldIds": "fieldIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecord/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecord/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "recordId": {
+      "type": "string"
+    },
+    "fieldIds": {
+      "description": "Columns (properties) to be loaded in the result",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "databaseId",
+    "recordId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecord/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecord/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "recordId": z.string(),
+  "fieldIds": z.array(z.string()).describe("Columns (properties) to be loaded in the result").optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findrecords",
+  "toolDescription": "Get the database records along with requested fields values",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/records",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    },
+    "query": {
+      "Pagination": "Pagination",
+      "recordIds": "recordIds",
+      "filter": "filter",
+      "searchQuery": "searchQuery",
+      "fieldIds": "fieldIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema-json/properties/Pagination.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema-json/properties/Pagination.json
@@ -1,0 +1,16 @@
+{
+  "description": "Pagination parameter",
+  "type": "object",
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "limit": {
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+      "format": "int32",
+      "default": 100
+    }
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema-json/root.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "Pagination": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>",
+      "additionalProperties": true
+    },
+    "recordIds": {
+      "description": "Items filter parameter",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "filter": {
+      "description": "Filter parameter",
+      "type": "string",
+      "example": "{\"and\": [{\"or\": [{\"op\": \"equals\",\"fld\": \"FI123456\",\"val\": 224}]},{\"op\": \"isNotEmpty\",\"fld\": \"FI123654\"}]}"
+    },
+    "searchQuery": {
+      "description": "Search query by all fields. Special characters (\", <> etc. must be escaped). The value is ignored if items filter is provided",
+      "type": "string"
+    },
+    "fieldIds": {
+      "description": "Columns (properties) to be loaded in the result",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema/properties/Pagination.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema/properties/Pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "nextPageToken": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findrecords/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "Pagination": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>").optional(),
+  "recordIds": z.array(z.string()).describe("Items filter parameter").optional(),
+  "filter": z.string().describe("Filter parameter").optional(),
+  "searchQuery": z.string().describe("Search query by all fields. Special characters (\", <> etc. must be escaped). The value is ignored if items filter is provided").optional(),
+  "fieldIds": z.array(z.string()).describe("Columns (properties) to be loaded in the result").optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findsubfolders",
+  "toolDescription": "Get the folder's subfolders",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders/{folderId}/folders",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "folderId": "folderId"
+    },
+    "query": {
+      "Pagination": "Pagination",
+      "folderIds": "folderIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema-json/properties/Pagination.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema-json/properties/Pagination.json
@@ -1,0 +1,16 @@
+{
+  "description": "Pagination parameter",
+  "type": "object",
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "limit": {
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+      "format": "int32",
+      "default": 100
+    }
+  }
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "folderId": {
+      "type": "string"
+    },
+    "Pagination": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>",
+      "additionalProperties": true
+    },
+    "folderIds": {
+      "description": "Folders filter parameter",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "folderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema/properties/Pagination.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema/properties/Pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "nextPageToken": z.string().optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/findsubfolders/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "folderId": z.string(),
+  "Pagination": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `Pagination` to the tool, first call the tool `expandSchema` with \"/properties/Pagination\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameter</property-description>").optional(),
+  "folderIds": z.array(z.string()).describe("Folders filter parameter").optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/folderspost/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/folderspost/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "folderspost",
+  "toolDescription": "Create a new folder within a given folder",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "requestId": "requestId",
+      "title": "title",
+      "parentFolderId": "parentFolderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/folderspost/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/folderspost/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "requestId": {
+      "type": "string",
+      "description": "Should  be any unique value, e.g. UUID, current timestamp etc"
+    },
+    "title": {
+      "type": "string"
+    },
+    "parentFolderId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "requestId",
+    "title",
+    "parentFolderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/folderspost/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/folderspost/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "requestId": z.string().describe("Should  be any unique value, e.g. UUID, current timestamp etc"),
+  "title": z.string(),
+  "parentFolderId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/getrootfolder/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/getrootfolder/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getrootfolder",
+  "toolDescription": "Get root folder for a space",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/spaces/{spaceId}/root/folder",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "spaceId": "spaceId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/getrootfolder/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/getrootfolder/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "spaceId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "spaceId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/getrootfolder/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/getrootfolder/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "spaceId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatedatabase/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatedatabase/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatedatabase",
+  "toolDescription": "Update a given database",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    },
+    "body": {
+      "title": "title",
+      "parentFolderId": "parentFolderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatedatabase/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatedatabase/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "parentFolderId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatedatabase/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatedatabase/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "title": z.string().optional(),
+  "parentFolderId": z.string().optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefield/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefield/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatefield",
+  "toolDescription": "Update an existing database field (property)",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/fields/{fieldId}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId",
+      "fieldId": "fieldId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefield/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefield/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "fieldId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "databaseId",
+    "fieldId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefield/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefield/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "fieldId": z.string()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefolder/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefolder/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatefolder",
+  "toolDescription": "Update a given folder",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/folders/{folderId}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "folderId": "folderId"
+    },
+    "body": {
+      "title": "title",
+      "parentFolderId": "parentFolderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefolder/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefolder/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "folderId": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "parentFolderId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "folderId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefolder/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updatefolder/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "folderId": z.string(),
+  "title": z.string().optional(),
+  "parentFolderId": z.string().optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/index.ts
@@ -1,0 +1,34 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updaterecord",
+  "toolDescription": "Update a given database record",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/records/{recordId}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId",
+      "recordId": "recordId"
+    },
+    "query": {
+      "fieldIds": "fieldIds"
+    },
+    "body": {
+      "title": "title",
+      "fieldValues": "fieldValues"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema-json/properties/fieldValues.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema-json/properties/fieldValues.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "additionalProperties": {},
+  "properties": {}
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema-json/root.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "recordId": {
+      "type": "string"
+    },
+    "fieldIds": {
+      "description": "Columns (properties) to be loaded in the result",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "title": {
+      "type": "string"
+    },
+    "fieldValues": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `fieldValues` to the tool, first call the tool `expandSchema` with \"/properties/fieldValues\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "databaseId",
+    "recordId",
+    "title",
+    "fieldValues"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema/properties/fieldValues.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema/properties/fieldValues.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecord/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "recordId": z.string(),
+  "fieldIds": z.array(z.string()).describe("Columns (properties) to be loaded in the result").optional(),
+  "title": z.string(),
+  "fieldValues": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `fieldValues` to the tool, first call the tool `expandSchema` with \"/properties/fieldValues\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecords/index.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecords/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updaterecords",
+  "toolDescription": "Update some database records",
+  "baseUrl": "https://www.wrike.com/app/wrike_v2_web",
+  "path": "/public/api/v1/databases/{databaseId}/records",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "databaseId": "databaseId"
+    },
+    "query": {
+      "fieldIds": "fieldIds"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecords/schema-json/root.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecords/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "databaseId": {
+      "type": "string"
+    },
+    "fieldIds": {
+      "description": "Columns (properties) to be loaded in the result",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "databaseId"
+  ]
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecords/schema/root.ts
+++ b/servers/www_wrike_com_app_wrike_v2_web/src/tools/updaterecords/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "databaseId": z.string(),
+  "fieldIds": z.array(z.string()).describe("Columns (properties) to be loaded in the result").optional()
+}

--- a/servers/www_wrike_com_app_wrike_v2_web/tsconfig.json
+++ b/servers/www_wrike_com_app_wrike_v2_web/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `www_wrike_com_app_wrike_v2_web`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/www_wrike_com_app_wrike_v2_web`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "www_wrike_com_app_wrike_v2_web": {
      "command": "npx",
      "args": ["-y", "@open-mcp/www_wrike_com_app_wrike_v2_web"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.