### PR TITLE
Add MCP server `h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1`

### DIFF
--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/.npmignore
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/README.md
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/README.md
@@ -1,0 +1,107 @@
+# @open-mcp/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+OAUTH2_TOKEN='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1 \
+  .cursor/mcp.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1 \
+  /path/to/client/config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `OAUTH2_TOKEN` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_consulta_cep_cep_
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `cep` (string)
+- `x-cpf-usuario` (string)

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/package.json
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/constants.ts
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/constants.ts
@@ -1,0 +1,6 @@
+export const OPENAPI_URL = "https://www.gov.br/conecta/catalogo/apis/cep-codigo-de-enderecamento-postal/swagger%20-1.json/swagger.json"
+export const SERVER_NAME = "h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_consulta_cep_cep_/index.js"
+]

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/index.ts
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/server.ts
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/tools/get_consulta_cep_cep_/index.ts
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/tools/get_consulta_cep_cep_/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_consulta_cep_cep_",
+  "toolDescription": "Consulta CEP",
+  "baseUrl": "https://h-apigateway.conectagov.np.estaleiro.serpro.gov.br/api-cep/v1",
+  "path": "/consulta/cep/{cep}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "cep": "cep"
+    },
+    "header": {
+      "x-cpf-usuario": "x-cpf-usuario"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/tools/get_consulta_cep_cep_/schema-json/root.json
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/tools/get_consulta_cep_cep_/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "cep": {
+      "description": "Número do CEP",
+      "type": "string"
+    },
+    "x-cpf-usuario": {
+      "description": "CPF do usuário da requisição",
+      "type": "string",
+      "default": ""
+    }
+  },
+  "required": [
+    "cep",
+    "x-cpf-usuario"
+  ]
+}

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/tools/get_consulta_cep_cep_/schema/root.ts
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/src/tools/get_consulta_cep_cep_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "cep": z.string().describe("Número do CEP"),
+  "x-cpf-usuario": z.string().describe("CPF do usuário da requisição")
+}

--- a/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/tsconfig.json
+++ b/servers/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1": {
      "command": "npx",
      "args": ["-y", "@open-mcp/h_apigateway_conectagov_np_estaleiro_serpro_gov_br_api_cep_v1"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.