### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,356 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### getcomments
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `after` (string)
+- `before` (string)
+- `limit` (integer)
+- `cursor` (string)
+- `comment_status_filter` (string)
+- `external_comment_id` (string)
+- `post_id` (array)
+
+### getcommentdetail
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `comment_id` (string)
+
+### getpostsv1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `after` (string)
+- `before` (string)
+- `limit` (integer)
+- `cursor` (string)
+- `external_id` (string)
+- `group_id` (array)
+
+### createpostv1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `attachments` (array)
+- `body` (string)
+- `comments_enabled` (boolean)
+- `external_id` (string)
+- `group_id` (string)
+- `highlighted_until` (string)
+- `mentioned_user_ids` (array)
+- `published_at` (string)
+- `reactions_enabled` (boolean)
+- `scheduled_at` (string)
+- `send_push_notifications` (boolean)
+- `title` (string)
+
+### getpostdetail
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `postId` (string)
+
+### getcommentsforpost
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `postId` (string)
+- `after` (string)
+- `before` (string)
+- `limit` (integer)
+- `cursor` (string)
+
+### createcommentreaction
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `postId` (string)
+- `commentId` (string)
+- `published_at` (string)
+- `reacting_user_id` (string)
+- `type` (string)
+
+### createpostseen
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `postId` (string)
+- `seen_at` (string)
+- `user_id` (string)
+
+### createpostreaction
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `postId` (string)
+- `published_at` (string)
+- `reacting_user_id` (string)
+- `type` (string)
+
+### deletepostv1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `post_id` (string)
+
+### updatepostv1
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `post_id` (string)
+- `attachments` (array)
+- `body` (string)
+- `comments_enabled` (boolean)
+- `external_id` (string)
+- `highlighted_until` (string)
+- `mentioned_user_ids` (array)
+- `published_at` (string)
+- `reactions_enabled` (boolean)
+- `scheduled_at` (string)
+- `title` (string)
+
+### createcomment
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `post_id` (string)
+- `attachments` (array)
+- `author_id` (string)
+- `body` (string)
+- `external_id` (string)
+- `language` (string)
+- `mentioned_user_ids` (array)
+- `published_at` (string)
+- `quoted_comment_id` (string)
+
+### deletecomment
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `post_id` (string)
+- `comment_id` (string)
+
+### updatecomment
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `post_id` (string)
+- `comment_id` (string)
+- `attachments` (array)
+- `body` (string)
+- `external_id` (string)
+- `language` (string)
+- `mentioned_user_ids` (array)
+
+### getpostsv2
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `after` (string)
+- `before` (string)
+- `limit` (integer)
+- `cursor` (string)
+- `external_post_id` (string)
+- `published_status` (string)
+- `post_status` (string)
+- `group_id` (array)
+
+### createpostv2
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `attachments` (array)
+- `author_id` (string)
+- `body` (string)
+- `comments_enabled` (boolean)
+- `external_id` (string)
+- `group_ids` (array)
+- `highlighted_until` (string)
+- `language` (string)
+- `mentioned_user_ids` (array)
+- `published_at` (string)
+- `reactions_enabled` (boolean)
+- `scheduled_at` (string)
+- `send_push_notifications` (boolean)
+- `title` (string)
+
+### uploadattachment
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getattachmentstatus
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `attachment_id` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,23 @@
+export const OPENAPI_URL = "https://base.flip-app.com/openapi/external/post/spec/post_api.yml"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getcomments/index.js",
+  "./tools/getcommentdetail/index.js",
+  "./tools/getpostsv1/index.js",
+  "./tools/createpostv1/index.js",
+  "./tools/getpostdetail/index.js",
+  "./tools/getcommentsforpost/index.js",
+  "./tools/createcommentreaction/index.js",
+  "./tools/createpostseen/index.js",
+  "./tools/createpostreaction/index.js",
+  "./tools/deletepostv1/index.js",
+  "./tools/updatepostv1/index.js",
+  "./tools/createcomment/index.js",
+  "./tools/deletecomment/index.js",
+  "./tools/updatecomment/index.js",
+  "./tools/getpostsv2/index.js",
+  "./tools/createpostv2/index.js",
+  "./tools/uploadattachment/index.js",
+  "./tools/getattachmentstatus/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/createcomment/index.ts
+++ b/servers/api_example_com/src/tools/createcomment/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createcomment",
+  "toolDescription": "Create a new comment for a post.",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{post_id}/comments",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "post_id": "post_id"
+    },
+    "body": {
+      "attachments": "attachments",
+      "author_id": "author_id",
+      "body": "body",
+      "external_id": "external_id",
+      "language": "language",
+      "mentioned_user_ids": "mentioned_user_ids",
+      "published_at": "published_at",
+      "quoted_comment_id": "quoted_comment_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/createcomment/schema-json/root.json
+++ b/servers/api_example_com/src/tools/createcomment/schema-json/root.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "post_id": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "attachments": {
+      "description": "List of attachment ids that belong to the comment.",
+      "items": {
+        "properties": {
+          "attachment_id": {
+            "description": "id of the uploaded attachment.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 10,
+      "nullable": true,
+      "type": "array"
+    },
+    "author_id": {
+      "description": "The user id of the author (default: current actor). If a user other than the current actor is specified, the current actor requires the legacy permission `POST_COMMENTS_IMPERSONATE`.",
+      "format": "uuid",
+      "nullable": true,
+      "type": "string"
+    },
+    "body": {
+      "description": "The body of the comment.",
+      "type": "string"
+    },
+    "external_id": {
+      "description": "Can be used for customer side identification of a comment. Should be unique.",
+      "nullable": true,
+      "type": "string"
+    },
+    "language": {
+      "description": "Language of the comment body represented as string compliant with ISO 639-1 norm. In case the language is not supported, the field will be ignored.",
+      "nullable": true,
+      "type": "string"
+    },
+    "mentioned_user_ids": {
+      "description": "The list of user IDs of users mentioned in the comment.",
+      "items": {
+        "format": "uuid",
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    },
+    "published_at": {
+      "description": "The timestamp of the publishing of the comment. If not provided, will be set to the time of the comment creation. The timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "quoted_comment_id": {
+      "description": "ID of the comment, that the newly created comment is responding to. If not provided, the comment will be a top level comment.",
+      "format": "uuid",
+      "nullable": true,
+      "type": "string"
+    }
+  },
+  "required": [
+    "post_id",
+    "body"
+  ]
+}

--- a/servers/api_example_com/src/tools/createcomment/schema/root.ts
+++ b/servers/api_example_com/src/tools/createcomment/schema/root.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "post_id": z.string().uuid(),
+  "attachments": z.array(z.object({ "attachment_id": z.string().uuid().describe("id of the uploaded attachment.") })).max(10).nullable().describe("List of attachment ids that belong to the comment.").optional(),
+  "author_id": z.string().uuid().nullable().describe("The user id of the author (default: current actor). If a user other than the current actor is specified, the current actor requires the legacy permission `POST_COMMENTS_IMPERSONATE`.").optional(),
+  "body": z.string().describe("The body of the comment."),
+  "external_id": z.string().nullable().describe("Can be used for customer side identification of a comment. Should be unique.").optional(),
+  "language": z.string().nullable().describe("Language of the comment body represented as string compliant with ISO 639-1 norm. In case the language is not supported, the field will be ignored.").optional(),
+  "mentioned_user_ids": z.array(z.string().uuid()).nullable().describe("The list of user IDs of users mentioned in the comment.").optional(),
+  "published_at": z.string().datetime({ offset: true }).nullable().describe("The timestamp of the publishing of the comment. If not provided, will be set to the time of the comment creation. The timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "quoted_comment_id": z.string().uuid().nullable().describe("ID of the comment, that the newly created comment is responding to. If not provided, the comment will be a top level comment.").optional()
+}

--- a/servers/api_example_com/src/tools/createcommentreaction/index.ts
+++ b/servers/api_example_com/src/tools/createcommentreaction/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createcommentreaction",
+  "toolDescription": "Create a new reaction for a comment",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{postId}/comments/{commentId}/reactions",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "postId": "postId",
+      "commentId": "commentId"
+    },
+    "body": {
+      "published_at": "published_at",
+      "reacting_user_id": "reacting_user_id",
+      "type": "type"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/createcommentreaction/schema-json/root.json
+++ b/servers/api_example_com/src/tools/createcommentreaction/schema-json/root.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "postId": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "commentId": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "published_at": {
+      "description": "The point in time when the reaction was made (default: now). If specified, it has to be a time in the past.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "reacting_user_id": {
+      "description": "The id of the user for whom the reaction is created (default: current actor). If a user other than the current actor is specified, the current actor needs the legacy permission `POST_COMMENTS_IMPERSONATE`.",
+      "format": "uuid",
+      "nullable": true,
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "postId",
+    "commentId",
+    "type"
+  ]
+}

--- a/servers/api_example_com/src/tools/createcommentreaction/schema/root.ts
+++ b/servers/api_example_com/src/tools/createcommentreaction/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "postId": z.string().uuid(),
+  "commentId": z.string().uuid(),
+  "published_at": z.string().datetime({ offset: true }).nullable().describe("The point in time when the reaction was made (default: now). If specified, it has to be a time in the past.").optional(),
+  "reacting_user_id": z.string().uuid().nullable().describe("The id of the user for whom the reaction is created (default: current actor). If a user other than the current actor is specified, the current actor needs the legacy permission `POST_COMMENTS_IMPERSONATE`.").optional(),
+  "type": z.string()
+}

--- a/servers/api_example_com/src/tools/createpostreaction/index.ts
+++ b/servers/api_example_com/src/tools/createpostreaction/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createpostreaction",
+  "toolDescription": "Create a new reaction for a post",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{postId}/reactions",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "postId": "postId"
+    },
+    "body": {
+      "published_at": "published_at",
+      "reacting_user_id": "reacting_user_id",
+      "type": "type"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/createpostreaction/schema-json/root.json
+++ b/servers/api_example_com/src/tools/createpostreaction/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "postId": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "published_at": {
+      "description": "The point in time when the reaction was made (default: now). If specified, it has to be a time in the past.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "reacting_user_id": {
+      "description": "The id of the user for whom the reaction is created (default: current actor). If a user other than the current actor is specified, the current actor needs the legacy permission `POST_COMMENTS_IMPERSONATE`.",
+      "format": "uuid",
+      "nullable": true,
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "postId",
+    "type"
+  ]
+}

--- a/servers/api_example_com/src/tools/createpostreaction/schema/root.ts
+++ b/servers/api_example_com/src/tools/createpostreaction/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "postId": z.string().uuid(),
+  "published_at": z.string().datetime({ offset: true }).nullable().describe("The point in time when the reaction was made (default: now). If specified, it has to be a time in the past.").optional(),
+  "reacting_user_id": z.string().uuid().nullable().describe("The id of the user for whom the reaction is created (default: current actor). If a user other than the current actor is specified, the current actor needs the legacy permission `POST_COMMENTS_IMPERSONATE`.").optional(),
+  "type": z.string()
+}

--- a/servers/api_example_com/src/tools/createpostseen/index.ts
+++ b/servers/api_example_com/src/tools/createpostseen/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createpostseen",
+  "toolDescription": "Create a new seen for a post",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{postId}/post-seen",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "postId": "postId"
+    },
+    "body": {
+      "seen_at": "seen_at",
+      "user_id": "user_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/createpostseen/schema-json/root.json
+++ b/servers/api_example_com/src/tools/createpostseen/schema-json/root.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "postId": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "seen_at": {
+      "description": "The point in time when the user has viewed the post (default: now). If specified, it has to be a time in the past.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "user_id": {
+      "description": "The id of the user for who the seen is created (default: current actor). If a user other than the current actor is specified, the current actor requires the legacy permission `POST_COMMENTS_IMPERSONATE`.",
+      "format": "uuid",
+      "nullable": true,
+      "type": "string"
+    }
+  },
+  "required": [
+    "postId"
+  ]
+}

--- a/servers/api_example_com/src/tools/createpostseen/schema/root.ts
+++ b/servers/api_example_com/src/tools/createpostseen/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "postId": z.string().uuid(),
+  "seen_at": z.string().datetime({ offset: true }).nullable().describe("The point in time when the user has viewed the post (default: now). If specified, it has to be a time in the past.").optional(),
+  "user_id": z.string().uuid().nullable().describe("The id of the user for who the seen is created (default: current actor). If a user other than the current actor is specified, the current actor requires the legacy permission `POST_COMMENTS_IMPERSONATE`.").optional()
+}

--- a/servers/api_example_com/src/tools/createpostv1/index.ts
+++ b/servers/api_example_com/src/tools/createpostv1/index.ts
@@ -1,0 +1,37 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createpostv1",
+  "toolDescription": "Create a new post (V1)",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "attachments": "attachments",
+      "body": "body",
+      "comments_enabled": "comments_enabled",
+      "external_id": "external_id",
+      "group_id": "group_id",
+      "highlighted_until": "highlighted_until",
+      "mentioned_user_ids": "mentioned_user_ids",
+      "published_at": "published_at",
+      "reactions_enabled": "reactions_enabled",
+      "scheduled_at": "scheduled_at",
+      "send_push_notifications": "send_push_notifications",
+      "title": "title"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/createpostv1/schema-json/root.json
+++ b/servers/api_example_com/src/tools/createpostv1/schema-json/root.json
@@ -1,0 +1,90 @@
+{
+  "type": "object",
+  "properties": {
+    "attachments": {
+      "description": "List of attachment ids that belong to the post.",
+      "items": {
+        "properties": {
+          "attachment_id": {
+            "description": "id of the uploaded attachment.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 50,
+      "nullable": true,
+      "type": "array"
+    },
+    "body": {
+      "description": "The body in HTML format. The maximum payload is 204800 bytes. Inline images in the html must have the `attachment_id` set as `src` (`<img src='attachment-id'>).",
+      "nullable": true,
+      "type": "string"
+    },
+    "comments_enabled": {
+      "description": "Determines if comments are enabled for this post. If not set, the default value of the group will be used.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "external_id": {
+      "description": "Can be used for customer side identification of a post. Should be unique.",
+      "nullable": true,
+      "type": "string"
+    },
+    "group_id": {
+      "description": "The group which the post will be assigned to. The user must be a member of this group.",
+      "format": "uuid",
+      "type": "string"
+    },
+    "highlighted_until": {
+      "description": "The highlighted date indicates until when a post should be a highlighted post.\nIf no value is passed, the post will not be highlighted.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "mentioned_user_ids": {
+      "description": "List of user ids that are mentioned in the post.",
+      "items": {
+        "format": "uuid",
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    },
+    "published_at": {
+      "description": "The published date indicates when the post was published.\nThe value can't be used if the value is in the future or the `scheduled_at` is set.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "reactions_enabled": {
+      "description": "Determines if reactions are enabled for this post. If not set, the default value of the group will be used.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "scheduled_at": {
+      "description": "The scheduled date indicates when the post is to be published.\nIf no value is passed, the post will be published immediately.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "send_push_notifications": {
+      "default": true,
+      "description": "Set if members of the group of this post should receive a notification on their devices.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "title": {
+      "description": "The title in plain text.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "group_id",
+    "title"
+  ]
+}

--- a/servers/api_example_com/src/tools/createpostv1/schema/root.ts
+++ b/servers/api_example_com/src/tools/createpostv1/schema/root.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "attachments": z.array(z.object({ "attachment_id": z.string().uuid().describe("id of the uploaded attachment.") })).max(50).nullable().describe("List of attachment ids that belong to the post.").optional(),
+  "body": z.string().nullable().describe("The body in HTML format. The maximum payload is 204800 bytes. Inline images in the html must have the `attachment_id` set as `src` (`<img src='attachment-id'>).").optional(),
+  "comments_enabled": z.boolean().nullable().describe("Determines if comments are enabled for this post. If not set, the default value of the group will be used.").optional(),
+  "external_id": z.string().nullable().describe("Can be used for customer side identification of a post. Should be unique.").optional(),
+  "group_id": z.string().uuid().describe("The group which the post will be assigned to. The user must be a member of this group."),
+  "highlighted_until": z.string().datetime({ offset: true }).nullable().describe("The highlighted date indicates until when a post should be a highlighted post.\nIf no value is passed, the post will not be highlighted.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "mentioned_user_ids": z.array(z.string().uuid()).nullable().describe("List of user ids that are mentioned in the post.").optional(),
+  "published_at": z.string().datetime({ offset: true }).nullable().describe("The published date indicates when the post was published.\nThe value can't be used if the value is in the future or the `scheduled_at` is set.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "reactions_enabled": z.boolean().nullable().describe("Determines if reactions are enabled for this post. If not set, the default value of the group will be used.").optional(),
+  "scheduled_at": z.string().datetime({ offset: true }).nullable().describe("The scheduled date indicates when the post is to be published.\nIf no value is passed, the post will be published immediately.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "send_push_notifications": z.boolean().nullable().describe("Set if members of the group of this post should receive a notification on their devices.").optional(),
+  "title": z.string().describe("The title in plain text.")
+}

--- a/servers/api_example_com/src/tools/createpostv2/index.ts
+++ b/servers/api_example_com/src/tools/createpostv2/index.ts
@@ -1,0 +1,39 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createpostv2",
+  "toolDescription": "Create a new post (V2)",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v2/posts",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "attachments": "attachments",
+      "author_id": "author_id",
+      "body": "body",
+      "comments_enabled": "comments_enabled",
+      "external_id": "external_id",
+      "group_ids": "group_ids",
+      "highlighted_until": "highlighted_until",
+      "language": "language",
+      "mentioned_user_ids": "mentioned_user_ids",
+      "published_at": "published_at",
+      "reactions_enabled": "reactions_enabled",
+      "scheduled_at": "scheduled_at",
+      "send_push_notifications": "send_push_notifications",
+      "title": "title"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/createpostv2/schema-json/root.json
+++ b/servers/api_example_com/src/tools/createpostv2/schema-json/root.json
@@ -1,0 +1,104 @@
+{
+  "type": "object",
+  "properties": {
+    "attachments": {
+      "description": "List of attachment ids that belong to the post.",
+      "items": {
+        "properties": {
+          "attachment_id": {
+            "description": "id of the uploaded attachment.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 50,
+      "nullable": true,
+      "type": "array"
+    },
+    "author_id": {
+      "description": "The author of the post (default: current actor). Both the current actor and the specified user must belong to the channel/group the post is assigned to. If a user other than the current actor is specified, the current actor must have the legacy permission `POST_COMMENTS_IMPERSONATE`.",
+      "format": "uuid",
+      "nullable": true,
+      "type": "string"
+    },
+    "body": {
+      "description": "The body in HTML format. The maximum payload is 204800 bytes.",
+      "nullable": true,
+      "type": "string"
+    },
+    "comments_enabled": {
+      "description": "Determines if comments are enabled for this post. If not set, the default value of the group will be used.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "external_id": {
+      "description": "Can be used for customer side identification of a post. Should be unique.",
+      "nullable": true,
+      "type": "string"
+    },
+    "group_ids": {
+      "description": "The groups which the post will be assigned to. The user must be a member of these groups.",
+      "items": {
+        "format": "uuid",
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "highlighted_until": {
+      "description": "The highlighted date indicates until when a post should be a highlighted post.\nIf no value is passed, the post will not be highlighted.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "language": {
+      "description": "An ISO 639-1 language code or null for the language of the post content. If specified, Flip can use it to support auto-translation functionality.",
+      "nullable": true,
+      "type": "string"
+    },
+    "mentioned_user_ids": {
+      "description": "List of user ids that are mentioned in the post.",
+      "items": {
+        "format": "uuid",
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    },
+    "published_at": {
+      "description": "The published date indicates when the post was published.\nThe value can't be used if the value is in the future or the `scheduled_at` is set.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "reactions_enabled": {
+      "description": "Determines if reactions are enabled for this post. If not set, the default value of the group will be used.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "scheduled_at": {
+      "description": "The scheduled date indicates when the post is to be published.\nIf no value is passed, the post will be published immediately.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "send_push_notifications": {
+      "default": true,
+      "description": "Set if members of the group of this post should receive a notification on their devices.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "title": {
+      "description": "The title in plain text.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "group_ids",
+    "title"
+  ]
+}

--- a/servers/api_example_com/src/tools/createpostv2/schema/root.ts
+++ b/servers/api_example_com/src/tools/createpostv2/schema/root.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "attachments": z.array(z.object({ "attachment_id": z.string().uuid().describe("id of the uploaded attachment.") })).max(50).nullable().describe("List of attachment ids that belong to the post.").optional(),
+  "author_id": z.string().uuid().nullable().describe("The author of the post (default: current actor). Both the current actor and the specified user must belong to the channel/group the post is assigned to. If a user other than the current actor is specified, the current actor must have the legacy permission `POST_COMMENTS_IMPERSONATE`.").optional(),
+  "body": z.string().nullable().describe("The body in HTML format. The maximum payload is 204800 bytes.").optional(),
+  "comments_enabled": z.boolean().nullable().describe("Determines if comments are enabled for this post. If not set, the default value of the group will be used.").optional(),
+  "external_id": z.string().nullable().describe("Can be used for customer side identification of a post. Should be unique.").optional(),
+  "group_ids": z.array(z.string().uuid()).describe("The groups which the post will be assigned to. The user must be a member of these groups."),
+  "highlighted_until": z.string().datetime({ offset: true }).nullable().describe("The highlighted date indicates until when a post should be a highlighted post.\nIf no value is passed, the post will not be highlighted.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "language": z.string().nullable().describe("An ISO 639-1 language code or null for the language of the post content. If specified, Flip can use it to support auto-translation functionality.").optional(),
+  "mentioned_user_ids": z.array(z.string().uuid()).nullable().describe("List of user ids that are mentioned in the post.").optional(),
+  "published_at": z.string().datetime({ offset: true }).nullable().describe("The published date indicates when the post was published.\nThe value can't be used if the value is in the future or the `scheduled_at` is set.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "reactions_enabled": z.boolean().nullable().describe("Determines if reactions are enabled for this post. If not set, the default value of the group will be used.").optional(),
+  "scheduled_at": z.string().datetime({ offset: true }).nullable().describe("The scheduled date indicates when the post is to be published.\nIf no value is passed, the post will be published immediately.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "send_push_notifications": z.boolean().nullable().describe("Set if members of the group of this post should receive a notification on their devices.").optional(),
+  "title": z.string().describe("The title in plain text.")
+}

--- a/servers/api_example_com/src/tools/deletecomment/index.ts
+++ b/servers/api_example_com/src/tools/deletecomment/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletecomment",
+  "toolDescription": "Delete an existing comment.",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{post_id}/comments/{comment_id}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "post_id": "post_id",
+      "comment_id": "comment_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/deletecomment/schema-json/root.json
+++ b/servers/api_example_com/src/tools/deletecomment/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "post_id": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "comment_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "post_id",
+    "comment_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/deletecomment/schema/root.ts
+++ b/servers/api_example_com/src/tools/deletecomment/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "post_id": z.string().uuid(),
+  "comment_id": z.string().uuid()
+}

--- a/servers/api_example_com/src/tools/deletepostv1/index.ts
+++ b/servers/api_example_com/src/tools/deletepostv1/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletepostv1",
+  "toolDescription": "Delete a post by id",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{post_id}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "post_id": "post_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/deletepostv1/schema-json/root.json
+++ b/servers/api_example_com/src/tools/deletepostv1/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "post_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "post_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/deletepostv1/schema/root.ts
+++ b/servers/api_example_com/src/tools/deletepostv1/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "post_id": z.string().uuid()
+}

--- a/servers/api_example_com/src/tools/getattachmentstatus/index.ts
+++ b/servers/api_example_com/src/tools/getattachmentstatus/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getattachmentstatus",
+  "toolDescription": "Get the processing status for an uploaded attachment.",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/v1/attachments/{attachment_id}/status",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "attachment_id": "attachment_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getattachmentstatus/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getattachmentstatus/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "attachment_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "attachment_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/getattachmentstatus/schema/root.ts
+++ b/servers/api_example_com/src/tools/getattachmentstatus/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "attachment_id": z.string().uuid()
+}

--- a/servers/api_example_com/src/tools/getcommentdetail/index.ts
+++ b/servers/api_example_com/src/tools/getcommentdetail/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcommentdetail",
+  "toolDescription": "Get a comment by IDs",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/comments/{comment_id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "comment_id": "comment_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getcommentdetail/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getcommentdetail/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "comment_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "comment_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/getcommentdetail/schema/root.ts
+++ b/servers/api_example_com/src/tools/getcommentdetail/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "comment_id": z.string().uuid()
+}

--- a/servers/api_example_com/src/tools/getcomments/index.ts
+++ b/servers/api_example_com/src/tools/getcomments/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcomments",
+  "toolDescription": "Get all comment IDs",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/comments",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "after": "after",
+      "before": "before",
+      "limit": "limit",
+      "cursor": "cursor",
+      "comment_status_filter": "comment_status_filter",
+      "external_comment_id": "external_comment_id",
+      "post_id": "post_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getcomments/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getcomments/schema-json/root.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "properties": {
+    "after": {
+      "description": "Returns the comments which have `created_at`, `deleted_at` or `updated_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.",
+      "nullable": true,
+      "pattern": "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$",
+      "type": "string"
+    },
+    "before": {
+      "description": "Returns the comments which have `created_at`, `deleted_at` or `updated_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before` parameter is exclusive.",
+      "nullable": true,
+      "pattern": "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Limits the count of the posts in response to the parameter value. Maximum is 1000.",
+      "default": 30,
+      "format": "int32",
+      "maximum": 1000,
+      "nullable": true,
+      "type": "integer"
+    },
+    "cursor": {
+      "description": "Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.",
+      "nullable": true,
+      "type": "string"
+    },
+    "comment_status_filter": {
+      "description": "Filter search results by comment status. There are 3 options: `ONLY_CREATED`, `ONLY_DELETED`, `ONLY_UPDATED` and `ALL`.",
+      "default": "ONLY_CREATED",
+      "nullable": true,
+      "type": "string"
+    },
+    "external_comment_id": {
+      "description": "Returns comments that have this `external_id`.",
+      "nullable": true,
+      "type": "string"
+    },
+    "post_id": {
+      "description": "Returns comments that are in a list of posts. This query parameter can be repeated to include more posts.",
+      "items": {
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getcomments/schema/root.ts
+++ b/servers/api_example_com/src/tools/getcomments/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "after": z.string().regex(new RegExp("^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$")).nullable().describe("Returns the comments which have `created_at`, `deleted_at` or `updated_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.").optional(),
+  "before": z.string().regex(new RegExp("^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$")).nullable().describe("Returns the comments which have `created_at`, `deleted_at` or `updated_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before` parameter is exclusive.").optional(),
+  "limit": z.number().int().lte(1000).nullable().describe("Limits the count of the posts in response to the parameter value. Maximum is 1000.").optional(),
+  "cursor": z.string().nullable().describe("Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.").optional(),
+  "comment_status_filter": z.string().nullable().describe("Filter search results by comment status. There are 3 options: `ONLY_CREATED`, `ONLY_DELETED`, `ONLY_UPDATED` and `ALL`.").optional(),
+  "external_comment_id": z.string().nullable().describe("Returns comments that have this `external_id`.").optional(),
+  "post_id": z.array(z.string()).nullable().describe("Returns comments that are in a list of posts. This query parameter can be repeated to include more posts.").optional()
+}

--- a/servers/api_example_com/src/tools/getcommentsforpost/index.ts
+++ b/servers/api_example_com/src/tools/getcommentsforpost/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcommentsforpost",
+  "toolDescription": "Get all comments for a post.",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{postId}/comments",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "postId": "postId"
+    },
+    "query": {
+      "after": "after",
+      "before": "before",
+      "limit": "limit",
+      "cursor": "cursor"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getcommentsforpost/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getcommentsforpost/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "postId": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "after": {
+      "description": "Returns the comments which have `created_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.",
+      "nullable": true,
+      "type": "string"
+    },
+    "before": {
+      "description": "Returns the comments which have `created_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before`parameter is exclusive.",
+      "nullable": true,
+      "type": "string"
+    },
+    "limit": {
+      "description": "Limits the count of the comments in response to the parameter value.",
+      "default": 30,
+      "format": "int32",
+      "maximum": 1000,
+      "nullable": true,
+      "type": "integer"
+    },
+    "cursor": {
+      "description": "Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.",
+      "nullable": true,
+      "type": "string"
+    }
+  },
+  "required": [
+    "postId"
+  ]
+}

--- a/servers/api_example_com/src/tools/getcommentsforpost/schema/root.ts
+++ b/servers/api_example_com/src/tools/getcommentsforpost/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "postId": z.string().uuid(),
+  "after": z.string().nullable().describe("Returns the comments which have `created_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.").optional(),
+  "before": z.string().nullable().describe("Returns the comments which have `created_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before`parameter is exclusive.").optional(),
+  "limit": z.number().int().lte(1000).nullable().describe("Limits the count of the comments in response to the parameter value.").optional(),
+  "cursor": z.string().nullable().describe("Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.").optional()
+}

--- a/servers/api_example_com/src/tools/getpostdetail/index.ts
+++ b/servers/api_example_com/src/tools/getpostdetail/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpostdetail",
+  "toolDescription": "Get the post by id",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{postId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "postId": "postId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getpostdetail/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getpostdetail/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "postId": {
+      "description": "The id of the post you are searching for.",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "postId"
+  ]
+}

--- a/servers/api_example_com/src/tools/getpostdetail/schema/root.ts
+++ b/servers/api_example_com/src/tools/getpostdetail/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "postId": z.string().uuid().describe("The id of the post you are searching for.")
+}

--- a/servers/api_example_com/src/tools/getpostsv1/index.ts
+++ b/servers/api_example_com/src/tools/getpostsv1/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpostsv1",
+  "toolDescription": "Get all posts from the groups the user is a member of (V1)",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "after": "after",
+      "before": "before",
+      "limit": "limit",
+      "cursor": "cursor",
+      "external_id": "external_id",
+      "group_id": "group_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getpostsv1/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getpostsv1/schema-json/root.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "after": {
+      "description": "Returns the posts which have `published_at`, `updated_at` or `deleted_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.",
+      "nullable": true,
+      "type": "string"
+    },
+    "before": {
+      "description": "Returns the posts which have `published_at`, `updated_at` or `deleted_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before`parameter is exclusive.",
+      "nullable": true,
+      "type": "string"
+    },
+    "limit": {
+      "description": "Limits the count of the posts in response to the parameter value.",
+      "default": 30,
+      "format": "int32",
+      "maximum": 1000,
+      "nullable": true,
+      "type": "integer"
+    },
+    "cursor": {
+      "description": "Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.",
+      "nullable": true,
+      "type": "string"
+    },
+    "external_id": {
+      "description": "Returns posts that have this `external_id`.",
+      "nullable": true,
+      "type": "string"
+    },
+    "group_id": {
+      "description": "Returns posts that are in a group with this `group_id`. This query parameter can be repeated to include more groups.",
+      "items": {
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getpostsv1/schema/root.ts
+++ b/servers/api_example_com/src/tools/getpostsv1/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "after": z.string().nullable().describe("Returns the posts which have `published_at`, `updated_at` or `deleted_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.").optional(),
+  "before": z.string().nullable().describe("Returns the posts which have `published_at`, `updated_at` or `deleted_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before`parameter is exclusive.").optional(),
+  "limit": z.number().int().lte(1000).nullable().describe("Limits the count of the posts in response to the parameter value.").optional(),
+  "cursor": z.string().nullable().describe("Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.").optional(),
+  "external_id": z.string().nullable().describe("Returns posts that have this `external_id`.").optional(),
+  "group_id": z.array(z.string()).nullable().describe("Returns posts that are in a group with this `group_id`. This query parameter can be repeated to include more groups.").optional()
+}

--- a/servers/api_example_com/src/tools/getpostsv2/index.ts
+++ b/servers/api_example_com/src/tools/getpostsv2/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpostsv2",
+  "toolDescription": "Get all posts from the groups the user is a member of (V2)",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v2/posts",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "after": "after",
+      "before": "before",
+      "limit": "limit",
+      "cursor": "cursor",
+      "external_post_id": "external_post_id",
+      "published_status": "published_status",
+      "post_status": "post_status",
+      "group_id": "group_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getpostsv2/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getpostsv2/schema-json/root.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "properties": {
+    "after": {
+      "description": "Returns the posts which have `created_at`, `published_at`, `updated_at` or `deleted_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.",
+      "nullable": true,
+      "pattern": "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$",
+      "type": "string"
+    },
+    "before": {
+      "description": "Returns the posts which have `created_at`, `published_at`, `updated_at` or `deleted_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before` parameter is exclusive.",
+      "nullable": true,
+      "pattern": "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Limits the count of the posts in response to the parameter value. Maximum is 1000.",
+      "default": 30,
+      "format": "int32",
+      "maximum": 1000,
+      "nullable": true,
+      "type": "integer"
+    },
+    "cursor": {
+      "description": "Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.",
+      "nullable": true,
+      "type": "string"
+    },
+    "external_post_id": {
+      "description": "Returns posts that have this `external_post_id`.",
+      "nullable": true,
+      "type": "string"
+    },
+    "published_status": {
+      "description": "Filter search results by post publishing status. There are 3 options: `ONLY_PUBLISHED` (default), `ONLY_SCHEDULED` and `ALL`.",
+      "default": "ONLY_PUBLISHED",
+      "nullable": true,
+      "type": "string"
+    },
+    "post_status": {
+      "description": "Filter search results by post status. There are 5 options: `ONLY_CREATED`, `ONLY_UPDATED`, `ONLY_CREATED_OR_UPDATED` (default), `ONLY_DELETED` and `ALL`.",
+      "default": "ONLY_CREATED_OR_UPDATED",
+      "nullable": true,
+      "type": "string"
+    },
+    "group_id": {
+      "description": "Returns posts that are in a group with this `group_id`. This query parameter can be repeated to include more groups.",
+      "items": {
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getpostsv2/schema/root.ts
+++ b/servers/api_example_com/src/tools/getpostsv2/schema/root.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "after": z.string().regex(new RegExp("^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$")).nullable().describe("Returns the posts which have `created_at`, `published_at`, `updated_at` or `deleted_at` value after the `after` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `after` parameter is inclusive.").optional(),
+  "before": z.string().regex(new RegExp("^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$")).nullable().describe("Returns the posts which have `created_at`, `published_at`, `updated_at` or `deleted_at` value before the `before` value. The full ISO 8601 must be used e.g. `2021-12-20T10:33:52Z`. The `before` parameter is exclusive.").optional(),
+  "limit": z.number().int().lte(1000).nullable().describe("Limits the count of the posts in response to the parameter value. Maximum is 1000.").optional(),
+  "cursor": z.string().nullable().describe("Cursor from an already made call for pagination. The cursor is encoded and must only be used if retrieved from a previous call from this API. It should not be changed in any way.\nIF THE CURSOR IS SET IT WILL OVERWRITE ALL OTHER QUERY PARAMETERS.").optional(),
+  "external_post_id": z.string().nullable().describe("Returns posts that have this `external_post_id`.").optional(),
+  "published_status": z.string().nullable().describe("Filter search results by post publishing status. There are 3 options: `ONLY_PUBLISHED` (default), `ONLY_SCHEDULED` and `ALL`.").optional(),
+  "post_status": z.string().nullable().describe("Filter search results by post status. There are 5 options: `ONLY_CREATED`, `ONLY_UPDATED`, `ONLY_CREATED_OR_UPDATED` (default), `ONLY_DELETED` and `ALL`.").optional(),
+  "group_id": z.array(z.string()).nullable().describe("Returns posts that are in a group with this `group_id`. This query parameter can be repeated to include more groups.").optional()
+}

--- a/servers/api_example_com/src/tools/updatecomment/index.ts
+++ b/servers/api_example_com/src/tools/updatecomment/index.ts
@@ -1,0 +1,34 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatecomment",
+  "toolDescription": "Update a comment",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{post_id}/comments/{comment_id}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "post_id": "post_id",
+      "comment_id": "comment_id"
+    },
+    "body": {
+      "attachments": "attachments",
+      "body": "body",
+      "external_id": "external_id",
+      "language": "language",
+      "mentioned_user_ids": "mentioned_user_ids"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/updatecomment/schema-json/root.json
+++ b/servers/api_example_com/src/tools/updatecomment/schema-json/root.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "post_id": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "comment_id": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "attachments": {
+      "description": "List of attachment ids that belong to the comment.",
+      "items": {
+        "properties": {
+          "attachment_id": {
+            "description": "id of the uploaded attachment.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 10,
+      "nullable": true,
+      "type": "array"
+    },
+    "body": {
+      "description": "The body of the comment.",
+      "type": "string"
+    },
+    "external_id": {
+      "description": "Can be used for customer side identification of a comment. Should be unique.",
+      "nullable": true,
+      "type": "string"
+    },
+    "language": {
+      "description": "Language of the comment body represented as string compliant with ISO 639-1 norm. In case the language is not supported, the field will be ignored.",
+      "nullable": true,
+      "type": "string"
+    },
+    "mentioned_user_ids": {
+      "description": "User IDs of mentioned users. If not provided, the mentioned users will be removed. Comment body must contain the mentioned user IDs in a properly formatted form. Use of this field requires the feature to be enabled.",
+      "items": {
+        "format": "uuid",
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    }
+  },
+  "required": [
+    "post_id",
+    "comment_id",
+    "body"
+  ]
+}

--- a/servers/api_example_com/src/tools/updatecomment/schema/root.ts
+++ b/servers/api_example_com/src/tools/updatecomment/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "post_id": z.string().uuid(),
+  "comment_id": z.string().uuid(),
+  "attachments": z.array(z.object({ "attachment_id": z.string().uuid().describe("id of the uploaded attachment.") })).max(10).nullable().describe("List of attachment ids that belong to the comment.").optional(),
+  "body": z.string().describe("The body of the comment."),
+  "external_id": z.string().nullable().describe("Can be used for customer side identification of a comment. Should be unique.").optional(),
+  "language": z.string().nullable().describe("Language of the comment body represented as string compliant with ISO 639-1 norm. In case the language is not supported, the field will be ignored.").optional(),
+  "mentioned_user_ids": z.array(z.string().uuid()).nullable().describe("User IDs of mentioned users. If not provided, the mentioned users will be removed. Comment body must contain the mentioned user IDs in a properly formatted form. Use of this field requires the feature to be enabled.").optional()
+}

--- a/servers/api_example_com/src/tools/updatepostv1/index.ts
+++ b/servers/api_example_com/src/tools/updatepostv1/index.ts
@@ -1,0 +1,38 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatepostv1",
+  "toolDescription": "Update a post by id",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/post/v1/posts/{post_id}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "post_id": "post_id"
+    },
+    "body": {
+      "attachments": "attachments",
+      "body": "body",
+      "comments_enabled": "comments_enabled",
+      "external_id": "external_id",
+      "highlighted_until": "highlighted_until",
+      "mentioned_user_ids": "mentioned_user_ids",
+      "published_at": "published_at",
+      "reactions_enabled": "reactions_enabled",
+      "scheduled_at": "scheduled_at",
+      "title": "title"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/updatepostv1/schema-json/root.json
+++ b/servers/api_example_com/src/tools/updatepostv1/schema-json/root.json
@@ -1,0 +1,83 @@
+{
+  "type": "object",
+  "properties": {
+    "post_id": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "attachments": {
+      "description": "List of attachment ids that belong to the post.",
+      "items": {
+        "properties": {
+          "attachment_id": {
+            "description": "id of the uploaded attachment.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 50,
+      "nullable": true,
+      "type": "array"
+    },
+    "body": {
+      "description": "The body in HTML format. The maximum payload is 204800 bytes.",
+      "nullable": true,
+      "type": "string"
+    },
+    "comments_enabled": {
+      "description": "Determines if comments are enabled for this post. If not set, the default value of the group will be used.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "external_id": {
+      "description": "Can be used for customer side identification of a post. Should be unique.",
+      "nullable": true,
+      "type": "string"
+    },
+    "highlighted_until": {
+      "description": "The highlighted date indicates until when a post should be a highlighted post.\nIf no value is passed, the post will not be highlighted.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "mentioned_user_ids": {
+      "description": "List of user ids that are mentioned in the post.",
+      "items": {
+        "format": "uuid",
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    },
+    "published_at": {
+      "description": "The published date indicates when the post was published.\nThe value can't be used if the value is in the future or the `scheduled_at` is set.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "reactions_enabled": {
+      "description": "Determines if reactions are enabled for this post. If not set, the default value of the group will be used.",
+      "nullable": true,
+      "type": "boolean"
+    },
+    "scheduled_at": {
+      "description": "The scheduled date indicates when the post is to be published.\nIf no value is passed, the post will be published immediately.\nA post that has already been published cannot be scheduled again.\"\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.",
+      "format": "date-time",
+      "nullable": true,
+      "type": "string"
+    },
+    "title": {
+      "description": "The title in plain text.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "post_id",
+    "title"
+  ]
+}

--- a/servers/api_example_com/src/tools/updatepostv1/schema/root.ts
+++ b/servers/api_example_com/src/tools/updatepostv1/schema/root.ts
@@ -1,0 +1,15 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "post_id": z.string().uuid(),
+  "attachments": z.array(z.object({ "attachment_id": z.string().uuid().describe("id of the uploaded attachment.") })).max(50).nullable().describe("List of attachment ids that belong to the post.").optional(),
+  "body": z.string().nullable().describe("The body in HTML format. The maximum payload is 204800 bytes.").optional(),
+  "comments_enabled": z.boolean().nullable().describe("Determines if comments are enabled for this post. If not set, the default value of the group will be used.").optional(),
+  "external_id": z.string().nullable().describe("Can be used for customer side identification of a post. Should be unique.").optional(),
+  "highlighted_until": z.string().datetime({ offset: true }).nullable().describe("The highlighted date indicates until when a post should be a highlighted post.\nIf no value is passed, the post will not be highlighted.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "mentioned_user_ids": z.array(z.string().uuid()).nullable().describe("List of user ids that are mentioned in the post.").optional(),
+  "published_at": z.string().datetime({ offset: true }).nullable().describe("The published date indicates when the post was published.\nThe value can't be used if the value is in the future or the `scheduled_at` is set.\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "reactions_enabled": z.boolean().nullable().describe("Determines if reactions are enabled for this post. If not set, the default value of the group will be used.").optional(),
+  "scheduled_at": z.string().datetime({ offset: true }).nullable().describe("The scheduled date indicates when the post is to be published.\nIf no value is passed, the post will be published immediately.\nA post that has already been published cannot be scheduled again.\"\nThe timestamp is formatted as full ISO 8601 e.g. `2021-12-20T10:33:52Z`.").optional(),
+  "title": z.string().describe("The title in plain text.")
+}

--- a/servers/api_example_com/src/tools/uploadattachment/index.ts
+++ b/servers/api_example_com/src/tools/uploadattachment/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "uploadattachment",
+  "toolDescription": "Upload attachment",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/external/v1/attachments",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/uploadattachment/schema-json/root.json
+++ b/servers/api_example_com/src/tools/uploadattachment/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/uploadattachment/schema/root.ts
+++ b/servers/api_example_com/src/tools/uploadattachment/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.