### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,448 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `productId` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `productId` (string)
+- `colorId` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `productId` (string)
+- `colorId` (string)
+
+### putapimobilebyversioncountriesbycountrylanguagesbylanguagecart
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `quantity` (number)
+- `sizeId` (string)
+- `variantId` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageminica
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `password` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `termsAccepted` (boolean)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `email` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageregis
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `firstName` (string)
+- `lastName` (string)
+- `password` (string)
+- `shippingCountry` (other)
+- `email` (string)
+- `gender` (other)
+- `newsletterAccepted` (boolean)
+- `birthDate` (object)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `email` (string)
+- `password` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `day` (string)
+- `month` (string)
+- `year` (number)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `email` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `items` (array)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `url` (string)
+- `pageType` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+- `isNewAccount` (string)
+- `isNewsletterAccepted` (string)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)
+
+### postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `version` (string)
+- `country` (string)
+- `language` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,32 @@
+export const OPENAPI_URL = "https://pref.shop.c-and-a.com/api/mobile/v2/countries/de/languages/de/openapi"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/index.js",
+  "./tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/index.js",
+  "./tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/index.js",
+  "./tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.js",
+  "./tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/index.ts
+++ b/servers/api_example_com/src/tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc",
+  "toolDescription": "Delete account",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/account",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "body": {
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/schema-json/root.json
+++ b/servers/api_example_com/src/tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language",
+    "password"
+  ]
+}

--- a/servers/api_example_com/src/tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/schema/root.ts
+++ b/servers/api_example_com/src/tools/deleteapimobilebyversioncountriesbycountrylanguagesbylanguageacc/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "password": z.string()
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun",
+  "toolDescription": "Get wishlist",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/account/wishlist",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema/root.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string()
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/index.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getapimobilebyversioncountriesbycountrylanguagesbylanguageminica",
+  "toolDescription": "Query Minicart",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/minicart",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/schema/root.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageminica/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string()
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/index.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie",
+  "toolDescription": "Get preview app home page by id",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/preview/app-homes/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id",
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/schema/root.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageprevie/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string(),
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string()
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/index.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc",
+  "toolDescription": "Get Product Sizes",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/product/{productId}/{colorId}/sizes",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language",
+      "productId": "productId",
+      "colorId": "colorId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "default": "v2"
+    },
+    "country": {
+      "type": "string",
+      "default": "de"
+    },
+    "language": {
+      "type": "string",
+      "default": "de"
+    },
+    "productId": {
+      "type": "string",
+      "default": "2108540"
+    },
+    "colorId": {
+      "type": "string",
+      "default": "1"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/schema/root.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageproduc/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string().optional(),
+  "country": z.string().optional(),
+  "language": z.string().optional(),
+  "productId": z.string().optional(),
+  "colorId": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/index.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap",
+  "toolDescription": "Get app home page",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/view/app-home",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/schema/root.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewap/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string()
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/index.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy",
+  "toolDescription": "Get my account page",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/view/my-account",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "query": {
+      "isNewAccount": "isNewAccount",
+      "isNewsletterAccepted": "isNewsletterAccepted"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/schema-json/root.json
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "isNewAccount": {
+      "type": "string"
+    },
+    "isNewsletterAccepted": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/schema/root.ts
+++ b/servers/api_example_com/src/tools/getapimobilebyversioncountriesbycountrylanguagesbylanguageviewmy/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "isNewAccount": z.string().optional(),
+  "isNewsletterAccepted": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou",
+  "toolDescription": "Reset password",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/account/refresh-token",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/schema-json/root.json
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/schema/root.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageaccou/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string()
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/index.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin",
+  "toolDescription": "User login",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "body": {
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/schema-json/root.json
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language",
+    "email",
+    "password"
+  ]
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/schema/root.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagelogin/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "email": z.string().email(),
+  "password": z.string()
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/index.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig",
+  "toolDescription": "Resolves deep links",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/navigation/deep-link-navigation",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "body": {
+      "url": "url",
+      "pageType": "pageType"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/schema-json/root.json
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://www.c-and-a.com/es/ca/shop/slim-jeans-flex-jog-denim-lycra-2161544/1"
+    },
+    "pageType": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language"
+  ]
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/schema/root.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguagenavig/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "url": z.string().url().optional(),
+  "pageType": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/index.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "postapimobilebyversioncountriesbycountrylanguagesbylanguageregis",
+  "toolDescription": "Account creation",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/register",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "body": {
+      "firstName": "firstName",
+      "lastName": "lastName",
+      "password": "password",
+      "shippingCountry": "shippingCountry",
+      "email": "email",
+      "gender": "gender",
+      "newsletterAccepted": "newsletterAccepted",
+      "birthDate": "birthDate"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema-json/properties/birthDate.json
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema-json/properties/birthDate.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "day": {
+      "type": "string"
+    },
+    "month": {
+      "type": "string"
+    },
+    "year": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "day",
+    "month",
+    "year"
+  ]
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema-json/root.json
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema-json/root.json
@@ -1,0 +1,373 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    },
+    "shippingCountry": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "AT"
+            },
+            {
+              "type": "string",
+              "const": "at"
+            },
+            {
+              "type": "string",
+              "const": "BE"
+            },
+            {
+              "type": "string",
+              "const": "be"
+            },
+            {
+              "type": "string",
+              "const": "CH"
+            },
+            {
+              "type": "string",
+              "const": "ch"
+            },
+            {
+              "type": "string",
+              "const": "CZ"
+            },
+            {
+              "type": "string",
+              "const": "cz"
+            },
+            {
+              "type": "string",
+              "const": "DE"
+            },
+            {
+              "type": "string",
+              "const": "de"
+            },
+            {
+              "type": "string",
+              "const": "DK"
+            },
+            {
+              "type": "string",
+              "const": "dk"
+            },
+            {
+              "type": "string",
+              "const": "ES"
+            },
+            {
+              "type": "string",
+              "const": "es"
+            },
+            {
+              "type": "string",
+              "const": "FI"
+            },
+            {
+              "type": "string",
+              "const": "fi"
+            },
+            {
+              "type": "string",
+              "const": "FR"
+            },
+            {
+              "type": "string",
+              "const": "fr"
+            },
+            {
+              "type": "string",
+              "const": "GR"
+            },
+            {
+              "type": "string",
+              "const": "gr"
+            },
+            {
+              "type": "string",
+              "const": "HR"
+            },
+            {
+              "type": "string",
+              "const": "hr"
+            },
+            {
+              "type": "string",
+              "const": "HU"
+            },
+            {
+              "type": "string",
+              "const": "hu"
+            },
+            {
+              "type": "string",
+              "const": "IT"
+            },
+            {
+              "type": "string",
+              "const": "it"
+            },
+            {
+              "type": "string",
+              "const": "NL"
+            },
+            {
+              "type": "string",
+              "const": "nl"
+            },
+            {
+              "type": "string",
+              "const": "PL"
+            },
+            {
+              "type": "string",
+              "const": "pl"
+            },
+            {
+              "type": "string",
+              "const": "PT"
+            },
+            {
+              "type": "string",
+              "const": "pt"
+            },
+            {
+              "type": "string",
+              "const": "RO"
+            },
+            {
+              "type": "string",
+              "const": "ro"
+            },
+            {
+              "type": "string",
+              "const": "SE"
+            },
+            {
+              "type": "string",
+              "const": "se"
+            },
+            {
+              "type": "string",
+              "const": "SI"
+            },
+            {
+              "type": "string",
+              "const": "si"
+            },
+            {
+              "type": "string",
+              "const": "SK"
+            },
+            {
+              "type": "string",
+              "const": "sk"
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "AT"
+            },
+            {
+              "type": "string",
+              "const": "at"
+            },
+            {
+              "type": "string",
+              "const": "BE"
+            },
+            {
+              "type": "string",
+              "const": "be"
+            },
+            {
+              "type": "string",
+              "const": "CH"
+            },
+            {
+              "type": "string",
+              "const": "ch"
+            },
+            {
+              "type": "string",
+              "const": "CZ"
+            },
+            {
+              "type": "string",
+              "const": "cz"
+            },
+            {
+              "type": "string",
+              "const": "DE"
+            },
+            {
+              "type": "string",
+              "const": "de"
+            },
+            {
+              "type": "string",
+              "const": "ES"
+            },
+            {
+              "type": "string",
+              "const": "es"
+            },
+            {
+              "type": "string",
+              "const": "EU"
+            },
+            {
+              "type": "string",
+              "const": "eu"
+            },
+            {
+              "type": "string",
+              "const": "FR"
+            },
+            {
+              "type": "string",
+              "const": "fr"
+            },
+            {
+              "type": "string",
+              "const": "HR"
+            },
+            {
+              "type": "string",
+              "const": "hr"
+            },
+            {
+              "type": "string",
+              "const": "HU"
+            },
+            {
+              "type": "string",
+              "const": "hu"
+            },
+            {
+              "type": "string",
+              "const": "IT"
+            },
+            {
+              "type": "string",
+              "const": "it"
+            },
+            {
+              "type": "string",
+              "const": "NL"
+            },
+            {
+              "type": "string",
+              "const": "nl"
+            },
+            {
+              "type": "string",
+              "const": "PL"
+            },
+            {
+              "type": "string",
+              "const": "pl"
+            },
+            {
+              "type": "string",
+              "const": "RO"
+            },
+            {
+              "type": "string",
+              "const": "ro"
+            },
+            {
+              "type": "string",
+              "const": "SI"
+            },
+            {
+              "type": "string",
+              "const": "si"
+            },
+            {
+              "type": "string",
+              "const": "SK"
+            },
+            {
+              "type": "string",
+              "const": "sk"
+            }
+          ]
+        }
+      ]
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "gender": {
+      "anyOf": [
+        {
+          "type": "string",
+          "const": "MR"
+        },
+        {
+          "type": "string",
+          "const": "mr"
+        },
+        {
+          "type": "string",
+          "const": "MRS"
+        },
+        {
+          "type": "string",
+          "const": "mrs"
+        },
+        {
+          "type": "string",
+          "const": "OTHER"
+        },
+        {
+          "type": "string",
+          "const": "other"
+        }
+      ]
+    },
+    "newsletterAccepted": {
+      "type": "boolean"
+    },
+    "birthDate": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `birthDate` to the tool, first call the tool `expandSchema` with \"/properties/birthDate\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language",
+    "firstName",
+    "lastName",
+    "password",
+    "email",
+    "gender"
+  ]
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema/properties/birthDate.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema/properties/birthDate.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "day": z.string(),
+  "month": z.string(),
+  "year": z.number()
+}

--- a/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema/root.ts
+++ b/servers/api_example_com/src/tools/postapimobilebyversioncountriesbycountrylanguagesbylanguageregis/schema/root.ts
@@ -1,0 +1,15 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "firstName": z.string(),
+  "lastName": z.string(),
+  "password": z.string(),
+  "shippingCountry": z.union([z.union([z.literal("AT"), z.literal("at"), z.literal("BE"), z.literal("be"), z.literal("CH"), z.literal("ch"), z.literal("CZ"), z.literal("cz"), z.literal("DE"), z.literal("de"), z.literal("DK"), z.literal("dk"), z.literal("ES"), z.literal("es"), z.literal("FI"), z.literal("fi"), z.literal("FR"), z.literal("fr"), z.literal("GR"), z.literal("gr"), z.literal("HR"), z.literal("hr"), z.literal("HU"), z.literal("hu"), z.literal("IT"), z.literal("it"), z.literal("NL"), z.literal("nl"), z.literal("PL"), z.literal("pl"), z.literal("PT"), z.literal("pt"), z.literal("RO"), z.literal("ro"), z.literal("SE"), z.literal("se"), z.literal("SI"), z.literal("si"), z.literal("SK"), z.literal("sk")]), z.union([z.literal("AT"), z.literal("at"), z.literal("BE"), z.literal("be"), z.literal("CH"), z.literal("ch"), z.literal("CZ"), z.literal("cz"), z.literal("DE"), z.literal("de"), z.literal("ES"), z.literal("es"), z.literal("EU"), z.literal("eu"), z.literal("FR"), z.literal("fr"), z.literal("HR"), z.literal("hr"), z.literal("HU"), z.literal("hu"), z.literal("IT"), z.literal("it"), z.literal("NL"), z.literal("nl"), z.literal("PL"), z.literal("pl"), z.literal("RO"), z.literal("ro"), z.literal("SI"), z.literal("si"), z.literal("SK"), z.literal("sk")])]).optional(),
+  "email": z.string().email(),
+  "gender": z.union([z.literal("MR"), z.literal("mr"), z.literal("MRS"), z.literal("mrs"), z.literal("OTHER"), z.literal("other")]),
+  "newsletterAccepted": z.boolean().optional(),
+  "birthDate": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `birthDate` to the tool, first call the tool `expandSchema` with \"/properties/birthDate\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.ts
+++ b/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun",
+  "toolDescription": "Update user birthdate",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/account/birthdate",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "body": {
+      "day": "day",
+      "month": "month",
+      "year": "year"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema-json/root.json
+++ b/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema-json/root.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "day": {
+      "type": "string"
+    },
+    "month": {
+      "type": "string"
+    },
+    "year": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language",
+    "day",
+    "month",
+    "year"
+  ]
+}

--- a/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema/root.ts
+++ b/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguageaccoun/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "day": z.string(),
+  "month": z.string(),
+  "year": z.number()
+}

--- a/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/index.ts
+++ b/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "putapimobilebyversioncountriesbycountrylanguagesbylanguagecart",
+  "toolDescription": "Save a cart",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/mobile/{version}/countries/{country}/languages/{language}/cart",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "version": "version",
+      "country": "country",
+      "language": "language"
+    },
+    "body": {
+      "quantity": "quantity",
+      "sizeId": "sizeId",
+      "variantId": "variantId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/schema-json/root.json
+++ b/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/schema-json/root.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "quantity": {
+      "type": "number"
+    },
+    "sizeId": {
+      "type": "string"
+    },
+    "variantId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "country",
+    "language",
+    "quantity",
+    "variantId"
+  ]
+}

--- a/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/schema/root.ts
+++ b/servers/api_example_com/src/tools/putapimobilebyversioncountriesbycountrylanguagesbylanguagecart/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "version": z.string(),
+  "country": z.string(),
+  "language": z.string(),
+  "quantity": z.number(),
+  "sizeId": z.string().optional(),
+  "variantId": z.string()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.