### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,119 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_health_health_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### webhook_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `from` (object)
+- `to` (object)
+- `message` (object)
+- `reference` (string)
+- `groupings` (array)
+- `timeUtc` (string)
+- `channel` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,7 @@
+export const OPENAPI_URL = "https://fawn-vocal-freely.ngrok-free.app/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_health_health_get/index.js",
+  "./tools/webhook_post/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/get_health_health_get/index.ts
+++ b/servers/api_example_com/src/tools/get_health_health_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_health_health_get",
+  "toolDescription": "Get Health",
+  "baseUrl": "https://api.example.com",
+  "path": "/health",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_health_health_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_health_health_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_health_health_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_health_health_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/webhook_post/index.ts
+++ b/servers/api_example_com/src/tools/webhook_post/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "webhook_post",
+  "toolDescription": "Webhook",
+  "baseUrl": "https://api.example.com",
+  "path": "/",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "from": "from",
+      "to": "to",
+      "message": "message",
+      "reference": "reference",
+      "groupings": "groupings",
+      "timeUtc": "timeUtc",
+      "channel": "channel"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/webhook_post/schema-json/properties/from.json
+++ b/servers/api_example_com/src/tools/webhook_post/schema-json/properties/from.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name"
+    },
+    "number": {
+      "type": "string",
+      "title": "Number"
+    }
+  },
+  "type": "object",
+  "required": [
+    "name",
+    "number"
+  ],
+  "title": "From"
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema-json/properties/message.json
+++ b/servers/api_example_com/src/tools/webhook_post/schema-json/properties/message.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "text": {
+      "type": "string",
+      "title": "Text"
+    },
+    "media": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `media` to the tool, first call the tool `expandSchema` with \"/properties/message/properties/media\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "custom": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `custom` to the tool, first call the tool `expandSchema` with \"/properties/message/properties/custom\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "type": "object",
+  "required": [
+    "text",
+    "media",
+    "custom"
+  ],
+  "title": "Message"
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema-json/properties/message/properties/custom.json
+++ b/servers/api_example_com/src/tools/webhook_post/schema-json/properties/message/properties/custom.json
@@ -1,0 +1,6 @@
+{
+  "additionalProperties": true,
+  "type": "object",
+  "title": "Custom",
+  "properties": {}
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema-json/properties/message/properties/media.json
+++ b/servers/api_example_com/src/tools/webhook_post/schema-json/properties/message/properties/media.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "mediaUri": {
+      "type": "string",
+      "title": "Mediauri"
+    },
+    "contentType": {
+      "type": "string",
+      "title": "Contenttype"
+    },
+    "title": {
+      "type": "string",
+      "title": "Title"
+    }
+  },
+  "type": "object",
+  "required": [
+    "mediaUri",
+    "contentType",
+    "title"
+  ],
+  "title": "Media"
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema-json/properties/to.json
+++ b/servers/api_example_com/src/tools/webhook_post/schema-json/properties/to.json
@@ -1,0 +1,13 @@
+{
+  "properties": {
+    "number": {
+      "type": "string",
+      "title": "Number"
+    }
+  },
+  "type": "object",
+  "required": [
+    "number"
+  ],
+  "title": "To"
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/webhook_post/schema-json/root.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "properties": {
+    "from": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `from` to the tool, first call the tool `expandSchema` with \"/properties/from\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "to": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `to` to the tool, first call the tool `expandSchema` with \"/properties/to\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "message": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `message` to the tool, first call the tool `expandSchema` with \"/properties/message\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    },
+    "reference": {
+      "type": "string",
+      "title": "Reference"
+    },
+    "groupings": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Groupings"
+    },
+    "timeUtc": {
+      "type": "string",
+      "title": "Timeutc"
+    },
+    "channel": {
+      "type": "string",
+      "title": "Channel"
+    }
+  },
+  "required": [
+    "from",
+    "to",
+    "message",
+    "reference",
+    "groupings",
+    "timeUtc",
+    "channel"
+  ]
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema/properties/from.ts
+++ b/servers/api_example_com/src/tools/webhook_post/schema/properties/from.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string(),
+  "number": z.string()
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema/properties/message.ts
+++ b/servers/api_example_com/src/tools/webhook_post/schema/properties/message.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "text": z.string(),
+  "media": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `media` to the tool, first call the tool `expandSchema` with \"/properties/message/properties/media\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>"),
+  "custom": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `custom` to the tool, first call the tool `expandSchema` with \"/properties/message/properties/custom\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema/properties/message/properties/custom.ts
+++ b/servers/api_example_com/src/tools/webhook_post/schema/properties/message/properties/custom.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/webhook_post/schema/properties/message/properties/media.ts
+++ b/servers/api_example_com/src/tools/webhook_post/schema/properties/message/properties/media.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "mediaUri": z.string(),
+  "contentType": z.string(),
+  "title": z.string()
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema/properties/to.ts
+++ b/servers/api_example_com/src/tools/webhook_post/schema/properties/to.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "number": z.string()
+}

--- a/servers/api_example_com/src/tools/webhook_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/webhook_post/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "from": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `from` to the tool, first call the tool `expandSchema` with \"/properties/from\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>"),
+  "to": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `to` to the tool, first call the tool `expandSchema` with \"/properties/to\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>"),
+  "message": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `message` to the tool, first call the tool `expandSchema` with \"/properties/message\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>"),
+  "reference": z.string(),
+  "groupings": z.array(z.string()),
+  "timeUtc": z.string(),
+  "channel": z.string()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.