### PR TITLE
Add MCP server `_validator`

### DIFF
--- a/servers/_validator/.npmignore
+++ b/servers/_validator/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_validator/README.md
+++ b/servers/_validator/README.md
@@ -1,0 +1,220 @@
+# @open-mcp/_validator
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "_validator": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/_validator@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/_validator@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add _validator \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add _validator \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add _validator \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_validator": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_validator"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### validatebyurl
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `url` (string)
+- `resolve` (boolean)
+- `resolveFully` (boolean)
+- `validateInternalRefs` (boolean)
+- `validateExternalRefs` (boolean)
+- `resolveRequestBody` (boolean)
+- `resolveCombinators` (boolean)
+- `allowEmptyStrings` (boolean)
+- `legacyYamlDeserialization` (boolean)
+- `inferSchemaType` (boolean)
+- `jsonSchemaValidation` (boolean)
+- `legacyJsonSchemaValidation` (boolean)
+
+### validatebycontent
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `resolve` (boolean)
+- `resolveFully` (boolean)
+- `validateInternalRefs` (boolean)
+- `validateExternalRefs` (boolean)
+- `resolveRequestBody` (boolean)
+- `resolveCombinators` (boolean)
+- `allowEmptyStrings` (boolean)
+- `legacyYamlDeserialization` (boolean)
+- `inferSchemaType` (boolean)
+- `jsonSchemaValidation` (boolean)
+- `legacyJsonSchemaValidation` (boolean)
+
+### reviewbyurl
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `url` (string)
+- `resolve` (boolean)
+- `resolveFully` (boolean)
+- `validateInternalRefs` (boolean)
+- `validateExternalRefs` (boolean)
+- `resolveRequestBody` (boolean)
+- `resolveCombinators` (boolean)
+- `allowEmptyStrings` (boolean)
+- `legacyYamlDeserialization` (boolean)
+- `inferSchemaType` (boolean)
+- `jsonSchemaValidation` (boolean)
+- `legacyJsonSchemaValidation` (boolean)
+
+### reviewbycontent
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `resolve` (boolean)
+- `resolveFully` (boolean)
+- `validateInternalRefs` (boolean)
+- `validateExternalRefs` (boolean)
+- `resolveRequestBody` (boolean)
+- `resolveCombinators` (boolean)
+- `allowEmptyStrings` (boolean)
+- `legacyYamlDeserialization` (boolean)
+- `inferSchemaType` (boolean)
+- `jsonSchemaValidation` (boolean)
+- `legacyJsonSchemaValidation` (boolean)
+
+### parsebyurl
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `url` (string)
+- `resolve` (boolean)
+- `resolveFully` (boolean)
+- `flatten` (boolean)
+- `validateInternalRefs` (boolean)
+- `validateExternalRefs` (boolean)
+- `resolveRequestBody` (boolean)
+- `resolveCombinators` (boolean)
+- `allowEmptyStrings` (boolean)
+- `legacyYamlDeserialization` (boolean)
+- `inferSchemaType` (boolean)
+- `jsonSchemaValidation` (boolean)
+- `legacyJsonSchemaValidation` (boolean)
+- `returnFullParseResult` (boolean)
+
+### parsebycontent
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `resolve` (boolean)
+- `resolveFully` (boolean)
+- `flatten` (boolean)
+- `validateInternalRefs` (boolean)
+- `validateExternalRefs` (boolean)
+- `resolveRequestBody` (boolean)
+- `resolveCombinators` (boolean)
+- `allowEmptyStrings` (boolean)
+- `legacyYamlDeserialization` (boolean)
+- `inferSchemaType` (boolean)
+- `jsonSchemaValidation` (boolean)
+- `legacyJsonSchemaValidation` (boolean)
+- `returnFullParseResult` (boolean)

--- a/servers/_validator/package.json
+++ b/servers/_validator/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/_validator",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "_validator": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/_validator/src/constants.ts
+++ b/servers/_validator/src/constants.ts
@@ -1,0 +1,11 @@
+export const OPENAPI_URL = "https://validator.swagger.io/validator/openapi.json"
+export const SERVER_NAME = "_validator"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/validatebyurl/index.js",
+  "./tools/validatebycontent/index.js",
+  "./tools/reviewbyurl/index.js",
+  "./tools/reviewbycontent/index.js",
+  "./tools/parsebyurl/index.js",
+  "./tools/parsebycontent/index.js"
+]

--- a/servers/_validator/src/index.ts
+++ b/servers/_validator/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/_validator/src/server.ts
+++ b/servers/_validator/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_validator/src/tools/parsebycontent/index.ts
+++ b/servers/_validator/src/tools/parsebycontent/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parsebycontent",
+  "toolDescription": "Resolves / Dereferences Swagger/OpenAPI 2.0 or an OpenAPI 3.x definition returning the resolved file",
+  "baseUrl": "/validator",
+  "path": "/parse",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "resolve": "resolve",
+      "resolveFully": "resolveFully",
+      "flatten": "flatten",
+      "validateInternalRefs": "validateInternalRefs",
+      "validateExternalRefs": "validateExternalRefs",
+      "resolveRequestBody": "resolveRequestBody",
+      "resolveCombinators": "resolveCombinators",
+      "allowEmptyStrings": "allowEmptyStrings",
+      "legacyYamlDeserialization": "legacyYamlDeserialization",
+      "inferSchemaType": "inferSchemaType",
+      "jsonSchemaValidation": "jsonSchemaValidation",
+      "legacyJsonSchemaValidation": "legacyJsonSchemaValidation",
+      "returnFullParseResult": "returnFullParseResult"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_validator/src/tools/parsebycontent/schema-json/root.json
+++ b/servers/_validator/src/tools/parsebycontent/schema-json/root.json
@@ -1,0 +1,58 @@
+{
+  "type": "object",
+  "properties": {
+    "resolve": {
+      "description": "resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "resolveFully": {
+      "description": "fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "flatten": {
+      "description": "flatten the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "validateInternalRefs": {
+      "description": "validate internal references",
+      "type": "boolean"
+    },
+    "validateExternalRefs": {
+      "description": "validate external references while resolving",
+      "type": "boolean"
+    },
+    "resolveRequestBody": {
+      "description": "bundle requestBody inline during resolving also with resolveFully set to false",
+      "type": "boolean"
+    },
+    "resolveCombinators": {
+      "description": "customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "allowEmptyStrings": {
+      "description": "when set to true parses empty values as empty strings",
+      "type": "boolean"
+    },
+    "legacyYamlDeserialization": {
+      "description": "legacyYamlDeserialization",
+      "type": "boolean"
+    },
+    "inferSchemaType": {
+      "description": "infer schema type for item, default and schemas with additionalProperties",
+      "type": "boolean"
+    },
+    "jsonSchemaValidation": {
+      "description": "performs JSON Schema validation",
+      "type": "boolean"
+    },
+    "legacyJsonSchemaValidation": {
+      "description": "performs JSON Schema validation using legacy engine (fge)",
+      "type": "boolean"
+    },
+    "returnFullParseResult": {
+      "description": "if set to true returns the full parse result including validation messages",
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/_validator/src/tools/parsebycontent/schema/root.ts
+++ b/servers/_validator/src/tools/parsebycontent/schema/root.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "resolve": z.boolean().describe("resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "resolveFully": z.boolean().describe("fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "flatten": z.boolean().describe("flatten the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "validateInternalRefs": z.boolean().describe("validate internal references").optional(),
+  "validateExternalRefs": z.boolean().describe("validate external references while resolving").optional(),
+  "resolveRequestBody": z.boolean().describe("bundle requestBody inline during resolving also with resolveFully set to false").optional(),
+  "resolveCombinators": z.boolean().describe("customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "allowEmptyStrings": z.boolean().describe("when set to true parses empty values as empty strings").optional(),
+  "legacyYamlDeserialization": z.boolean().describe("legacyYamlDeserialization").optional(),
+  "inferSchemaType": z.boolean().describe("infer schema type for item, default and schemas with additionalProperties").optional(),
+  "jsonSchemaValidation": z.boolean().describe("performs JSON Schema validation").optional(),
+  "legacyJsonSchemaValidation": z.boolean().describe("performs JSON Schema validation using legacy engine (fge)").optional(),
+  "returnFullParseResult": z.boolean().describe("if set to true returns the full parse result including validation messages").optional()
+}

--- a/servers/_validator/src/tools/parsebyurl/index.ts
+++ b/servers/_validator/src/tools/parsebyurl/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parsebyurl",
+  "toolDescription": "Resolves / Dereferences a Swagger/OpenAPI 2.0 or an OpenAPI 3.x definition returning the resolved file",
+  "baseUrl": "/validator",
+  "path": "/parse",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "url": "url",
+      "resolve": "resolve",
+      "resolveFully": "resolveFully",
+      "flatten": "flatten",
+      "validateInternalRefs": "validateInternalRefs",
+      "validateExternalRefs": "validateExternalRefs",
+      "resolveRequestBody": "resolveRequestBody",
+      "resolveCombinators": "resolveCombinators",
+      "allowEmptyStrings": "allowEmptyStrings",
+      "legacyYamlDeserialization": "legacyYamlDeserialization",
+      "inferSchemaType": "inferSchemaType",
+      "jsonSchemaValidation": "jsonSchemaValidation",
+      "legacyJsonSchemaValidation": "legacyJsonSchemaValidation",
+      "returnFullParseResult": "returnFullParseResult"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_validator/src/tools/parsebyurl/schema-json/root.json
+++ b/servers/_validator/src/tools/parsebyurl/schema-json/root.json
@@ -1,0 +1,64 @@
+{
+  "type": "object",
+  "properties": {
+    "url": {
+      "description": "A URL to the definition",
+      "type": "string"
+    },
+    "resolve": {
+      "description": "resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "resolveFully": {
+      "description": "fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "flatten": {
+      "description": "flatten the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "validateInternalRefs": {
+      "description": "validate internal references",
+      "type": "boolean"
+    },
+    "validateExternalRefs": {
+      "description": "validate external references while resolving",
+      "type": "boolean"
+    },
+    "resolveRequestBody": {
+      "description": "bundle requestBody inline during resolving also with resolveFully set to false",
+      "type": "boolean"
+    },
+    "resolveCombinators": {
+      "description": "customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "allowEmptyStrings": {
+      "description": "when set to true parses empty values as empty strings",
+      "type": "boolean"
+    },
+    "legacyYamlDeserialization": {
+      "description": "legacyYamlDeserialization",
+      "type": "boolean"
+    },
+    "inferSchemaType": {
+      "description": "infer schema type for item, default and schemas with additionalProperties",
+      "type": "boolean"
+    },
+    "jsonSchemaValidation": {
+      "description": "performs JSON Schema validation",
+      "type": "boolean"
+    },
+    "legacyJsonSchemaValidation": {
+      "description": "performs JSON Schema validation using legacy engine (fge)",
+      "type": "boolean"
+    },
+    "returnFullParseResult": {
+      "description": "if set to true returns the full parse result including validation messages",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "url"
+  ]
+}

--- a/servers/_validator/src/tools/parsebyurl/schema/root.ts
+++ b/servers/_validator/src/tools/parsebyurl/schema/root.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "url": z.string().describe("A URL to the definition"),
+  "resolve": z.boolean().describe("resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "resolveFully": z.boolean().describe("fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "flatten": z.boolean().describe("flatten the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "validateInternalRefs": z.boolean().describe("validate internal references").optional(),
+  "validateExternalRefs": z.boolean().describe("validate external references while resolving").optional(),
+  "resolveRequestBody": z.boolean().describe("bundle requestBody inline during resolving also with resolveFully set to false").optional(),
+  "resolveCombinators": z.boolean().describe("customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "allowEmptyStrings": z.boolean().describe("when set to true parses empty values as empty strings").optional(),
+  "legacyYamlDeserialization": z.boolean().describe("legacyYamlDeserialization").optional(),
+  "inferSchemaType": z.boolean().describe("infer schema type for item, default and schemas with additionalProperties").optional(),
+  "jsonSchemaValidation": z.boolean().describe("performs JSON Schema validation").optional(),
+  "legacyJsonSchemaValidation": z.boolean().describe("performs JSON Schema validation using legacy engine (fge)").optional(),
+  "returnFullParseResult": z.boolean().describe("if set to true returns the full parse result including validation messages").optional()
+}

--- a/servers/_validator/src/tools/reviewbycontent/index.ts
+++ b/servers/_validator/src/tools/reviewbycontent/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "reviewbycontent",
+  "toolDescription": "Validates a Swagger/OpenAPI 2.0 or an OpenAPI 3.x definition returning a validation response",
+  "baseUrl": "/validator",
+  "path": "/debug",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "resolve": "resolve",
+      "resolveFully": "resolveFully",
+      "validateInternalRefs": "validateInternalRefs",
+      "validateExternalRefs": "validateExternalRefs",
+      "resolveRequestBody": "resolveRequestBody",
+      "resolveCombinators": "resolveCombinators",
+      "allowEmptyStrings": "allowEmptyStrings",
+      "legacyYamlDeserialization": "legacyYamlDeserialization",
+      "inferSchemaType": "inferSchemaType",
+      "jsonSchemaValidation": "jsonSchemaValidation",
+      "legacyJsonSchemaValidation": "legacyJsonSchemaValidation"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_validator/src/tools/reviewbycontent/schema-json/root.json
+++ b/servers/_validator/src/tools/reviewbycontent/schema-json/root.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "properties": {
+    "resolve": {
+      "description": "resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "resolveFully": {
+      "description": "fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "validateInternalRefs": {
+      "description": "validate internal references",
+      "type": "boolean"
+    },
+    "validateExternalRefs": {
+      "description": "validate external references while resolving",
+      "type": "boolean"
+    },
+    "resolveRequestBody": {
+      "description": "bundle requestBody inline during resolving also with resolveFully set to false",
+      "type": "boolean"
+    },
+    "resolveCombinators": {
+      "description": "customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "allowEmptyStrings": {
+      "description": "when set to true parses empty values as empty strings",
+      "type": "boolean"
+    },
+    "legacyYamlDeserialization": {
+      "description": "legacyYamlDeserialization",
+      "type": "boolean"
+    },
+    "inferSchemaType": {
+      "description": "infer schema type for item, default and schemas with additionalProperties",
+      "type": "boolean"
+    },
+    "jsonSchemaValidation": {
+      "description": "performs JSON Schema validation",
+      "type": "boolean"
+    },
+    "legacyJsonSchemaValidation": {
+      "description": "performs JSON Schema validation using legacy engine (fge)",
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/_validator/src/tools/reviewbycontent/schema/root.ts
+++ b/servers/_validator/src/tools/reviewbycontent/schema/root.ts
@@ -1,0 +1,15 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "resolve": z.boolean().describe("resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "resolveFully": z.boolean().describe("fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "validateInternalRefs": z.boolean().describe("validate internal references").optional(),
+  "validateExternalRefs": z.boolean().describe("validate external references while resolving").optional(),
+  "resolveRequestBody": z.boolean().describe("bundle requestBody inline during resolving also with resolveFully set to false").optional(),
+  "resolveCombinators": z.boolean().describe("customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "allowEmptyStrings": z.boolean().describe("when set to true parses empty values as empty strings").optional(),
+  "legacyYamlDeserialization": z.boolean().describe("legacyYamlDeserialization").optional(),
+  "inferSchemaType": z.boolean().describe("infer schema type for item, default and schemas with additionalProperties").optional(),
+  "jsonSchemaValidation": z.boolean().describe("performs JSON Schema validation").optional(),
+  "legacyJsonSchemaValidation": z.boolean().describe("performs JSON Schema validation using legacy engine (fge)").optional()
+}

--- a/servers/_validator/src/tools/reviewbyurl/index.ts
+++ b/servers/_validator/src/tools/reviewbyurl/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "reviewbyurl",
+  "toolDescription": "Validates a Swagger/OpenAPI 2.0 or an OpenAPI 3.x definition returning a validation response",
+  "baseUrl": "/validator",
+  "path": "/debug",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "url": "url",
+      "resolve": "resolve",
+      "resolveFully": "resolveFully",
+      "validateInternalRefs": "validateInternalRefs",
+      "validateExternalRefs": "validateExternalRefs",
+      "resolveRequestBody": "resolveRequestBody",
+      "resolveCombinators": "resolveCombinators",
+      "allowEmptyStrings": "allowEmptyStrings",
+      "legacyYamlDeserialization": "legacyYamlDeserialization",
+      "inferSchemaType": "inferSchemaType",
+      "jsonSchemaValidation": "jsonSchemaValidation",
+      "legacyJsonSchemaValidation": "legacyJsonSchemaValidation"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_validator/src/tools/reviewbyurl/schema-json/root.json
+++ b/servers/_validator/src/tools/reviewbyurl/schema-json/root.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "properties": {
+    "url": {
+      "description": "A URL to the definition",
+      "type": "string"
+    },
+    "resolve": {
+      "description": "resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "resolveFully": {
+      "description": "fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "validateInternalRefs": {
+      "description": "validate internal references",
+      "type": "boolean"
+    },
+    "validateExternalRefs": {
+      "description": "validate external references while resolving",
+      "type": "boolean"
+    },
+    "resolveRequestBody": {
+      "description": "bundle requestBody inline during resolving also with resolveFully set to false",
+      "type": "boolean"
+    },
+    "resolveCombinators": {
+      "description": "customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "allowEmptyStrings": {
+      "description": "when set to true parses empty values as empty strings",
+      "type": "boolean"
+    },
+    "legacyYamlDeserialization": {
+      "description": "legacyYamlDeserialization",
+      "type": "boolean"
+    },
+    "inferSchemaType": {
+      "description": "infer schema type for item, default and schemas with additionalProperties",
+      "type": "boolean"
+    },
+    "jsonSchemaValidation": {
+      "description": "performs JSON Schema validation",
+      "type": "boolean"
+    },
+    "legacyJsonSchemaValidation": {
+      "description": "performs JSON Schema validation using legacy engine (fge)",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "url"
+  ]
+}

--- a/servers/_validator/src/tools/reviewbyurl/schema/root.ts
+++ b/servers/_validator/src/tools/reviewbyurl/schema/root.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "url": z.string().describe("A URL to the definition"),
+  "resolve": z.boolean().describe("resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "resolveFully": z.boolean().describe("fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "validateInternalRefs": z.boolean().describe("validate internal references").optional(),
+  "validateExternalRefs": z.boolean().describe("validate external references while resolving").optional(),
+  "resolveRequestBody": z.boolean().describe("bundle requestBody inline during resolving also with resolveFully set to false").optional(),
+  "resolveCombinators": z.boolean().describe("customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "allowEmptyStrings": z.boolean().describe("when set to true parses empty values as empty strings").optional(),
+  "legacyYamlDeserialization": z.boolean().describe("legacyYamlDeserialization").optional(),
+  "inferSchemaType": z.boolean().describe("infer schema type for item, default and schemas with additionalProperties").optional(),
+  "jsonSchemaValidation": z.boolean().describe("performs JSON Schema validation").optional(),
+  "legacyJsonSchemaValidation": z.boolean().describe("performs JSON Schema validation using legacy engine (fge)").optional()
+}

--- a/servers/_validator/src/tools/validatebycontent/index.ts
+++ b/servers/_validator/src/tools/validatebycontent/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "validatebycontent",
+  "toolDescription": "Validates a Swagger/OpenAPI 2.0 or an OpenAPI 3.x definition returning a valid/invalid badge",
+  "baseUrl": "/validator",
+  "path": "/",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "resolve": "resolve",
+      "resolveFully": "resolveFully",
+      "validateInternalRefs": "validateInternalRefs",
+      "validateExternalRefs": "validateExternalRefs",
+      "resolveRequestBody": "resolveRequestBody",
+      "resolveCombinators": "resolveCombinators",
+      "allowEmptyStrings": "allowEmptyStrings",
+      "legacyYamlDeserialization": "legacyYamlDeserialization",
+      "inferSchemaType": "inferSchemaType",
+      "jsonSchemaValidation": "jsonSchemaValidation",
+      "legacyJsonSchemaValidation": "legacyJsonSchemaValidation"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_validator/src/tools/validatebycontent/schema-json/root.json
+++ b/servers/_validator/src/tools/validatebycontent/schema-json/root.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "properties": {
+    "resolve": {
+      "description": "resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "resolveFully": {
+      "description": "fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "validateInternalRefs": {
+      "description": "validate internal references",
+      "type": "boolean"
+    },
+    "validateExternalRefs": {
+      "description": "validate external references while resolving",
+      "type": "boolean"
+    },
+    "resolveRequestBody": {
+      "description": "bundle requestBody inline during resolving also with resolveFully set to false",
+      "type": "boolean"
+    },
+    "resolveCombinators": {
+      "description": "customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "allowEmptyStrings": {
+      "description": "when set to true parses empty values as empty strings",
+      "type": "boolean"
+    },
+    "legacyYamlDeserialization": {
+      "description": "legacyYamlDeserialization",
+      "type": "boolean"
+    },
+    "inferSchemaType": {
+      "description": "infer schema type for item, default and schemas with additionalProperties",
+      "type": "boolean"
+    },
+    "jsonSchemaValidation": {
+      "description": "performs JSON Schema validation",
+      "type": "boolean"
+    },
+    "legacyJsonSchemaValidation": {
+      "description": "performs JSON Schema validation using legacy engine (fge)",
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/_validator/src/tools/validatebycontent/schema/root.ts
+++ b/servers/_validator/src/tools/validatebycontent/schema/root.ts
@@ -1,0 +1,15 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "resolve": z.boolean().describe("resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "resolveFully": z.boolean().describe("fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "validateInternalRefs": z.boolean().describe("validate internal references").optional(),
+  "validateExternalRefs": z.boolean().describe("validate external references while resolving").optional(),
+  "resolveRequestBody": z.boolean().describe("bundle requestBody inline during resolving also with resolveFully set to false").optional(),
+  "resolveCombinators": z.boolean().describe("customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "allowEmptyStrings": z.boolean().describe("when set to true parses empty values as empty strings").optional(),
+  "legacyYamlDeserialization": z.boolean().describe("legacyYamlDeserialization").optional(),
+  "inferSchemaType": z.boolean().describe("infer schema type for item, default and schemas with additionalProperties").optional(),
+  "jsonSchemaValidation": z.boolean().describe("performs JSON Schema validation").optional(),
+  "legacyJsonSchemaValidation": z.boolean().describe("performs JSON Schema validation using legacy engine (fge)").optional()
+}

--- a/servers/_validator/src/tools/validatebyurl/index.ts
+++ b/servers/_validator/src/tools/validatebyurl/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "validatebyurl",
+  "toolDescription": "Validates a Swagger/OpenAPI 2.0 or an OpenAPI 3.x definition returning a valid/invalid badge",
+  "baseUrl": "/validator",
+  "path": "/",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "url": "url",
+      "resolve": "resolve",
+      "resolveFully": "resolveFully",
+      "validateInternalRefs": "validateInternalRefs",
+      "validateExternalRefs": "validateExternalRefs",
+      "resolveRequestBody": "resolveRequestBody",
+      "resolveCombinators": "resolveCombinators",
+      "allowEmptyStrings": "allowEmptyStrings",
+      "legacyYamlDeserialization": "legacyYamlDeserialization",
+      "inferSchemaType": "inferSchemaType",
+      "jsonSchemaValidation": "jsonSchemaValidation",
+      "legacyJsonSchemaValidation": "legacyJsonSchemaValidation"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_validator/src/tools/validatebyurl/schema-json/root.json
+++ b/servers/_validator/src/tools/validatebyurl/schema-json/root.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "properties": {
+    "url": {
+      "description": "A URL to the definition",
+      "type": "string"
+    },
+    "resolve": {
+      "description": "resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n",
+      "type": "boolean"
+    },
+    "resolveFully": {
+      "description": "fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "validateInternalRefs": {
+      "description": "validate internal references",
+      "type": "boolean"
+    },
+    "validateExternalRefs": {
+      "description": "validate external references while resolving",
+      "type": "boolean"
+    },
+    "resolveRequestBody": {
+      "description": "bundle requestBody inline during resolving also with resolveFully set to false",
+      "type": "boolean"
+    },
+    "resolveCombinators": {
+      "description": "customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n",
+      "type": "boolean"
+    },
+    "allowEmptyStrings": {
+      "description": "when set to true parses empty values as empty strings",
+      "type": "boolean"
+    },
+    "legacyYamlDeserialization": {
+      "description": "legacyYamlDeserialization",
+      "type": "boolean"
+    },
+    "inferSchemaType": {
+      "description": "infer schema type for item, default and schemas with additionalProperties",
+      "type": "boolean"
+    },
+    "jsonSchemaValidation": {
+      "description": "performs JSON Schema validation",
+      "type": "boolean"
+    },
+    "legacyJsonSchemaValidation": {
+      "description": "performs JSON Schema validation using legacy engine (fge)",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "url"
+  ]
+}

--- a/servers/_validator/src/tools/validatebyurl/schema/root.ts
+++ b/servers/_validator/src/tools/validatebyurl/schema/root.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "url": z.string().describe("A URL to the definition"),
+  "resolve": z.boolean().describe("resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options\n").optional(),
+  "resolveFully": z.boolean().describe("fully resolves the definition\nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "validateInternalRefs": z.boolean().describe("validate internal references").optional(),
+  "validateExternalRefs": z.boolean().describe("validate external references while resolving").optional(),
+  "resolveRequestBody": z.boolean().describe("bundle requestBody inline during resolving also with resolveFully set to false").optional(),
+  "resolveCombinators": z.boolean().describe("customizes behaviour related to `allOf/anyOf/oneOf` with resolveFully set to true. \nSee https://github.com/swagger-api/swagger-parser/blob/master/README.md#options'\n").optional(),
+  "allowEmptyStrings": z.boolean().describe("when set to true parses empty values as empty strings").optional(),
+  "legacyYamlDeserialization": z.boolean().describe("legacyYamlDeserialization").optional(),
+  "inferSchemaType": z.boolean().describe("infer schema type for item, default and schemas with additionalProperties").optional(),
+  "jsonSchemaValidation": z.boolean().describe("performs JSON Schema validation").optional(),
+  "legacyJsonSchemaValidation": z.boolean().describe("performs JSON Schema validation using legacy engine (fge)").optional()
+}

--- a/servers/_validator/tsconfig.json
+++ b/servers/_validator/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_validator`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_validator`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_validator": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_validator"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.