### PR TITLE
Add MCP server `6_dot_authentiqio_appspot_com`

### DIFF
--- a/servers/6_dot_authentiqio_appspot_com/.npmignore
+++ b/servers/6_dot_authentiqio_appspot_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/6_dot_authentiqio_appspot_com/README.md
+++ b/servers/6_dot_authentiqio_appspot_com/README.md
@@ -1,0 +1,236 @@
+# @open-mcp/6_dot_authentiqio_appspot_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "6_dot_authentiqio_appspot_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/6_dot_authentiqio_appspot_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/6_dot_authentiqio_appspot_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add 6_dot_authentiqio_appspot_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add 6_dot_authentiqio_appspot_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add 6_dot_authentiqio_appspot_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "6_dot_authentiqio_appspot_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/6_dot_authentiqio_appspot_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### key_revoke_nosecret
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `email` (string)
+- `phone` (string)
+- `code` (string)
+
+### key_register
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### key_revoke
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `PK` (string)
+- `secret` (string)
+
+### key_retrieve
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `PK` (string)
+
+### head_key_pk_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `PK` (string)
+
+### key_update
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `PK` (string)
+
+### key_bind
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `PK` (string)
+
+### push_login_request
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `callback` (string)
+
+### sign_request
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `test` (integer)
+
+### sign_delete
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `job` (string)
+
+### sign_retrieve
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `job` (string)
+
+### sign_retrieve_head
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `job` (string)
+
+### sign_confirm
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `job` (string)
+
+### sign_update
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `job` (string)

--- a/servers/6_dot_authentiqio_appspot_com/package.json
+++ b/servers/6_dot_authentiqio_appspot_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/6_dot_authentiqio_appspot_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "6_dot_authentiqio_appspot_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/constants.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/constants.ts
@@ -1,0 +1,19 @@
+export const OPENAPI_URL = "https://api.apis.guru/v2/specs/6-dot-authentiqio.appspot.com/6/openapi.json"
+export const SERVER_NAME = "6_dot_authentiqio_appspot_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/key_revoke_nosecret/index.js",
+  "./tools/key_register/index.js",
+  "./tools/key_revoke/index.js",
+  "./tools/key_retrieve/index.js",
+  "./tools/head_key_pk_/index.js",
+  "./tools/key_update/index.js",
+  "./tools/key_bind/index.js",
+  "./tools/push_login_request/index.js",
+  "./tools/sign_request/index.js",
+  "./tools/sign_delete/index.js",
+  "./tools/sign_retrieve/index.js",
+  "./tools/sign_retrieve_head/index.js",
+  "./tools/sign_confirm/index.js",
+  "./tools/sign_update/index.js"
+]

--- a/servers/6_dot_authentiqio_appspot_com/src/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/6_dot_authentiqio_appspot_com/src/server.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/head_key_pk_/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/head_key_pk_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "head_key_pk_",
+  "toolDescription": "HEAD info on Authentiq ID",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key/{PK}",
+  "method": "head",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "PK": "PK"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/head_key_pk_/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/head_key_pk_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "PK"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/head_key_pk_/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/head_key_pk_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "PK": z.string().describe("Public Signing Key - Authentiq ID (43 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_bind/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_bind/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "key_bind",
+  "toolDescription": "Update Authentiq ID by replacing the object.\n\nv4: `JWT(sub,email,phone)` to bind email/phone hash; \n\nv5: POST issuer-signed email & phone scopes\nand PUT to update registration `JWT(sub, pk, devtoken, ...)`\n\nSee: https://github.com/skion/aut",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key/{PK}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "PK": "PK"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_bind/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_bind/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "PK"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_bind/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_bind/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "PK": z.string().describe("Public Signing Key - Authentiq ID (43 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_register/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_register/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "key_register",
+  "toolDescription": "Register a new ID `JWT(sub, devtoken)`\n\nv5: `JWT(sub, pk, devtoken, ...)`\n\nSee: https://github.com/skion/authentiq/wiki/JWT-Examples",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_register/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_register/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_register/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_register/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_retrieve/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_retrieve/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "key_retrieve",
+  "toolDescription": "Get public details of an Authentiq ID.",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key/{PK}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "PK": "PK"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_retrieve/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_retrieve/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "PK"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_retrieve/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_retrieve/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "PK": z.string().describe("Public Signing Key - Authentiq ID (43 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "key_revoke",
+  "toolDescription": "Revoke an Identity (Key) with a revocation secret",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key/{PK}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "PK": "PK"
+    },
+    "query": {
+      "secret": "secret"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "type": "string"
+    },
+    "secret": {
+      "description": "revokation secret",
+      "type": "string"
+    }
+  },
+  "required": [
+    "PK",
+    "secret"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "PK": z.string().describe("Public Signing Key - Authentiq ID (43 chars)"),
+  "secret": z.string().describe("revokation secret")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke_nosecret/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke_nosecret/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "key_revoke_nosecret",
+  "toolDescription": "Revoke an Authentiq ID using email & phone.\n\nIf called with `email` and `phone` only, a verification code \nwill be sent by email. Do a second call adding `code` to \ncomplete the revocation.",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "email": "email",
+      "phone": "phone",
+      "code": "code"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke_nosecret/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke_nosecret/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "email": {
+      "description": "primary email associated to Key (ID)",
+      "type": "string"
+    },
+    "phone": {
+      "description": "primary phone number, international representation",
+      "type": "string"
+    },
+    "code": {
+      "description": "verification code sent by email",
+      "type": "string"
+    }
+  },
+  "required": [
+    "email",
+    "phone"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke_nosecret/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_revoke_nosecret/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email": z.string().describe("primary email associated to Key (ID)"),
+  "phone": z.string().describe("primary phone number, international representation"),
+  "code": z.string().describe("verification code sent by email").optional()
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_update/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_update/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "key_update",
+  "toolDescription": "update properties of an Authentiq ID.\n(not operational in v4; use PUT for now)\n\nv5: POST issuer-signed email & phone scopes in\na self-signed JWT\n\nSee: https://github.com/skion/authentiq/wiki/JWT-Examples",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/key/{PK}",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "PK": "PK"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_update/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_update/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "PK": {
+      "description": "Public Signing Key - Authentiq ID (43 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "PK"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/key_update/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/key_update/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "PK": z.string().describe("Public Signing Key - Authentiq ID (43 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/push_login_request/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/push_login_request/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "push_login_request",
+  "toolDescription": "push sign-in request\nSee: https://github.com/skion/authentiq/wiki/JWT-Examples",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "callback": "callback"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/push_login_request/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/push_login_request/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "callback": {
+      "description": "URI App will connect to",
+      "type": "string"
+    }
+  },
+  "required": [
+    "callback"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/push_login_request/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/push_login_request/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "callback": z.string().describe("URI App will connect to")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_confirm/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_confirm/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sign_confirm",
+  "toolDescription": "this is a scope confirmation",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/scope/{job}",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "job": "job"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_confirm/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_confirm/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "job": {
+      "description": "Job ID (20 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_confirm/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_confirm/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "job": z.string().describe("Job ID (20 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_delete/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_delete/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sign_delete",
+  "toolDescription": "delete a verification job",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/scope/{job}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "job": "job"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_delete/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_delete/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "job": {
+      "description": "Job ID (20 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_delete/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_delete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "job": z.string().describe("Job ID (20 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_request/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_request/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sign_request",
+  "toolDescription": "scope verification request\nSee: https://github.com/skion/authentiq/wiki/JWT-Examples",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/scope",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "test": "test"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_request/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_request/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "test": {
+      "description": "test only mode, using test issuer",
+      "type": "integer"
+    }
+  },
+  "required": []
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_request/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_request/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "test": z.number().int().describe("test only mode, using test issuer").optional()
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sign_retrieve",
+  "toolDescription": "get the status / current content of a verification job",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/scope/{job}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "job": "job"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "job": {
+      "description": "Job ID (20 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "job": z.string().describe("Job ID (20 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve_head/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve_head/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sign_retrieve_head",
+  "toolDescription": "HEAD to get the status of a verification job",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/scope/{job}",
+  "method": "head",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "job": "job"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve_head/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve_head/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "job": {
+      "description": "Job ID (20 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve_head/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_retrieve_head/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "job": z.string().describe("Job ID (20 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_update/index.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_update/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sign_update",
+  "toolDescription": "authority updates a JWT with its signature\nSee: https://github.com/skion/authentiq/wiki/JWT-Examples",
+  "baseUrl": "https://6-dot-authentiqio.appspot.com",
+  "path": "/scope/{job}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "job": "job"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_update/schema-json/root.json
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_update/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "job": {
+      "description": "Job ID (20 chars)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job"
+  ]
+}

--- a/servers/6_dot_authentiqio_appspot_com/src/tools/sign_update/schema/root.ts
+++ b/servers/6_dot_authentiqio_appspot_com/src/tools/sign_update/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "job": z.string().describe("Job ID (20 chars)")
+}

--- a/servers/6_dot_authentiqio_appspot_com/tsconfig.json
+++ b/servers/6_dot_authentiqio_appspot_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `6_dot_authentiqio_appspot_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/6_dot_authentiqio_appspot_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "6_dot_authentiqio_appspot_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/6_dot_authentiqio_appspot_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.