### PR TITLE
Add MCP server `_baseurl_`

### DIFF
--- a/servers/_baseurl_/.npmignore
+++ b/servers/_baseurl_/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_baseurl_/README.md
+++ b/servers/_baseurl_/README.md
@@ -1,0 +1,304 @@
+# @open-mcp/_baseurl_
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "_baseurl_": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/_baseurl_@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/_baseurl_@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+NOAUTH_CREDENTIALS='...'
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add _baseurl_ \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --NOAUTH_CREDENTIALS=$NOAUTH_CREDENTIALS \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add _baseurl_ \
+  .cursor/mcp.json \
+  --NOAUTH_CREDENTIALS=$NOAUTH_CREDENTIALS \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add _baseurl_ \
+  /path/to/client/config.json \
+  --NOAUTH_CREDENTIALS=$NOAUTH_CREDENTIALS \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_baseurl_": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_baseurl_"],
+      "env": {"NOAUTH_CREDENTIALS":"...","API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `NOAUTH_CREDENTIALS` - gets sent to the API provider
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### post_api_account_oauth_token
+
+**Environment variables**
+
+- `NOAUTH_CREDENTIALS`
+
+**Input schema**
+
+No input parameters
+
+### get_api_v1_0_pacientes_idpaciente_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idPaciente` (string)
+
+### get_api_v1_0_pacientes_dni_dni_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `dni` (string)
+
+### get_api_v1_0_pacientes_telefono_telefono_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `telefono` (string)
+
+### get_api_v1_0_aseguradoras
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_api_v1_0_aseguradoras_privados
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_api_v1_0_aseguradoras_pacientes_idpaciente_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idPaciente` (string)
+
+### get_api_v1_0_especialidades
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_api_v1_0_especialidades_aseguradoras_idaseguradora_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idAseguradora` (string)
+
+### get_api_v1_0_especialistas_especialidades_idespecialidad_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idEspecialidad` (string)
+
+### get_api_v1_0_especialistas_especialidades_idespecialidad_asegura
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idEspecialidad` (string)
+- `idAseguradora` (string)
+
+### get_api_v1_0_especialistas_idespecialista_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idEspecialista` (string)
+
+### get_api_v1_0_tiposcitas_especialistas_idespecialista_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idEspecialista` (string)
+
+### get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idPaciente` (string)
+- `idAseguradora` (string)
+- `idEspecialidad` (string)
+- `idEspecialista` (string)
+- `idTipoCita` (string)
+- `fechaDesde` (string)
+- `fechaHasta` (string)
+
+### get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idPaciente` (string)
+- `idAseguradora` (string)
+- `idEspecialidad` (string)
+- `idEspecialista` (string)
+- `idTipoCita` (string)
+- `fechaDesde` (string)
+- `fechaHasta` (string)
+
+### post_api_v1_0_citas
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### delete_api_v1_0_citas_idcita_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idCita` (string)
+
+### get_api_v1_0_citas_pacientes_idpaciente_pendientes
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idPaciente` (string)
+
+### get_api_v1_0_citas_pacientes_idpaciente_realizadas
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `idPaciente` (string)

--- a/servers/_baseurl_/package.json
+++ b/servers/_baseurl_/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/_baseurl_",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "_baseurl_": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/_baseurl_/src/constants.ts
+++ b/servers/_baseurl_/src/constants.ts
@@ -1,0 +1,24 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/carlosalarconroman01/clinica-asturias/refs/heads/main/openapi%20clinica%20asturias.json"
+export const SERVER_NAME = "_baseurl_"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/post_api_account_oauth_token/index.js",
+  "./tools/get_api_v1_0_pacientes_idpaciente_/index.js",
+  "./tools/get_api_v1_0_pacientes_dni_dni_/index.js",
+  "./tools/get_api_v1_0_pacientes_telefono_telefono_/index.js",
+  "./tools/get_api_v1_0_aseguradoras/index.js",
+  "./tools/get_api_v1_0_aseguradoras_privados/index.js",
+  "./tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/index.js",
+  "./tools/get_api_v1_0_especialidades/index.js",
+  "./tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/index.js",
+  "./tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/index.js",
+  "./tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/index.js",
+  "./tools/get_api_v1_0_especialistas_idespecialista_/index.js",
+  "./tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/index.js",
+  "./tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/index.js",
+  "./tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/index.js",
+  "./tools/post_api_v1_0_citas/index.js",
+  "./tools/delete_api_v1_0_citas_idcita_/index.js",
+  "./tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/index.js",
+  "./tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/index.js"
+]

--- a/servers/_baseurl_/src/index.ts
+++ b/servers/_baseurl_/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/_baseurl_/src/server.ts
+++ b/servers/_baseurl_/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_baseurl_/src/tools/delete_api_v1_0_citas_idcita_/index.ts
+++ b/servers/_baseurl_/src/tools/delete_api_v1_0_citas_idcita_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_api_v1_0_citas_idcita_",
+  "toolDescription": "citas/{idCita}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/citas/{idCita}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idCita": "idCita"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/delete_api_v1_0_citas_idcita_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/delete_api_v1_0_citas_idcita_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idCita": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idCita"
+  ]
+}

--- a/servers/_baseurl_/src/tools/delete_api_v1_0_citas_idcita_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/delete_api_v1_0_citas_idcita_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idCita": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_aseguradoras",
+  "toolDescription": "aseguradoras",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/aseguradoras",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_aseguradoras_pacientes_idpaciente_",
+  "toolDescription": "aseguradoras/pacientes/{idPaciente}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/aseguradoras/pacientes/{idPaciente}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idPaciente": "idPaciente"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idPaciente": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idPaciente"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_pacientes_idpaciente_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idPaciente": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_privados/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_privados/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_aseguradoras_privados",
+  "toolDescription": "aseguradoras/privados",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/aseguradoras/privados",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_privados/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_privados/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_privados/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_aseguradoras_privados/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg",
+  "toolDescription": "citas/disponibilidad/dias/pacientes/{idPaciente}/aseguradoras/{idAseguradora}/especialidades/{idEspecialidad}/especialistas/{idEspecialista}/tiposCitas/{idTipoCita}/fechaDesde{fechaDesde}/fechaHasta/{fechaHasta}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/citas/disponibilidad/dias/pacientes/{idPaciente}/aseguradoras/{idAseguradora}/especialidades/{idEspecialidad}/especialistas/{idEspecialista}/tiposCitas/{idTipoCita}/fechaDesde/{fechaDesde}/fechaHasta/{fechaHasta}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idPaciente": "idPaciente",
+      "idAseguradora": "idAseguradora",
+      "idEspecialidad": "idEspecialidad",
+      "idEspecialista": "idEspecialista",
+      "idTipoCita": "idTipoCita",
+      "fechaDesde": "fechaDesde",
+      "fechaHasta": "fechaHasta"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "idPaciente": {
+      "type": "string"
+    },
+    "idAseguradora": {
+      "type": "string"
+    },
+    "idEspecialidad": {
+      "type": "string"
+    },
+    "idEspecialista": {
+      "type": "string"
+    },
+    "idTipoCita": {
+      "type": "string"
+    },
+    "fechaDesde": {
+      "type": "string"
+    },
+    "fechaHasta": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idPaciente",
+    "idAseguradora",
+    "idEspecialidad",
+    "idEspecialista",
+    "idTipoCita",
+    "fechaDesde",
+    "fechaHasta"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_dias_pacientes_idpaciente_aseg/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idPaciente": z.string(),
+  "idAseguradora": z.string(),
+  "idEspecialidad": z.string(),
+  "idEspecialista": z.string(),
+  "idTipoCita": z.string(),
+  "fechaDesde": z.string(),
+  "fechaHasta": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as",
+  "toolDescription": "citas/disponibilidad/huecos/pacientes/{idPaciente}/aseguradoras/{idAseguradora}/especialidades/{idEspecialidad}/especialistas/{idEspecialista}/tiposCitas/{idTipoCita}/fechaDesde{fechaDesde}/fechaHasta{fechaHasta}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/citas/disponibilidad/huecos/pacientes/{idPaciente}/aseguradoras/{idAseguradora}/especialidades/{idEspecialidad}/especialistas/{idEspecialista}/tiposCitas/{idTipoCita}/fechaDesde/{fechaDesde}/fechaHasta/{fechaHasta}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idPaciente": "idPaciente",
+      "idAseguradora": "idAseguradora",
+      "idEspecialidad": "idEspecialidad",
+      "idEspecialista": "idEspecialista",
+      "idTipoCita": "idTipoCita",
+      "fechaDesde": "fechaDesde",
+      "fechaHasta": "fechaHasta"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "idPaciente": {
+      "type": "string"
+    },
+    "idAseguradora": {
+      "type": "string"
+    },
+    "idEspecialidad": {
+      "type": "string"
+    },
+    "idEspecialista": {
+      "type": "string"
+    },
+    "idTipoCita": {
+      "type": "string"
+    },
+    "fechaDesde": {
+      "type": "string"
+    },
+    "fechaHasta": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idPaciente",
+    "idAseguradora",
+    "idEspecialidad",
+    "idEspecialista",
+    "idTipoCita",
+    "fechaDesde",
+    "fechaHasta"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_disponibilidad_huecos_pacientes_idpaciente_as/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idPaciente": z.string(),
+  "idAseguradora": z.string(),
+  "idEspecialidad": z.string(),
+  "idEspecialista": z.string(),
+  "idTipoCita": z.string(),
+  "fechaDesde": z.string(),
+  "fechaHasta": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_citas_pacientes_idpaciente_pendientes",
+  "toolDescription": "citas/pacientes/{idPaciente}/pendientes",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/citas/pacientes/{idPaciente}/pendientes",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idPaciente": "idPaciente"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idPaciente": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idPaciente"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_pendientes/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idPaciente": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_citas_pacientes_idpaciente_realizadas",
+  "toolDescription": "citas/pacientes/{idPaciente}/realizadas",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/citas/pacientes/{idPaciente}/realizadas",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idPaciente": "idPaciente"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idPaciente": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idPaciente"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_citas_pacientes_idpaciente_realizadas/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idPaciente": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialidades/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialidades/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_especialidades",
+  "toolDescription": "especialidades",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/especialidades",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialidades/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialidades/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialidades/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialidades/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_especialidades_aseguradoras_idaseguradora_",
+  "toolDescription": "especialidades/aseguradoras/{idAseguradora}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/especialidades/aseguradoras/{idAseguradora}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idAseguradora": "idAseguradora"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idAseguradora": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idAseguradora"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialidades_aseguradoras_idaseguradora_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idAseguradora": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_especialistas_especialidades_idespecialidad_",
+  "toolDescription": "especialistas/especialidades/{idEspecialidad}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/especialistas/especialidades/{idEspecialidad}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idEspecialidad": "idEspecialidad"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idEspecialidad": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idEspecialidad"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idEspecialidad": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_especialistas_especialidades_idespecialidad_asegura",
+  "toolDescription": "especialistas/especialidades/{idEspecialidad}/aseguradoras/{idAseguradora}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/especialistas/especialidades/{idEspecialidad}/aseguradoras/{idAseguradora}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idEspecialidad": "idEspecialidad",
+      "idAseguradora": "idAseguradora"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "idEspecialidad": {
+      "type": "string"
+    },
+    "idAseguradora": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idEspecialidad",
+    "idAseguradora"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_especialidades_idespecialidad_asegura/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idEspecialidad": z.string(),
+  "idAseguradora": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_idespecialista_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_idespecialista_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_especialistas_idespecialista_",
+  "toolDescription": "especialistas/{idEspecialista}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/especialistas/{idEspecialista}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idEspecialista": "idEspecialista"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_idespecialista_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_idespecialista_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idEspecialista": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idEspecialista"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_idespecialista_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_especialistas_idespecialista_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idEspecialista": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_dni_dni_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_dni_dni_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_pacientes_dni_dni_",
+  "toolDescription": "pacientes/dni/{dni}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/pacientes/dni/{dni}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "dni": "dni"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_dni_dni_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_dni_dni_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "dni": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "dni"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_dni_dni_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_dni_dni_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "dni": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_idpaciente_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_idpaciente_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_pacientes_idpaciente_",
+  "toolDescription": "pacientes/{idPaciente}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/pacientes/{idPaciente}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idPaciente": "idPaciente"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_idpaciente_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_idpaciente_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idPaciente": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idPaciente"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_idpaciente_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_idpaciente_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idPaciente": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_telefono_telefono_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_telefono_telefono_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_pacientes_telefono_telefono_",
+  "toolDescription": "pacientes/telefono/{telefono}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/pacientes/telefono/{telefono}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "telefono": "telefono"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_telefono_telefono_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_telefono_telefono_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "telefono": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "telefono"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_telefono_telefono_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_pacientes_telefono_telefono_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "telefono": z.string()
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/index.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_v1_0_tiposcitas_especialistas_idespecialista_",
+  "toolDescription": "tiposCitas/especialistas/{idEspecialista}",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/tiposCitas/especialistas/{idEspecialista}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "idEspecialista": "idEspecialista"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "idEspecialista": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "idEspecialista"
+  ]
+}

--- a/servers/_baseurl_/src/tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/schema/root.ts
+++ b/servers/_baseurl_/src/tools/get_api_v1_0_tiposcitas_especialistas_idespecialista_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "idEspecialista": z.string()
+}

--- a/servers/_baseurl_/src/tools/post_api_account_oauth_token/index.ts
+++ b/servers/_baseurl_/src/tools/post_api_account_oauth_token/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_api_account_oauth_token",
+  "toolDescription": "account/oauth/token",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/account/oauth/token",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "noauth <mcp-env-var>NOAUTH_CREDENTIALS</mcp-env-var>",
+      "in": "header",
+      "envVarName": "NOAUTH_CREDENTIALS"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/post_api_account_oauth_token/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/post_api_account_oauth_token/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_baseurl_/src/tools/post_api_account_oauth_token/schema/root.ts
+++ b/servers/_baseurl_/src/tools/post_api_account_oauth_token/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_baseurl_/src/tools/post_api_v1_0_citas/index.ts
+++ b/servers/_baseurl_/src/tools/post_api_v1_0_citas/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_api_v1_0_citas",
+  "toolDescription": "citas",
+  "baseUrl": "http://{{baseurl}}",
+  "path": "/api/v1.0/citas",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_baseurl_/src/tools/post_api_v1_0_citas/schema-json/root.json
+++ b/servers/_baseurl_/src/tools/post_api_v1_0_citas/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_baseurl_/src/tools/post_api_v1_0_citas/schema/root.ts
+++ b/servers/_baseurl_/src/tools/post_api_v1_0_citas/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_baseurl_/tsconfig.json
+++ b/servers/_baseurl_/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_baseurl_`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_baseurl_`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_baseurl_": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_baseurl_"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.