### PR TITLE
Add MCP server `dss-test`

### DIFF
--- a/servers/dss-test/.npmignore
+++ b/servers/dss-test/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/dss-test/README.md
+++ b/servers/dss-test/README.md
@@ -1,0 +1,416 @@
+# @open-mcp/dss-test
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "dss-test": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/dss-test@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/dss-test@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add dss-test \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add dss-test \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add dss-test \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "dss-test": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/dss-test"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### deleteinstance
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_instance_instanceidurlparam_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### createinstitution
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `Id` (string)
+- `LegacyId` (string)
+- `Name` (string)
+- `Tenant` (string)
+
+### getinstitutionbyid
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_institution_institutionidurlparam_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getinstitutions
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `institutionsLegacy[]` (array)
+- `search` (string)
+- `tenant` (string)
+- `aet` (string)
+
+### deleteseries
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_series_seriesidurlparam_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getstorageareas
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `search` (string)
+
+### getstudies
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `institution` (string)
+- `institutions[]` (array)
+- `institutionLegacy` (string)
+- `institutionsLegacy[]` (array)
+- `dicomStudyId` (string)
+- `patientId` (string)
+- `modality` (string)
+- `source` (string)
+- `studyInstanceUid` (string)
+- `limit` (integer)
+- `page` (integer)
+- `date` (string)
+- `accessionNumber` (string)
+- `storageArea[]` (array)
+
+### getstudiesviewerurl
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_studies_viewer_url
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### deletestudy
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_studies_studyidurlparam_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getstudy
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_study_studyidurlparam_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getstudyviewerurl
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_api_v1_study_studyidurlparam_viewer_url
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### createtransfer
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filesSize` (integer)
+- `id` (string)
+- `institutionId` (string)
+- `numOfFiles` (integer)
+- `source` (string)
+- `storageArea` (string)
+
+### createtransferresource
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `location` (string)
+- `transferId` (string)
+
+### parameters_api_v1_transfer_transferidurlparam_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### updatetransfer
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filesSize` (integer)
+- `numOfFiles` (integer)
+- `status` (string)
+
+### parameters_api_v1_transfer_transferidurlparam_resource
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### createresourcefortransfer
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `institutionId` (string)
+- `path` (string)
+
+### parameters_api_v1_transfer_transferidurlparam_upload_url
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getuploadurlfortransfer
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `fileName` (string)
+
+### gettransfers
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `status` (string)
+- `statuses[]` (array)
+- `institution_id` (string)
+
+### getthumbnailimage
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters

--- a/servers/dss-test/package.json
+++ b/servers/dss-test/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/dss-test",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "dss-test": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/dss-test/src/constants.ts
+++ b/servers/dss-test/src/constants.ts
@@ -1,0 +1,34 @@
+export const OPENAPI_URL = "https://dicom-study-service.cmrad.com/api/v1/spec"
+export const SERVER_NAME = "dss-test"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/deleteinstance/index.js",
+  "./tools/parameters_api_v1_instance_instanceidurlparam_/index.js",
+  "./tools/createinstitution/index.js",
+  "./tools/getinstitutionbyid/index.js",
+  "./tools/parameters_api_v1_institution_institutionidurlparam_/index.js",
+  "./tools/getinstitutions/index.js",
+  "./tools/deleteseries/index.js",
+  "./tools/parameters_api_v1_series_seriesidurlparam_/index.js",
+  "./tools/getstorageareas/index.js",
+  "./tools/getstudies/index.js",
+  "./tools/getstudiesviewerurl/index.js",
+  "./tools/parameters_api_v1_studies_viewer_url/index.js",
+  "./tools/deletestudy/index.js",
+  "./tools/parameters_api_v1_studies_studyidurlparam_/index.js",
+  "./tools/getstudy/index.js",
+  "./tools/parameters_api_v1_study_studyidurlparam_/index.js",
+  "./tools/getstudyviewerurl/index.js",
+  "./tools/parameters_api_v1_study_studyidurlparam_viewer_url/index.js",
+  "./tools/createtransfer/index.js",
+  "./tools/createtransferresource/index.js",
+  "./tools/parameters_api_v1_transfer_transferidurlparam_/index.js",
+  "./tools/updatetransfer/index.js",
+  "./tools/parameters_api_v1_transfer_transferidurlparam_resource/index.js",
+  "./tools/createresourcefortransfer/index.js",
+  "./tools/parameters_api_v1_transfer_transferidurlparam_upload_url/index.js",
+  "./tools/getuploadurlfortransfer/index.js",
+  "./tools/gettransfers/index.js",
+  "./tools/getthumbnailimage/index.js",
+  "./tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/index.js"
+]

--- a/servers/dss-test/src/index.ts
+++ b/servers/dss-test/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/dss-test/src/server.ts
+++ b/servers/dss-test/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/dss-test/src/tools/createinstitution/index.ts
+++ b/servers/dss-test/src/tools/createinstitution/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createinstitution",
+  "toolDescription": "Create Institution",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/institution",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "Id": "Id",
+      "LegacyId": "LegacyId",
+      "Name": "Name",
+      "Tenant": "Tenant"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/createinstitution/schema-json/root.json
+++ b/servers/dss-test/src/tools/createinstitution/schema-json/root.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "properties": {
+    "Id": {
+      "description": "Represents an uuid",
+      "format": "uuid",
+      "title": "Uuid",
+      "type": "string"
+    },
+    "LegacyId": {
+      "type": "string"
+    },
+    "Name": {
+      "type": "string"
+    },
+    "Tenant": {
+      "enum": [
+        "veheri",
+        "cmrad"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "Id",
+    "LegacyId",
+    "Name",
+    "Tenant"
+  ]
+}

--- a/servers/dss-test/src/tools/createinstitution/schema/root.ts
+++ b/servers/dss-test/src/tools/createinstitution/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "Id": z.string().uuid().describe("Represents an uuid"),
+  "LegacyId": z.string(),
+  "Name": z.string(),
+  "Tenant": z.enum(["veheri","cmrad"])
+}

--- a/servers/dss-test/src/tools/createresourcefortransfer/index.ts
+++ b/servers/dss-test/src/tools/createresourcefortransfer/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createresourcefortransfer",
+  "toolDescription": "create resource for transfer",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer/{transferIdUrlParam}/resource",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "institutionId": "institutionId",
+      "path": "path"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/createresourcefortransfer/schema-json/root.json
+++ b/servers/dss-test/src/tools/createresourcefortransfer/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "institutionId": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "institutionId",
+    "path"
+  ]
+}

--- a/servers/dss-test/src/tools/createresourcefortransfer/schema/root.ts
+++ b/servers/dss-test/src/tools/createresourcefortransfer/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "institutionId": z.string(),
+  "path": z.string()
+}

--- a/servers/dss-test/src/tools/createtransfer/index.ts
+++ b/servers/dss-test/src/tools/createtransfer/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createtransfer",
+  "toolDescription": "Create Transfer",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "filesSize": "filesSize",
+      "id": "id",
+      "institutionId": "institutionId",
+      "numOfFiles": "numOfFiles",
+      "source": "source",
+      "storageArea": "storageArea"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/createtransfer/schema-json/root.json
+++ b/servers/dss-test/src/tools/createtransfer/schema-json/root.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "filesSize": {
+      "description": "Represents a size in bytes",
+      "format": "int64",
+      "minimum": 0,
+      "title": "FilesSize",
+      "type": "integer"
+    },
+    "id": {
+      "description": "Represents an uuid",
+      "format": "uuid",
+      "title": "Uuid",
+      "type": "string"
+    },
+    "institutionId": {
+      "type": "string"
+    },
+    "numOfFiles": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "source": {
+      "enum": [
+        "web-upload",
+        "cm-connect",
+        "direct-dicom"
+      ],
+      "title": "TransferSource",
+      "type": "string"
+    },
+    "storageArea": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "filesSize",
+    "id",
+    "institutionId",
+    "numOfFiles",
+    "source",
+    "storageArea"
+  ]
+}

--- a/servers/dss-test/src/tools/createtransfer/schema/root.ts
+++ b/servers/dss-test/src/tools/createtransfer/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filesSize": z.number().int().gte(0).describe("Represents a size in bytes"),
+  "id": z.string().uuid().describe("Represents an uuid"),
+  "institutionId": z.string(),
+  "numOfFiles": z.number().int().gte(0),
+  "source": z.enum(["web-upload","cm-connect","direct-dicom"]),
+  "storageArea": z.string()
+}

--- a/servers/dss-test/src/tools/createtransferresource/index.ts
+++ b/servers/dss-test/src/tools/createtransferresource/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createtransferresource",
+  "toolDescription": "Create Transfer Resource",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer-resource",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "location": "location",
+      "transferId": "transferId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/createtransferresource/schema-json/root.json
+++ b/servers/dss-test/src/tools/createtransferresource/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "location": {
+      "type": "string"
+    },
+    "transferId": {
+      "description": "Represents an uuid",
+      "format": "uuid",
+      "title": "Uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "location",
+    "transferId"
+  ]
+}

--- a/servers/dss-test/src/tools/createtransferresource/schema/root.ts
+++ b/servers/dss-test/src/tools/createtransferresource/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "location": z.string(),
+  "transferId": z.string().uuid().describe("Represents an uuid")
+}

--- a/servers/dss-test/src/tools/deleteinstance/index.ts
+++ b/servers/dss-test/src/tools/deleteinstance/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteinstance",
+  "toolDescription": "delete instance",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/instance/{instanceIdUrlParam}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/deleteinstance/schema-json/root.json
+++ b/servers/dss-test/src/tools/deleteinstance/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/deleteinstance/schema/root.ts
+++ b/servers/dss-test/src/tools/deleteinstance/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/deleteseries/index.ts
+++ b/servers/dss-test/src/tools/deleteseries/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deleteseries",
+  "toolDescription": "delete series",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/series/{seriesIdUrlParam}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/deleteseries/schema-json/root.json
+++ b/servers/dss-test/src/tools/deleteseries/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/deleteseries/schema/root.ts
+++ b/servers/dss-test/src/tools/deleteseries/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/deletestudy/index.ts
+++ b/servers/dss-test/src/tools/deletestudy/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletestudy",
+  "toolDescription": "delete study",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/studies/{studyIdUrlParam}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/deletestudy/schema-json/root.json
+++ b/servers/dss-test/src/tools/deletestudy/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/deletestudy/schema/root.ts
+++ b/servers/dss-test/src/tools/deletestudy/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/getinstitutionbyid/index.ts
+++ b/servers/dss-test/src/tools/getinstitutionbyid/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinstitutionbyid",
+  "toolDescription": "Get institution by id",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/institution/{institutionIdUrlParam}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getinstitutionbyid/schema-json/root.json
+++ b/servers/dss-test/src/tools/getinstitutionbyid/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/getinstitutionbyid/schema/root.ts
+++ b/servers/dss-test/src/tools/getinstitutionbyid/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/getinstitutions/index.ts
+++ b/servers/dss-test/src/tools/getinstitutions/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinstitutions",
+  "toolDescription": "List institutions",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/institutions",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "institutionsLegacy[]": "institutionsLegacy[]",
+      "search": "search",
+      "tenant": "tenant",
+      "aet": "aet"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getinstitutions/schema-json/root.json
+++ b/servers/dss-test/src/tools/getinstitutions/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "institutionsLegacy[]": {
+      "description": "List of institution legacy ids",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "search": {
+      "description": "Search string",
+      "type": "string"
+    },
+    "tenant": {
+      "type": "string"
+    },
+    "aet": {
+      "description": "aet query string parameter",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/dss-test/src/tools/getinstitutions/schema/root.ts
+++ b/servers/dss-test/src/tools/getinstitutions/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "institutionsLegacy[]": z.array(z.string()).describe("List of institution legacy ids").optional(),
+  "search": z.string().describe("Search string").optional(),
+  "tenant": z.string().optional(),
+  "aet": z.string().describe("aet query string parameter").optional()
+}

--- a/servers/dss-test/src/tools/getstorageareas/index.ts
+++ b/servers/dss-test/src/tools/getstorageareas/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getstorageareas",
+  "toolDescription": "List storage areas",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/storage-areas",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "search": "search"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getstorageareas/schema-json/root.json
+++ b/servers/dss-test/src/tools/getstorageareas/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "search": {
+      "description": "Search string",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/dss-test/src/tools/getstorageareas/schema/root.ts
+++ b/servers/dss-test/src/tools/getstorageareas/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "search": z.string().describe("Search string").optional()
+}

--- a/servers/dss-test/src/tools/getstudies/index.ts
+++ b/servers/dss-test/src/tools/getstudies/index.ts
@@ -1,0 +1,39 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getstudies",
+  "toolDescription": "List studies",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/studies",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "institution": "institution",
+      "institutions[]": "institutions[]",
+      "institutionLegacy": "institutionLegacy",
+      "institutionsLegacy[]": "institutionsLegacy[]",
+      "dicomStudyId": "dicomStudyId",
+      "patientId": "patientId",
+      "modality": "modality",
+      "source": "source",
+      "studyInstanceUid": "studyInstanceUid",
+      "limit": "limit",
+      "page": "page",
+      "date": "date",
+      "accessionNumber": "accessionNumber",
+      "storageArea[]": "storageArea[]"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getstudies/schema-json/root.json
+++ b/servers/dss-test/src/tools/getstudies/schema-json/root.json
@@ -1,0 +1,78 @@
+{
+  "type": "object",
+  "properties": {
+    "institution": {
+      "description": "Institution id querystring parameter",
+      "format": "uuid",
+      "type": "string"
+    },
+    "institutions[]": {
+      "description": "List of institution ids",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "institutionLegacy": {
+      "description": "Institution Legacy id querystring parameter",
+      "format": "uuid",
+      "type": "string"
+    },
+    "institutionsLegacy[]": {
+      "description": "List of institution legacy ids",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "dicomStudyId": {
+      "description": "Study id from dicom",
+      "type": "string"
+    },
+    "patientId": {
+      "description": "Patient id from dicom",
+      "type": "string"
+    },
+    "modality": {
+      "description": "modality query string parameter",
+      "type": "string"
+    },
+    "source": {
+      "description": "source query string parameter",
+      "type": "string"
+    },
+    "studyInstanceUid": {
+      "description": "Study Instance Uid from dicom",
+      "type": "string"
+    },
+    "limit": {
+      "description": "limit items to return on pagination",
+      "default": 20,
+      "type": "integer"
+    },
+    "page": {
+      "description": "page number to return on pagination",
+      "default": 1,
+      "type": "integer"
+    },
+    "date": {
+      "description": "study creation date on dss",
+      "type": "string"
+    },
+    "accessionNumber": {
+      "description": "accession number from dicom",
+      "type": "string"
+    },
+    "storageArea[]": {
+      "description": "storage area that where the resources are stored",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    }
+  },
+  "required": []
+}

--- a/servers/dss-test/src/tools/getstudies/schema/root.ts
+++ b/servers/dss-test/src/tools/getstudies/schema/root.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "institution": z.string().uuid().describe("Institution id querystring parameter").optional(),
+  "institutions[]": z.array(z.string()).describe("List of institution ids").optional(),
+  "institutionLegacy": z.string().uuid().describe("Institution Legacy id querystring parameter").optional(),
+  "institutionsLegacy[]": z.array(z.string()).describe("List of institution legacy ids").optional(),
+  "dicomStudyId": z.string().describe("Study id from dicom").optional(),
+  "patientId": z.string().describe("Patient id from dicom").optional(),
+  "modality": z.string().describe("modality query string parameter").optional(),
+  "source": z.string().describe("source query string parameter").optional(),
+  "studyInstanceUid": z.string().describe("Study Instance Uid from dicom").optional(),
+  "limit": z.number().int().describe("limit items to return on pagination").optional(),
+  "page": z.number().int().describe("page number to return on pagination").optional(),
+  "date": z.string().describe("study creation date on dss").optional(),
+  "accessionNumber": z.string().describe("accession number from dicom").optional(),
+  "storageArea[]": z.array(z.string()).describe("storage area that where the resources are stored").optional()
+}

--- a/servers/dss-test/src/tools/getstudiesviewerurl/index.ts
+++ b/servers/dss-test/src/tools/getstudiesviewerurl/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getstudiesviewerurl",
+  "toolDescription": "Studies Viewer URL",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/studies/viewer_url",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getstudiesviewerurl/schema-json/root.json
+++ b/servers/dss-test/src/tools/getstudiesviewerurl/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/getstudiesviewerurl/schema/root.ts
+++ b/servers/dss-test/src/tools/getstudiesviewerurl/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/getstudy/index.ts
+++ b/servers/dss-test/src/tools/getstudy/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getstudy",
+  "toolDescription": "Get Study",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/study/{studyIdUrlParam}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getstudy/schema-json/root.json
+++ b/servers/dss-test/src/tools/getstudy/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/getstudy/schema/root.ts
+++ b/servers/dss-test/src/tools/getstudy/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/getstudyviewerurl/index.ts
+++ b/servers/dss-test/src/tools/getstudyviewerurl/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getstudyviewerurl",
+  "toolDescription": "Study viewer Url",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/study/{studyIdUrlParam}/viewer_url",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getstudyviewerurl/schema-json/root.json
+++ b/servers/dss-test/src/tools/getstudyviewerurl/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/getstudyviewerurl/schema/root.ts
+++ b/servers/dss-test/src/tools/getstudyviewerurl/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/getthumbnailimage/index.ts
+++ b/servers/dss-test/src/tools/getthumbnailimage/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getthumbnailimage",
+  "toolDescription": "Retrieve series thumbnail image",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/thumbnails/{studyIdUrlParam}/{seriesIdUrlParam}/{filenameUrlParam}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getthumbnailimage/schema-json/root.json
+++ b/servers/dss-test/src/tools/getthumbnailimage/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/getthumbnailimage/schema/root.ts
+++ b/servers/dss-test/src/tools/getthumbnailimage/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/gettransfers/index.ts
+++ b/servers/dss-test/src/tools/gettransfers/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettransfers",
+  "toolDescription": "List transfers",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfers",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "status": "status",
+      "statuses[]": "statuses[]",
+      "institution_id": "institution_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/gettransfers/schema-json/root.json
+++ b/servers/dss-test/src/tools/gettransfers/schema-json/root.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "enum": [
+        "uploading",
+        "completed",
+        "cancelled",
+        "failed"
+      ],
+      "type": "string"
+    },
+    "statuses[]": {
+      "items": {
+        "enum": [
+          "uploading",
+          "completed",
+          "cancelled",
+          "failed"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "institution_id": {
+      "description": "Institution id querystring parameter",
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/dss-test/src/tools/gettransfers/schema/root.ts
+++ b/servers/dss-test/src/tools/gettransfers/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "status": z.enum(["uploading","completed","cancelled","failed"]).optional(),
+  "statuses[]": z.array(z.enum(["uploading","completed","cancelled","failed"])).optional(),
+  "institution_id": z.string().uuid().describe("Institution id querystring parameter").optional()
+}

--- a/servers/dss-test/src/tools/getuploadurlfortransfer/index.ts
+++ b/servers/dss-test/src/tools/getuploadurlfortransfer/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getuploadurlfortransfer",
+  "toolDescription": "Get Upload url for transfer a file",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer/{transferIdUrlParam}/upload-url",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "fileName": "fileName"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/getuploadurlfortransfer/schema-json/root.json
+++ b/servers/dss-test/src/tools/getuploadurlfortransfer/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "fileName": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "fileName"
+  ]
+}

--- a/servers/dss-test/src/tools/getuploadurlfortransfer/schema/root.ts
+++ b/servers/dss-test/src/tools/getuploadurlfortransfer/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "fileName": z.string()
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_instance_instanceidurlparam_/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_instance_instanceidurlparam_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_instance_instanceidurlparam_",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/instance/{instanceIdUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_instance_instanceidurlparam_/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_instance_instanceidurlparam_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_instance_instanceidurlparam_/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_instance_instanceidurlparam_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_institution_institutionidurlparam_/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_institution_institutionidurlparam_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_institution_institutionidurlparam_",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/institution/{institutionIdUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_institution_institutionidurlparam_/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_institution_institutionidurlparam_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_institution_institutionidurlparam_/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_institution_institutionidurlparam_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_series_seriesidurlparam_/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_series_seriesidurlparam_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_series_seriesidurlparam_",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/series/{seriesIdUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_series_seriesidurlparam_/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_series_seriesidurlparam_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_series_seriesidurlparam_/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_series_seriesidurlparam_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_studies_studyidurlparam_/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_studies_studyidurlparam_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_studies_studyidurlparam_",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/studies/{studyIdUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_studies_studyidurlparam_/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_studies_studyidurlparam_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_studies_studyidurlparam_/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_studies_studyidurlparam_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_studies_viewer_url/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_studies_viewer_url/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_studies_viewer_url",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/studies/viewer_url",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_studies_viewer_url/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_studies_viewer_url/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_studies_viewer_url/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_studies_viewer_url/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_study_studyidurlparam_",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/study/{studyIdUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_viewer_url/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_viewer_url/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_study_studyidurlparam_viewer_url",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/study/{studyIdUrlParam}/viewer_url",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_viewer_url/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_viewer_url/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_viewer_url/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_study_studyidurlparam_viewer_url/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_transfer_transferidurlparam_",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer/{transferIdUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_resource/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_resource/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_transfer_transferidurlparam_resource",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer/{transferIdUrlParam}/resource",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_resource/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_resource/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_resource/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_resource/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_upload_url/index.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_upload_url/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_api_v1_transfer_transferidurlparam_upload_url",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer/{transferIdUrlParam}/upload-url",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_upload_url/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_upload_url/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_upload_url/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_api_v1_transfer_transferidurlparam_upload_url/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/index.ts
+++ b/servers/dss-test/src/tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu",
+  "toolDescription": "",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/thumbnails/{studyIdUrlParam}/{seriesIdUrlParam}/{filenameUrlParam}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/schema-json/root.json
+++ b/servers/dss-test/src/tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/dss-test/src/tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/schema/root.ts
+++ b/servers/dss-test/src/tools/parameters_thumbnails_studyidurlparam_seriesidurlparam_filenameu/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/dss-test/src/tools/updatetransfer/index.ts
+++ b/servers/dss-test/src/tools/updatetransfer/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatetransfer",
+  "toolDescription": "Update Transfer",
+  "baseUrl": "{scheme}://{baseHost}",
+  "path": "/api/v1/transfer/{transferIdUrlParam}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "filesSize": "filesSize",
+      "numOfFiles": "numOfFiles",
+      "status": "status"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/dss-test/src/tools/updatetransfer/schema-json/root.json
+++ b/servers/dss-test/src/tools/updatetransfer/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "filesSize": {
+      "format": "int64",
+      "nullable": true,
+      "type": "integer"
+    },
+    "numOfFiles": {
+      "nullable": true,
+      "type": "integer"
+    },
+    "status": {
+      "enum": [
+        "uploading",
+        "completed",
+        "cancelled",
+        "failed"
+      ],
+      "nullable": true,
+      "type": "string"
+    }
+  },
+  "required": [
+    "filesSize",
+    "numOfFiles",
+    "status"
+  ]
+}

--- a/servers/dss-test/src/tools/updatetransfer/schema/root.ts
+++ b/servers/dss-test/src/tools/updatetransfer/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filesSize": z.number().int().nullable(),
+  "numOfFiles": z.number().int().nullable(),
+  "status": z.enum(["uploading","completed","cancelled","failed"]).nullable()
+}

--- a/servers/dss-test/tsconfig.json
+++ b/servers/dss-test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `dss-test`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/dss-test`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "dss-test": {
      "command": "npx",
      "args": ["-y", "@open-mcp/dss-test"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.