### PR TITLE
Add MCP server `virtserver_swaggerhub_com_mconneely_universityapi_1_0_0`

### DIFF
--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/.npmignore
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/README.md
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/README.md
@@ -1,0 +1,190 @@
+# @open-mcp/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "virtserver_swaggerhub_com_mconneely_universityapi_1_0_0": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add virtserver_swaggerhub_com_mconneely_universityapi_1_0_0 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add virtserver_swaggerhub_com_mconneely_universityapi_1_0_0 \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add virtserver_swaggerhub_com_mconneely_universityapi_1_0_0 \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "virtserver_swaggerhub_com_mconneely_universityapi_1_0_0": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### getallcourses
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### createcourse
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `name` (string)
+- `description` (string)
+- `credits` (integer)
+
+### getcoursebyid
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `courseId` (integer)
+
+### updatecourse
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `courseId` (integer)
+- `name` (string)
+- `description` (string)
+- `credits` (integer)
+
+### deletecourse
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `courseId` (integer)
+
+### gettimetable
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### gettimetablebyid
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `timetableId` (integer)
+
+### createstudent
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `name` (string)
+- `email` (string)
+- `password` (string)
+
+### getstudentbyid
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `studentId` (integer)

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/package.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "virtserver_swaggerhub_com_mconneely_universityapi_1_0_0": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/constants.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/constants.ts
@@ -1,0 +1,14 @@
+export const OPENAPI_URL = "https://api.swaggerhub.com/apis/MConneely/UniversityAPI/1.0.0/swagger.json"
+export const SERVER_NAME = "virtserver_swaggerhub_com_mconneely_universityapi_1_0_0"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getallcourses/index.js",
+  "./tools/createcourse/index.js",
+  "./tools/getcoursebyid/index.js",
+  "./tools/updatecourse/index.js",
+  "./tools/deletecourse/index.js",
+  "./tools/gettimetable/index.js",
+  "./tools/gettimetablebyid/index.js",
+  "./tools/createstudent/index.js",
+  "./tools/getstudentbyid/index.js"
+]

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/server.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createcourse/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createcourse/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createcourse",
+  "toolDescription": "Create a new course",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/courses",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "description": "description",
+      "credits": "credits"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createcourse/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createcourse/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "credits": {
+      "type": "integer"
+    }
+  },
+  "required": []
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createcourse/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createcourse/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string().optional(),
+  "description": z.string().optional(),
+  "credits": z.number().int().optional()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createstudent/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createstudent/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createstudent",
+  "toolDescription": "Create a new student account",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/students",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createstudent/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createstudent/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createstudent/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/createstudent/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string().optional(),
+  "email": z.string().optional(),
+  "password": z.string().optional()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/deletecourse/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/deletecourse/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletecourse",
+  "toolDescription": "Delete a course",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/courses/{courseId}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "courseId": "courseId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/deletecourse/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/deletecourse/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "courseId": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "courseId"
+  ]
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/deletecourse/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/deletecourse/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "courseId": z.number().int()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getallcourses/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getallcourses/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getallcourses",
+  "toolDescription": "Retrieve all courses",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/courses",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getallcourses/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getallcourses/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getallcourses/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getallcourses/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getcoursebyid/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getcoursebyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcoursebyid",
+  "toolDescription": "Retrieve a course by ID",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/courses/{courseId}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "courseId": "courseId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getcoursebyid/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getcoursebyid/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "courseId": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "courseId"
+  ]
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getcoursebyid/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getcoursebyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "courseId": z.number().int()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getstudentbyid/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getstudentbyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getstudentbyid",
+  "toolDescription": "Retrieve a student by ID",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/students/{studentId}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "studentId": "studentId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getstudentbyid/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getstudentbyid/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "studentId": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "studentId"
+  ]
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getstudentbyid/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/getstudentbyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "studentId": z.number().int()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetable/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetable/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettimetable",
+  "toolDescription": "Retrieve the timetable",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/timetable",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetable/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetable/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetable/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetable/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetablebyid/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetablebyid/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettimetablebyid",
+  "toolDescription": "Retrieve a timetable entry by ID",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/timetable/{timetableId}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "timetableId": "timetableId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetablebyid/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetablebyid/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "timetableId": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "timetableId"
+  ]
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetablebyid/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/gettimetablebyid/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "timetableId": z.number().int()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/updatecourse/index.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/updatecourse/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatecourse",
+  "toolDescription": "Update an existing course",
+  "baseUrl": "https://virtserver.swaggerhub.com/MConneely/UniversityAPI/1.0.0",
+  "path": "/courses/{courseId}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "courseId": "courseId"
+    },
+    "body": {
+      "name": "name",
+      "description": "description",
+      "credits": "credits"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/updatecourse/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/updatecourse/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "courseId": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "credits": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "courseId"
+  ]
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/updatecourse/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/src/tools/updatecourse/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "courseId": z.number().int(),
+  "name": z.string().optional(),
+  "description": z.string().optional(),
+  "credits": z.number().int().optional()
+}

--- a/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/tsconfig.json
+++ b/servers/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `virtserver_swaggerhub_com_mconneely_universityapi_1_0_0`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "virtserver_swaggerhub_com_mconneely_universityapi_1_0_0": {
      "command": "npx",
      "args": ["-y", "@open-mcp/virtserver_swaggerhub_com_mconneely_universityapi_1_0_0"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.