### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,369 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_google_access_token_api_v1_users_user_id_google_access_token
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `user_id` (string)
+
+### login_api_v1_auth_login_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `email` (string)
+- `password` (string)
+
+### logout_api_v1_auth_logout_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### register_api_v1_auth_register_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `name` (string)
+- `email` (string)
+- `password` (string)
+
+### get_session_api_v1_auth_session_get
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### login_google_api_v1_auth_login_google_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### auth_google_api_v1_auth_google_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### oauth_callback_api_v1_auth_oauth_callback_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `code` (string)
+- `state` (other)
+
+### auth_success_api_v1_auth_success_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `session_token` (other)
+
+### webhook_handler_api_v1_webhooks_composio_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### sync_drive_handler_api_v1_webhooks_sync_drive_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### sync_gmail_handler_api_v1_webhooks_sync_gmail_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### gmail_handler_api_v1_webhooks_gmail_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### handle_subscription_api_v1_subscriptions_gmail_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `service` (string)
+- `user_id` (string)
+
+### get_email_analyses_api_v1_email_analysis_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `skip` (integer)
+- `limit` (integer)
+- `priority_level` (other)
+- `assigned_label` (other)
+- `user_id` (string)
+
+### get_email_analysis_api_v1_email_analysis_analysis_id_get
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `analysis_id` (string)
+
+### update_email_analysis_api_v1_email_analysis_analysis_id_put
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `analysis_id` (string)
+- `assigned_label` (other)
+- `priority_level` (other)
+- `suggested_action` (other)
+- `confidence_score` (other)
+
+### get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `email_id` (string)
+
+### get_analysis_stats_api_v1_email_analysis_stats_summary_get
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### handle_sse_api_v1_markitdown_sse_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### handle_sse_api_v1_excel_sse_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### query_session_api_v1_excel_sessions_session_id_query_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### upload_excel_file_api_v1_excel_upload_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### upload_file_api_v1_s3_upload_post
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### handle_sse_api_v1_notebook_sse_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### health_check_health_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,31 @@
+export const OPENAPI_URL = "https://ubik.solarpunk.technology/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_google_access_token_api_v1_users_user_id_google_access_token/index.js",
+  "./tools/login_api_v1_auth_login_post/index.js",
+  "./tools/logout_api_v1_auth_logout_post/index.js",
+  "./tools/register_api_v1_auth_register_post/index.js",
+  "./tools/get_session_api_v1_auth_session_get/index.js",
+  "./tools/login_google_api_v1_auth_login_google_get/index.js",
+  "./tools/auth_google_api_v1_auth_google_get/index.js",
+  "./tools/oauth_callback_api_v1_auth_oauth_callback_post/index.js",
+  "./tools/auth_success_api_v1_auth_success_get/index.js",
+  "./tools/webhook_handler_api_v1_webhooks_composio_post/index.js",
+  "./tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/index.js",
+  "./tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/index.js",
+  "./tools/gmail_handler_api_v1_webhooks_gmail_post/index.js",
+  "./tools/handle_subscription_api_v1_subscriptions_gmail_post/index.js",
+  "./tools/get_email_analyses_api_v1_email_analysis_get/index.js",
+  "./tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/index.js",
+  "./tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/index.js",
+  "./tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/index.js",
+  "./tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/index.js",
+  "./tools/handle_sse_api_v1_markitdown_sse_get/index.js",
+  "./tools/handle_sse_api_v1_excel_sse_get/index.js",
+  "./tools/query_session_api_v1_excel_sessions_session_id_query_post/index.js",
+  "./tools/upload_excel_file_api_v1_excel_upload_post/index.js",
+  "./tools/upload_file_api_v1_s3_upload_post/index.js",
+  "./tools/handle_sse_api_v1_notebook_sse_get/index.js",
+  "./tools/health_check_health_get/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/auth_google_api_v1_auth_google_get/index.ts
+++ b/servers/api_example_com/src/tools/auth_google_api_v1_auth_google_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "auth_google_api_v1_auth_google_get",
+  "toolDescription": "Auth Google",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/google",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/auth_google_api_v1_auth_google_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/auth_google_api_v1_auth_google_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/auth_google_api_v1_auth_google_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/auth_google_api_v1_auth_google_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/auth_success_api_v1_auth_success_get/index.ts
+++ b/servers/api_example_com/src/tools/auth_success_api_v1_auth_success_get/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "auth_success_api_v1_auth_success_get",
+  "toolDescription": "Auth Success",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/success",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "session_token": "session_token"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/auth_success_api_v1_auth_success_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/auth_success_api_v1_auth_success_get/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "session_token": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Session Token"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/auth_success_api_v1_auth_success_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/auth_success_api_v1_auth_success_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "session_token": z.union([z.string(), z.null()]).optional()
+}

--- a/servers/api_example_com/src/tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/index.ts
+++ b/servers/api_example_com/src/tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge",
+  "toolDescription": "Get Analysis By Email Id",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/email-analysis/email/{email_id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "email_id": "email_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "title": "Email Id"
+    }
+  },
+  "required": [
+    "email_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_analysis_by_email_id_api_v1_email_analysis_email_email_id_ge/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email_id": z.string()
+}

--- a/servers/api_example_com/src/tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/index.ts
+++ b/servers/api_example_com/src/tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_analysis_stats_api_v1_email_analysis_stats_summary_get",
+  "toolDescription": "Get Analysis Stats",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/email-analysis/stats/summary",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_analysis_stats_api_v1_email_analysis_stats_summary_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/get_email_analyses_api_v1_email_analysis_get/index.ts
+++ b/servers/api_example_com/src/tools/get_email_analyses_api_v1_email_analysis_get/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_email_analyses_api_v1_email_analysis_get",
+  "toolDescription": "Get Email Analyses",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/email-analysis/",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "skip": "skip",
+      "limit": "limit",
+      "priority_level": "priority_level",
+      "assigned_label": "assigned_label",
+      "user_id": "user_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_email_analyses_api_v1_email_analysis_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_email_analyses_api_v1_email_analysis_get/schema-json/root.json
@@ -1,0 +1,49 @@
+{
+  "type": "object",
+  "properties": {
+    "skip": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "title": "Skip"
+    },
+    "limit": {
+      "type": "integer",
+      "maximum": 1000,
+      "minimum": 1,
+      "default": 100,
+      "title": "Limit"
+    },
+    "priority_level": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(high|medium|low)$"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Priority Level"
+    },
+    "assigned_label": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Assigned Label"
+    },
+    "user_id": {
+      "description": "User ID",
+      "type": "string",
+      "title": "User Id"
+    }
+  },
+  "required": [
+    "user_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_email_analyses_api_v1_email_analysis_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_email_analyses_api_v1_email_analysis_get/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "skip": z.number().int().gte(0).optional(),
+  "limit": z.number().int().gte(1).lte(1000).optional(),
+  "priority_level": z.union([z.string().regex(new RegExp("^(high|medium|low)$")), z.null()]).optional(),
+  "assigned_label": z.union([z.string(), z.null()]).optional(),
+  "user_id": z.string().describe("User ID")
+}

--- a/servers/api_example_com/src/tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/index.ts
+++ b/servers/api_example_com/src/tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_email_analysis_api_v1_email_analysis_analysis_id_get",
+  "toolDescription": "Get Email Analysis",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/email-analysis/{analysis_id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "analysis_id": "analysis_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "analysis_id": {
+      "type": "string",
+      "title": "Analysis Id"
+    }
+  },
+  "required": [
+    "analysis_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_email_analysis_api_v1_email_analysis_analysis_id_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "analysis_id": z.string()
+}

--- a/servers/api_example_com/src/tools/get_google_access_token_api_v1_users_user_id_google_access_token/index.ts
+++ b/servers/api_example_com/src/tools/get_google_access_token_api_v1_users_user_id_google_access_token/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_google_access_token_api_v1_users_user_id_google_access_token",
+  "toolDescription": "Get Google Access Token",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/users/{user_id}/google-access-token",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "user_id": "user_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_google_access_token_api_v1_users_user_id_google_access_token/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_google_access_token_api_v1_users_user_id_google_access_token/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "user_id": {
+      "type": "string",
+      "title": "User Id"
+    }
+  },
+  "required": [
+    "user_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_google_access_token_api_v1_users_user_id_google_access_token/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_google_access_token_api_v1_users_user_id_google_access_token/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "user_id": z.string()
+}

--- a/servers/api_example_com/src/tools/get_session_api_v1_auth_session_get/index.ts
+++ b/servers/api_example_com/src/tools/get_session_api_v1_auth_session_get/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_session_api_v1_auth_session_get",
+  "toolDescription": "Get Session",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/session",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_session_api_v1_auth_session_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_session_api_v1_auth_session_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_session_api_v1_auth_session_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_session_api_v1_auth_session_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/gmail_handler_api_v1_webhooks_gmail_post/index.ts
+++ b/servers/api_example_com/src/tools/gmail_handler_api_v1_webhooks_gmail_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gmail_handler_api_v1_webhooks_gmail_post",
+  "toolDescription": "Gmail Handler",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/webhooks/gmail",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/gmail_handler_api_v1_webhooks_gmail_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/gmail_handler_api_v1_webhooks_gmail_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/gmail_handler_api_v1_webhooks_gmail_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/gmail_handler_api_v1_webhooks_gmail_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_excel_sse_get/index.ts
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_excel_sse_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "handle_sse_api_v1_excel_sse_get",
+  "toolDescription": "Handle Sse",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/excel/sse",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_excel_sse_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_excel_sse_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_excel_sse_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_excel_sse_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_markitdown_sse_get/index.ts
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_markitdown_sse_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "handle_sse_api_v1_markitdown_sse_get",
+  "toolDescription": "Handle Sse",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/markitdown/sse",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_markitdown_sse_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_markitdown_sse_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_markitdown_sse_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_markitdown_sse_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_notebook_sse_get/index.ts
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_notebook_sse_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "handle_sse_api_v1_notebook_sse_get",
+  "toolDescription": "Handle Sse",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/notebook/sse",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_notebook_sse_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_notebook_sse_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/handle_sse_api_v1_notebook_sse_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/handle_sse_api_v1_notebook_sse_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/handle_subscription_api_v1_subscriptions_gmail_post/index.ts
+++ b/servers/api_example_com/src/tools/handle_subscription_api_v1_subscriptions_gmail_post/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "handle_subscription_api_v1_subscriptions_gmail_post",
+  "toolDescription": "Handle Subscription",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/subscriptions/gmail",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "service": "service",
+      "user_id": "user_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/handle_subscription_api_v1_subscriptions_gmail_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/handle_subscription_api_v1_subscriptions_gmail_post/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "string",
+      "enum": [
+        "gmail"
+      ],
+      "title": "ServiceEnum"
+    },
+    "user_id": {
+      "type": "string",
+      "title": "User Id"
+    }
+  },
+  "required": [
+    "service",
+    "user_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/handle_subscription_api_v1_subscriptions_gmail_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/handle_subscription_api_v1_subscriptions_gmail_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "service": z.literal("gmail"),
+  "user_id": z.string()
+}

--- a/servers/api_example_com/src/tools/health_check_health_get/index.ts
+++ b/servers/api_example_com/src/tools/health_check_health_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "health_check_health_get",
+  "toolDescription": "Health Check",
+  "baseUrl": "https://api.example.com",
+  "path": "/health",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/health_check_health_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/health_check_health_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/health_check_health_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/health_check_health_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/login_api_v1_auth_login_post/index.ts
+++ b/servers/api_example_com/src/tools/login_api_v1_auth_login_post/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "login_api_v1_auth_login_post",
+  "toolDescription": "Login",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/login_api_v1_auth_login_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/login_api_v1_auth_login_post/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email",
+      "title": "Email"
+    },
+    "password": {
+      "type": "string",
+      "title": "Password"
+    }
+  },
+  "required": [
+    "email",
+    "password"
+  ]
+}

--- a/servers/api_example_com/src/tools/login_api_v1_auth_login_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/login_api_v1_auth_login_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email": z.string().email(),
+  "password": z.string()
+}

--- a/servers/api_example_com/src/tools/login_google_api_v1_auth_login_google_get/index.ts
+++ b/servers/api_example_com/src/tools/login_google_api_v1_auth_login_google_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "login_google_api_v1_auth_login_google_get",
+  "toolDescription": "Login Google",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/login/google",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/login_google_api_v1_auth_login_google_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/login_google_api_v1_auth_login_google_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/login_google_api_v1_auth_login_google_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/login_google_api_v1_auth_login_google_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/logout_api_v1_auth_logout_post/index.ts
+++ b/servers/api_example_com/src/tools/logout_api_v1_auth_logout_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "logout_api_v1_auth_logout_post",
+  "toolDescription": "Logout",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/logout",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/logout_api_v1_auth_logout_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/logout_api_v1_auth_logout_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/logout_api_v1_auth_logout_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/logout_api_v1_auth_logout_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/oauth_callback_api_v1_auth_oauth_callback_post/index.ts
+++ b/servers/api_example_com/src/tools/oauth_callback_api_v1_auth_oauth_callback_post/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "oauth_callback_api_v1_auth_oauth_callback_post",
+  "toolDescription": "Oauth Callback",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/oauth/callback",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "code": "code",
+      "state": "state"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/oauth_callback_api_v1_auth_oauth_callback_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/oauth_callback_api_v1_auth_oauth_callback_post/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "string",
+      "title": "Code"
+    },
+    "state": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "State"
+    }
+  },
+  "required": [
+    "code"
+  ]
+}

--- a/servers/api_example_com/src/tools/oauth_callback_api_v1_auth_oauth_callback_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/oauth_callback_api_v1_auth_oauth_callback_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "code": z.string(),
+  "state": z.union([z.string(), z.null()]).optional()
+}

--- a/servers/api_example_com/src/tools/query_session_api_v1_excel_sessions_session_id_query_post/index.ts
+++ b/servers/api_example_com/src/tools/query_session_api_v1_excel_sessions_session_id_query_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "query_session_api_v1_excel_sessions_session_id_query_post",
+  "toolDescription": "Query Session",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/excel/sessions/{session_id}/query",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/query_session_api_v1_excel_sessions_session_id_query_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/query_session_api_v1_excel_sessions_session_id_query_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/query_session_api_v1_excel_sessions_session_id_query_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/query_session_api_v1_excel_sessions_session_id_query_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/register_api_v1_auth_register_post/index.ts
+++ b/servers/api_example_com/src/tools/register_api_v1_auth_register_post/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "register_api_v1_auth_register_post",
+  "toolDescription": "Register",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/auth/register",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/register_api_v1_auth_register_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/register_api_v1_auth_register_post/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "title": "Email"
+    },
+    "password": {
+      "type": "string",
+      "title": "Password"
+    }
+  },
+  "required": [
+    "name",
+    "email",
+    "password"
+  ]
+}

--- a/servers/api_example_com/src/tools/register_api_v1_auth_register_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/register_api_v1_auth_register_post/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string(),
+  "email": z.string().email(),
+  "password": z.string()
+}

--- a/servers/api_example_com/src/tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/index.ts
+++ b/servers/api_example_com/src/tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sync_drive_handler_api_v1_webhooks_sync_drive_post",
+  "toolDescription": "Sync Drive Handler",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/webhooks/sync/drive",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/sync_drive_handler_api_v1_webhooks_sync_drive_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/index.ts
+++ b/servers/api_example_com/src/tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "sync_gmail_handler_api_v1_webhooks_sync_gmail_post",
+  "toolDescription": "Sync Gmail Handler",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/webhooks/sync/gmail",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/sync_gmail_handler_api_v1_webhooks_sync_gmail_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/index.ts
+++ b/servers/api_example_com/src/tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "update_email_analysis_api_v1_email_analysis_analysis_id_put",
+  "toolDescription": "Update Email Analysis",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/email-analysis/{analysis_id}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "analysis_id": "analysis_id"
+    },
+    "body": {
+      "assigned_label": "assigned_label",
+      "priority_level": "priority_level",
+      "suggested_action": "suggested_action",
+      "confidence_score": "confidence_score"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/schema-json/root.json
+++ b/servers/api_example_com/src/tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/schema-json/root.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "analysis_id": {
+      "type": "string",
+      "title": "Analysis Id"
+    },
+    "assigned_label": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Assigned Label"
+    },
+    "priority_level": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(high|medium|low)$"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Priority Level"
+    },
+    "suggested_action": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Suggested Action"
+    },
+    "confidence_score": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "maximum": 100,
+          "minimum": 0
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Confidence Score"
+    }
+  },
+  "required": [
+    "analysis_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/schema/root.ts
+++ b/servers/api_example_com/src/tools/update_email_analysis_api_v1_email_analysis_analysis_id_put/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "analysis_id": z.string(),
+  "assigned_label": z.union([z.string(), z.null()]).optional(),
+  "priority_level": z.union([z.string().regex(new RegExp("^(high|medium|low)$")), z.null()]).optional(),
+  "suggested_action": z.union([z.string(), z.null()]).optional(),
+  "confidence_score": z.union([z.number().int().gte(0).lte(100), z.null()]).optional()
+}

--- a/servers/api_example_com/src/tools/upload_excel_file_api_v1_excel_upload_post/index.ts
+++ b/servers/api_example_com/src/tools/upload_excel_file_api_v1_excel_upload_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "upload_excel_file_api_v1_excel_upload_post",
+  "toolDescription": "Upload Excel File",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/excel/upload",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/upload_excel_file_api_v1_excel_upload_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/upload_excel_file_api_v1_excel_upload_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/upload_excel_file_api_v1_excel_upload_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/upload_excel_file_api_v1_excel_upload_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/upload_file_api_v1_s3_upload_post/index.ts
+++ b/servers/api_example_com/src/tools/upload_file_api_v1_s3_upload_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "upload_file_api_v1_s3_upload_post",
+  "toolDescription": "Upload File",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/s3/upload",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/upload_file_api_v1_s3_upload_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/upload_file_api_v1_s3_upload_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/upload_file_api_v1_s3_upload_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/upload_file_api_v1_s3_upload_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/webhook_handler_api_v1_webhooks_composio_post/index.ts
+++ b/servers/api_example_com/src/tools/webhook_handler_api_v1_webhooks_composio_post/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "webhook_handler_api_v1_webhooks_composio_post",
+  "toolDescription": "Webhook Handler",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/v1/webhooks/composio",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/webhook_handler_api_v1_webhooks_composio_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/webhook_handler_api_v1_webhooks_composio_post/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/webhook_handler_api_v1_webhooks_composio_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/webhook_handler_api_v1_webhooks_composio_post/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.