### PR TITLE
Add MCP server `_api_environment_a_consumer_api_v0`

### DIFF
--- a/servers/_api_environment_a_consumer_api_v0/.npmignore
+++ b/servers/_api_environment_a_consumer_api_v0/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_api_environment_a_consumer_api_v0/README.md
+++ b/servers/_api_environment_a_consumer_api_v0/README.md
@@ -1,0 +1,151 @@
+# @open-mcp/_api_environment_a_consumer_api_v0
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "_api_environment_a_consumer_api_v0": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/_api_environment_a_consumer_api_v0@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/_api_environment_a_consumer_api_v0@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+OIDC_TOKEN='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add _api_environment_a_consumer_api_v0 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OIDC_TOKEN=$OIDC_TOKEN
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add _api_environment_a_consumer_api_v0 \
+  .cursor/mcp.json \
+  --OIDC_TOKEN=$OIDC_TOKEN
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add _api_environment_a_consumer_api_v0 \
+  /path/to/client/config.json \
+  --OIDC_TOKEN=$OIDC_TOKEN
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_api_environment_a_consumer_api_v0": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_api_environment_a_consumer_api_v0"],
+      "env": {"OIDC_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `OIDC_TOKEN` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_users_userid_accounts
+
+**Environment variables**
+
+- `OIDC_TOKEN`
+
+**Input schema**
+
+- `userId` (string)
+- `active` (boolean)
+
+### get_users_userid_accounts_accountid_number
+
+**Environment variables**
+
+- `OIDC_TOKEN`
+
+**Input schema**
+
+- `userId` (string)
+- `accountId` (string)
+
+### get_users_userid_accounts_entitlements
+
+**Environment variables**
+
+- `OIDC_TOKEN`
+
+**Input schema**
+
+- `userId` (string)
+
+### get_users_userid_accounts_accountid_
+
+**Environment variables**
+
+- `OIDC_TOKEN`
+
+**Input schema**
+
+- `userId` (string)
+- `accountId` (string)
+
+### put_users_userid_accounts_accountid_name
+
+**Environment variables**
+
+- `OIDC_TOKEN`
+
+**Input schema**
+
+- `userId` (string)
+- `accountId` (string)
+- `name` (string)

--- a/servers/_api_environment_a_consumer_api_v0/package.json
+++ b/servers/_api_environment_a_consumer_api_v0/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/_api_environment_a_consumer_api_v0",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "_api_environment_a_consumer_api_v0": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/constants.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/constants.ts
@@ -1,0 +1,10 @@
+export const OPENAPI_URL = "https://jackhenry.dev/open-api-docs/consumer-api/api-reference/v0/accounts/details/accounts.swagger.yaml"
+export const SERVER_NAME = "_api_environment_a_consumer_api_v0"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_users_userid_accounts/index.js",
+  "./tools/get_users_userid_accounts_accountid_number/index.js",
+  "./tools/get_users_userid_accounts_entitlements/index.js",
+  "./tools/get_users_userid_accounts_accountid_/index.js",
+  "./tools/put_users_userid_accounts_accountid_name/index.js"
+]

--- a/servers/_api_environment_a_consumer_api_v0/src/index.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/_api_environment_a_consumer_api_v0/src/server.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts/index.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_users_userid_accounts",
+  "toolDescription": "This endpoint supports being used with an Access Token from the Admin API with \"View everything – users, messages, settings, and organizations and organization members\" permission for Associated User.\n\nGet all accounts for a user. This endp",
+  "baseUrl": "https://{API_ENVIRONMENT}/a/consumer/api/v0",
+  "path": "/users/{userId}/accounts",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OIDC_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OIDC_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId"
+    },
+    "query": {
+      "active": "active"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts/schema-json/root.json
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the desired user",
+      "type": "string",
+      "format": "uuid",
+      "example": "01234567-abcd-4321-fedc-9876543210fa"
+    },
+    "active": {
+      "description": "DEPRECATED - If true, only return non-hidden accounts",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "userId"
+  ]
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts/schema/root.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the desired user"),
+  "active": z.boolean().describe("DEPRECATED - If true, only return non-hidden accounts").optional()
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_/index.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_users_userid_accounts_accountid_",
+  "toolDescription": "This endpoint supports being used with an Access Token from the Admin API with \"View everything – users, messages, settings, and organizations and organization members\" permission for Associated User.\n\nGet a single account for a user",
+  "baseUrl": "https://{API_ENVIRONMENT}/a/consumer/api/v0",
+  "path": "/users/{userId}/accounts/{accountId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OIDC_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OIDC_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId",
+      "accountId": "accountId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_/schema-json/root.json
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the desired user",
+      "type": "string",
+      "format": "uuid",
+      "example": "01234567-abcd-4321-fedc-9876543210fa"
+    },
+    "accountId": {
+      "description": "ID of the desired account",
+      "type": "string",
+      "format": "uuid",
+      "example": "02345617-bacd-3421-fdce-876593401fa0"
+    }
+  },
+  "required": [
+    "userId",
+    "accountId"
+  ]
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_/schema/root.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the desired user"),
+  "accountId": z.string().uuid().describe("ID of the desired account")
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_number/index.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_number/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_users_userid_accounts_accountid_number",
+  "toolDescription": "This endpoint supports being used with an Access Token from the Admin API with \"View everything – users, messages, settings, and organizations and organization members\" permission for Associated User.\n\nReturns the unmasked account number fo",
+  "baseUrl": "https://{API_ENVIRONMENT}/a/consumer/api/v0",
+  "path": "/users/{userId}/accounts/{accountId}/number",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OIDC_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OIDC_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId",
+      "accountId": "accountId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_number/schema-json/root.json
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_number/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the desired user",
+      "type": "string",
+      "format": "uuid",
+      "example": "01234567-abcd-4321-fedc-9876543210fa"
+    },
+    "accountId": {
+      "description": "ID of the desired account",
+      "type": "string",
+      "format": "uuid",
+      "example": "02345617-bacd-3421-fdce-876593401fa0"
+    }
+  },
+  "required": [
+    "userId",
+    "accountId"
+  ]
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_number/schema/root.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_accountid_number/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the desired user"),
+  "accountId": z.string().uuid().describe("ID of the desired account")
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_entitlements/index.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_entitlements/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_users_userid_accounts_entitlements",
+  "toolDescription": "This endpoint does not support being used with an Access Token from the Admin API.\n\nGets entitlements for all accounts",
+  "baseUrl": "https://{API_ENVIRONMENT}/a/consumer/api/v0",
+  "path": "/users/{userId}/accounts/entitlements",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OIDC_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OIDC_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_entitlements/schema-json/root.json
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_entitlements/schema-json/root.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the desired user",
+      "type": "string",
+      "format": "uuid",
+      "example": "01234567-abcd-4321-fedc-9876543210fa"
+    }
+  },
+  "required": [
+    "userId"
+  ]
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_entitlements/schema/root.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/get_users_userid_accounts_entitlements/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the desired user")
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/put_users_userid_accounts_accountid_name/index.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/put_users_userid_accounts_accountid_name/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_users_userid_accounts_accountid_name",
+  "toolDescription": "This endpoint does not support being used with an Access Token from the Admin API.\n\nUpdates an account's name.",
+  "baseUrl": "https://{API_ENVIRONMENT}/a/consumer/api/v0",
+  "path": "/users/{userId}/accounts/{accountId}/name",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OIDC_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OIDC_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId",
+      "accountId": "accountId"
+    },
+    "body": {
+      "name": "name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/put_users_userid_accounts_accountid_name/schema-json/root.json
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/put_users_userid_accounts_accountid_name/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the desired user",
+      "type": "string",
+      "format": "uuid",
+      "example": "01234567-abcd-4321-fedc-9876543210fa"
+    },
+    "accountId": {
+      "description": "ID of the desired account",
+      "type": "string",
+      "format": "uuid",
+      "example": "02345617-bacd-3421-fdce-876593401fa0"
+    },
+    "name": {
+      "type": "string",
+      "description": "Account name to update to"
+    }
+  },
+  "required": [
+    "userId",
+    "accountId",
+    "name"
+  ]
+}

--- a/servers/_api_environment_a_consumer_api_v0/src/tools/put_users_userid_accounts_accountid_name/schema/root.ts
+++ b/servers/_api_environment_a_consumer_api_v0/src/tools/put_users_userid_accounts_accountid_name/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the desired user"),
+  "accountId": z.string().uuid().describe("ID of the desired account"),
+  "name": z.string().describe("Account name to update to")
+}

--- a/servers/_api_environment_a_consumer_api_v0/tsconfig.json
+++ b/servers/_api_environment_a_consumer_api_v0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_api_environment_a_consumer_api_v0`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_api_environment_a_consumer_api_v0`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_api_environment_a_consumer_api_v0": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_api_environment_a_consumer_api_v0"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.