### PR TITLE
Add MCP server `imagerouter`

### DIFF
--- a/servers/imagerouter/.npmignore
+++ b/servers/imagerouter/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/imagerouter/README.md
+++ b/servers/imagerouter/README.md
@@ -1,0 +1,138 @@
+# @open-mcp/imagerouter
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "imagerouter": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/imagerouter@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/imagerouter@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add imagerouter \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add imagerouter \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add imagerouter \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "imagerouter": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/imagerouter"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### post_v1_openai_images_generations
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `prompt` (string)
+- `model` (string)
+- `response_format` (string)
+- `quality` (string)
+
+### post_v1_openai_videos_generations
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `prompt` (string)
+- `model` (string)
+- `response_format` (string)
+
+### post_v1_openai_images_edits
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### get_v1_models
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters

--- a/servers/imagerouter/package.json
+++ b/servers/imagerouter/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/imagerouter",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "imagerouter": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/imagerouter/src/constants.ts
+++ b/servers/imagerouter/src/constants.ts
@@ -1,0 +1,9 @@
+export const OPENAPI_URL = "https://api.imagerouter.io/.well-known/openapi.yaml"
+export const SERVER_NAME = "imagerouter"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/post_v1_openai_images_generations/index.js",
+  "./tools/post_v1_openai_videos_generations/index.js",
+  "./tools/post_v1_openai_images_edits/index.js",
+  "./tools/get_v1_models/index.js"
+]

--- a/servers/imagerouter/src/index.ts
+++ b/servers/imagerouter/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/imagerouter/src/server.ts
+++ b/servers/imagerouter/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/imagerouter/src/tools/get_v1_models/index.ts
+++ b/servers/imagerouter/src/tools/get_v1_models/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_v1_models",
+  "toolDescription": "",
+  "baseUrl": "https://api.imagerouter.io",
+  "path": "/v1/models",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/imagerouter/src/tools/get_v1_models/schema-json/root.json
+++ b/servers/imagerouter/src/tools/get_v1_models/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/imagerouter/src/tools/get_v1_models/schema/root.ts
+++ b/servers/imagerouter/src/tools/get_v1_models/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/imagerouter/src/tools/post_v1_openai_images_edits/index.ts
+++ b/servers/imagerouter/src/tools/post_v1_openai_images_edits/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_openai_images_edits",
+  "toolDescription": "",
+  "baseUrl": "https://api.imagerouter.io",
+  "path": "/v1/openai/images/edits",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/imagerouter/src/tools/post_v1_openai_images_edits/schema-json/root.json
+++ b/servers/imagerouter/src/tools/post_v1_openai_images_edits/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/imagerouter/src/tools/post_v1_openai_images_edits/schema/root.ts
+++ b/servers/imagerouter/src/tools/post_v1_openai_images_edits/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/imagerouter/src/tools/post_v1_openai_images_generations/index.ts
+++ b/servers/imagerouter/src/tools/post_v1_openai_images_generations/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_openai_images_generations",
+  "toolDescription": "",
+  "baseUrl": "https://api.imagerouter.io",
+  "path": "/v1/openai/images/generations",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "prompt": "prompt",
+      "model": "model",
+      "response_format": "response_format",
+      "quality": "quality"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/imagerouter/src/tools/post_v1_openai_images_generations/schema-json/root.json
+++ b/servers/imagerouter/src/tools/post_v1_openai_images_generations/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "prompt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "response_format": {
+      "type": "string",
+      "enum": [
+        "url",
+        "b64_json"
+      ],
+      "default": "url"
+    },
+    "quality": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "auto"
+    }
+  },
+  "required": [
+    "prompt",
+    "model"
+  ]
+}

--- a/servers/imagerouter/src/tools/post_v1_openai_images_generations/schema/root.ts
+++ b/servers/imagerouter/src/tools/post_v1_openai_images_generations/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prompt": z.string().min(1),
+  "model": z.string().min(1),
+  "response_format": z.enum(["url","b64_json"]).optional(),
+  "quality": z.enum(["auto","low","medium","high"]).optional()
+}

--- a/servers/imagerouter/src/tools/post_v1_openai_videos_generations/index.ts
+++ b/servers/imagerouter/src/tools/post_v1_openai_videos_generations/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_openai_videos_generations",
+  "toolDescription": "",
+  "baseUrl": "https://api.imagerouter.io",
+  "path": "/v1/openai/videos/generations",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "prompt": "prompt",
+      "model": "model",
+      "response_format": "response_format"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/imagerouter/src/tools/post_v1_openai_videos_generations/schema-json/root.json
+++ b/servers/imagerouter/src/tools/post_v1_openai_videos_generations/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "prompt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "response_format": {
+      "type": "string",
+      "enum": [
+        "url",
+        "b64_json"
+      ],
+      "default": "url"
+    }
+  },
+  "required": [
+    "prompt",
+    "model"
+  ]
+}

--- a/servers/imagerouter/src/tools/post_v1_openai_videos_generations/schema/root.ts
+++ b/servers/imagerouter/src/tools/post_v1_openai_videos_generations/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prompt": z.string().min(1),
+  "model": z.string().min(1),
+  "response_format": z.enum(["url","b64_json"]).optional()
+}

--- a/servers/imagerouter/tsconfig.json
+++ b/servers/imagerouter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `imagerouter`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/imagerouter`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "imagerouter": {
      "command": "npx",
      "args": ["-y", "@open-mcp/imagerouter"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.