### PR TITLE
Add MCP server `xpipe`

### DIFF
--- a/servers/xpipe/.npmignore
+++ b/servers/xpipe/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/xpipe/README.md
+++ b/servers/xpipe/README.md
@@ -1,0 +1,291 @@
+# @open-mcp/xpipe
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "xpipe": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/xpipe@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/xpipe@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add xpipe \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add xpipe \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add xpipe \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "xpipe": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/xpipe"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### handshake
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `auth` (other)
+- `client` (object)
+
+### connectionquery
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `categoryFilter` (string)
+- `connectionFilter` (string)
+- `typeFilter` (string)
+
+### connectioninfo
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connections` (array)
+
+### connectionadd
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `name` (string)
+- `data` (object)
+- `validate` (boolean)
+- `category` (string)
+
+### categoryad
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `name` (string)
+- `parent` (string)
+
+### connectionremove
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connections` (array)
+
+### connectionbrowse
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `directory` (string)
+- `connection` (string)
+
+### connectionterminal
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `directory` (string)
+- `connection` (string)
+
+### connectiontoggle
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `state` (boolean)
+- `connection` (string)
+
+### connectionrefresh
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+
+### shellstart
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+
+### shellstop
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+
+### shellexec
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+- `command` (string)
+
+### fsdata
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### fsread
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+- `path` (string)
+
+### fswrite
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+- `blob` (string)
+- `path` (string)
+
+### fsscript
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `connection` (string)
+- `blob` (string)
+
+### daemonversion
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters

--- a/servers/xpipe/package.json
+++ b/servers/xpipe/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/xpipe",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "xpipe": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/xpipe/src/constants.ts
+++ b/servers/xpipe/src/constants.ts
@@ -1,0 +1,23 @@
+export const OPENAPI_URL = "https://docs.xpipe.io/openapi.yaml"
+export const SERVER_NAME = "xpipe"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/handshake/index.js",
+  "./tools/connectionquery/index.js",
+  "./tools/connectioninfo/index.js",
+  "./tools/connectionadd/index.js",
+  "./tools/categoryad/index.js",
+  "./tools/connectionremove/index.js",
+  "./tools/connectionbrowse/index.js",
+  "./tools/connectionterminal/index.js",
+  "./tools/connectiontoggle/index.js",
+  "./tools/connectionrefresh/index.js",
+  "./tools/shellstart/index.js",
+  "./tools/shellstop/index.js",
+  "./tools/shellexec/index.js",
+  "./tools/fsdata/index.js",
+  "./tools/fsread/index.js",
+  "./tools/fswrite/index.js",
+  "./tools/fsscript/index.js",
+  "./tools/daemonversion/index.js"
+]

--- a/servers/xpipe/src/index.ts
+++ b/servers/xpipe/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/xpipe/src/server.ts
+++ b/servers/xpipe/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/xpipe/src/tools/categoryad/index.ts
+++ b/servers/xpipe/src/tools/categoryad/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "categoryad",
+  "toolDescription": "Add category",
+  "baseUrl": "http://localhost:21721",
+  "path": "/category/add",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "parent": "parent"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/categoryad/schema-json/root.json
+++ b/servers/xpipe/src/tools/categoryad/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The category name"
+    },
+    "parent": {
+      "type": "string",
+      "description": "The parent category uuid to put the new category in"
+    }
+  },
+  "required": [
+    "name",
+    "parent"
+  ]
+}

--- a/servers/xpipe/src/tools/categoryad/schema/root.ts
+++ b/servers/xpipe/src/tools/categoryad/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string().describe("The category name"),
+  "parent": z.string().describe("The parent category uuid to put the new category in")
+}

--- a/servers/xpipe/src/tools/connectionadd/index.ts
+++ b/servers/xpipe/src/tools/connectionadd/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectionadd",
+  "toolDescription": "Add connection",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/add",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "data": "data",
+      "validate": "validate",
+      "category": "category"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectionadd/schema-json/properties/data.json
+++ b/servers/xpipe/src/tools/connectionadd/schema-json/properties/data.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "description": "The raw connection store data. Schemas for connection types are not documented, but you can find the connection data of your existing connections in the xpipe vault.",
+  "properties": {}
+}

--- a/servers/xpipe/src/tools/connectionadd/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectionadd/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The connection name"
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>The raw connection store data. Schemas for connection types are not documented, but you can find the connection data of your existing connections in the xpipe vault.</property-description>",
+      "additionalProperties": true
+    },
+    "validate": {
+      "type": "boolean",
+      "description": "Whether to perform a connection validation before adding it, i.e., probe the connection first. If validation is enabled and fails, the connection will not be added"
+    },
+    "category": {
+      "type": "string",
+      "description": "The category uuid to put the connection in. If not specified, the default category will be used"
+    }
+  },
+  "required": [
+    "name",
+    "data",
+    "validate"
+  ]
+}

--- a/servers/xpipe/src/tools/connectionadd/schema/properties/data.ts
+++ b/servers/xpipe/src/tools/connectionadd/schema/properties/data.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/xpipe/src/tools/connectionadd/schema/root.ts
+++ b/servers/xpipe/src/tools/connectionadd/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string().describe("The connection name"),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>The raw connection store data. Schemas for connection types are not documented, but you can find the connection data of your existing connections in the xpipe vault.</property-description>"),
+  "validate": z.boolean().describe("Whether to perform a connection validation before adding it, i.e., probe the connection first. If validation is enabled and fails, the connection will not be added"),
+  "category": z.string().describe("The category uuid to put the connection in. If not specified, the default category will be used").optional()
+}

--- a/servers/xpipe/src/tools/connectionbrowse/index.ts
+++ b/servers/xpipe/src/tools/connectionbrowse/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectionbrowse",
+  "toolDescription": "Open connection file browser",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/browse",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "directory": "directory",
+      "connection": "connection"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectionbrowse/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectionbrowse/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "directory": {
+      "type": "string",
+      "description": "The optional directory to browse to"
+    },
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    }
+  },
+  "required": [
+    "directory",
+    "connection"
+  ]
+}

--- a/servers/xpipe/src/tools/connectionbrowse/schema/root.ts
+++ b/servers/xpipe/src/tools/connectionbrowse/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "directory": z.string().describe("The optional directory to browse to"),
+  "connection": z.string().describe("The connection uuid")
+}

--- a/servers/xpipe/src/tools/connectioninfo/index.ts
+++ b/servers/xpipe/src/tools/connectioninfo/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectioninfo",
+  "toolDescription": "Get connection info",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/info",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connections": "connections"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectioninfo/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectioninfo/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "connections": {
+      "type": "array",
+      "description": "The connections",
+      "items": {
+        "type": "string",
+        "description": "The unique id of the connection"
+      }
+    }
+  },
+  "required": [
+    "connections"
+  ]
+}

--- a/servers/xpipe/src/tools/connectioninfo/schema/root.ts
+++ b/servers/xpipe/src/tools/connectioninfo/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connections": z.array(z.string().describe("The unique id of the connection")).describe("The connections")
+}

--- a/servers/xpipe/src/tools/connectionquery/index.ts
+++ b/servers/xpipe/src/tools/connectionquery/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectionquery",
+  "toolDescription": "Query connections",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/query",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "categoryFilter": "categoryFilter",
+      "connectionFilter": "connectionFilter",
+      "typeFilter": "typeFilter"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectionquery/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectionquery/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "categoryFilter": {
+      "type": "string",
+      "description": "The filter string to match categories. Categories are delimited by / if they are hierarchical. The filter supports globs."
+    },
+    "connectionFilter": {
+      "type": "string",
+      "description": "The filter string to match connection names. Connection names are delimited by / if they are hierarchical. The filter supports globs."
+    },
+    "typeFilter": {
+      "type": "string",
+      "description": "The filter string to connection types. Every unique type of connection like SSH or docker has its own type identifier that you can match. The filter supports globs."
+    }
+  },
+  "required": [
+    "categoryFilter",
+    "connectionFilter",
+    "typeFilter"
+  ]
+}

--- a/servers/xpipe/src/tools/connectionquery/schema/root.ts
+++ b/servers/xpipe/src/tools/connectionquery/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "categoryFilter": z.string().describe("The filter string to match categories. Categories are delimited by / if they are hierarchical. The filter supports globs."),
+  "connectionFilter": z.string().describe("The filter string to match connection names. Connection names are delimited by / if they are hierarchical. The filter supports globs."),
+  "typeFilter": z.string().describe("The filter string to connection types. Every unique type of connection like SSH or docker has its own type identifier that you can match. The filter supports globs.")
+}

--- a/servers/xpipe/src/tools/connectionrefresh/index.ts
+++ b/servers/xpipe/src/tools/connectionrefresh/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectionrefresh",
+  "toolDescription": "Refresh connection",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/refresh",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectionrefresh/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectionrefresh/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    }
+  },
+  "required": [
+    "connection"
+  ]
+}

--- a/servers/xpipe/src/tools/connectionrefresh/schema/root.ts
+++ b/servers/xpipe/src/tools/connectionrefresh/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid")
+}

--- a/servers/xpipe/src/tools/connectionremove/index.ts
+++ b/servers/xpipe/src/tools/connectionremove/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectionremove",
+  "toolDescription": "Remove connection",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/remove",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connections": "connections"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectionremove/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectionremove/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "connections": {
+      "type": "array",
+      "description": "The connections to remove",
+      "items": {
+        "type": "string",
+        "description": "The unique id of the connection"
+      }
+    }
+  },
+  "required": [
+    "connections"
+  ]
+}

--- a/servers/xpipe/src/tools/connectionremove/schema/root.ts
+++ b/servers/xpipe/src/tools/connectionremove/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connections": z.array(z.string().describe("The unique id of the connection")).describe("The connections to remove")
+}

--- a/servers/xpipe/src/tools/connectionterminal/index.ts
+++ b/servers/xpipe/src/tools/connectionterminal/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectionterminal",
+  "toolDescription": "Open connection in terminal",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/terminal",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "directory": "directory",
+      "connection": "connection"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectionterminal/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectionterminal/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "directory": {
+      "type": "string",
+      "description": "The optional directory to use as the working directory"
+    },
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    }
+  },
+  "required": [
+    "directory",
+    "connection"
+  ]
+}

--- a/servers/xpipe/src/tools/connectionterminal/schema/root.ts
+++ b/servers/xpipe/src/tools/connectionterminal/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "directory": z.string().describe("The optional directory to use as the working directory"),
+  "connection": z.string().describe("The connection uuid")
+}

--- a/servers/xpipe/src/tools/connectiontoggle/index.ts
+++ b/servers/xpipe/src/tools/connectiontoggle/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "connectiontoggle",
+  "toolDescription": "Toggle connection",
+  "baseUrl": "http://localhost:21721",
+  "path": "/connection/toggle",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "state": "state",
+      "connection": "connection"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/connectiontoggle/schema-json/root.json
+++ b/servers/xpipe/src/tools/connectiontoggle/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "state": {
+      "type": "boolean",
+      "description": "The state to switch to"
+    },
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    }
+  },
+  "required": [
+    "state",
+    "connection"
+  ]
+}

--- a/servers/xpipe/src/tools/connectiontoggle/schema/root.ts
+++ b/servers/xpipe/src/tools/connectiontoggle/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "state": z.boolean().describe("The state to switch to"),
+  "connection": z.string().describe("The connection uuid")
+}

--- a/servers/xpipe/src/tools/daemonversion/index.ts
+++ b/servers/xpipe/src/tools/daemonversion/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "daemonversion",
+  "toolDescription": "Query daemon version",
+  "baseUrl": "http://localhost:21721",
+  "path": "/daemon/version",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/daemonversion/schema-json/root.json
+++ b/servers/xpipe/src/tools/daemonversion/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/xpipe/src/tools/daemonversion/schema/root.ts
+++ b/servers/xpipe/src/tools/daemonversion/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/xpipe/src/tools/fsdata/index.ts
+++ b/servers/xpipe/src/tools/fsdata/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "fsdata",
+  "toolDescription": "Store raw file blob",
+  "baseUrl": "http://localhost:21721",
+  "path": "/fs/blob",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/fsdata/schema-json/root.json
+++ b/servers/xpipe/src/tools/fsdata/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/xpipe/src/tools/fsdata/schema/root.ts
+++ b/servers/xpipe/src/tools/fsdata/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/xpipe/src/tools/fsread/index.ts
+++ b/servers/xpipe/src/tools/fsread/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "fsread",
+  "toolDescription": "Read a remote file",
+  "baseUrl": "http://localhost:21721",
+  "path": "/fs/read",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection",
+      "path": "path"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/fsread/schema-json/root.json
+++ b/servers/xpipe/src/tools/fsread/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    },
+    "path": {
+      "type": "string",
+      "description": "The target file path"
+    }
+  },
+  "required": [
+    "connection",
+    "path"
+  ]
+}

--- a/servers/xpipe/src/tools/fsread/schema/root.ts
+++ b/servers/xpipe/src/tools/fsread/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid"),
+  "path": z.string().describe("The target file path")
+}

--- a/servers/xpipe/src/tools/fsscript/index.ts
+++ b/servers/xpipe/src/tools/fsscript/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "fsscript",
+  "toolDescription": "Write blob to a shell script",
+  "baseUrl": "http://localhost:21721",
+  "path": "/fs/script",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection",
+      "blob": "blob"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/fsscript/schema-json/root.json
+++ b/servers/xpipe/src/tools/fsscript/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    },
+    "blob": {
+      "type": "string",
+      "description": "The blob uuid"
+    }
+  },
+  "required": [
+    "connection",
+    "blob"
+  ]
+}

--- a/servers/xpipe/src/tools/fsscript/schema/root.ts
+++ b/servers/xpipe/src/tools/fsscript/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid"),
+  "blob": z.string().describe("The blob uuid")
+}

--- a/servers/xpipe/src/tools/fswrite/index.ts
+++ b/servers/xpipe/src/tools/fswrite/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "fswrite",
+  "toolDescription": "Write blob to a remote file",
+  "baseUrl": "http://localhost:21721",
+  "path": "/fs/write",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection",
+      "blob": "blob",
+      "path": "path"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/fswrite/schema-json/root.json
+++ b/servers/xpipe/src/tools/fswrite/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    },
+    "blob": {
+      "type": "string",
+      "description": "The blob uuid"
+    },
+    "path": {
+      "type": "string",
+      "description": "The target filepath"
+    }
+  },
+  "required": [
+    "connection",
+    "blob",
+    "path"
+  ]
+}

--- a/servers/xpipe/src/tools/fswrite/schema/root.ts
+++ b/servers/xpipe/src/tools/fswrite/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid"),
+  "blob": z.string().describe("The blob uuid"),
+  "path": z.string().describe("The target filepath")
+}

--- a/servers/xpipe/src/tools/handshake/index.ts
+++ b/servers/xpipe/src/tools/handshake/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "handshake",
+  "toolDescription": "Establish session",
+  "baseUrl": "http://localhost:21721",
+  "path": "/handshake",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "auth": "auth",
+      "client": "client"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/handshake/schema-json/properties/client.json
+++ b/servers/xpipe/src/tools/handshake/schema-json/properties/client.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "discriminator": {
+    "propertyName": "type"
+  },
+  "properties": {
+    "type": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ]
+}

--- a/servers/xpipe/src/tools/handshake/schema-json/root.json
+++ b/servers/xpipe/src/tools/handshake/schema-json/root.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "auth": {
+      "discriminator": {
+        "propertyName": "type",
+        "mapping": {
+          "apiKey": "#/components/schemas/ApiKey",
+          "local": "#/components/schemas/Local"
+        }
+      },
+      "anyOf": [
+        {
+          "description": "API key authentication",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string",
+              "description": "The API key"
+            }
+          },
+          "required": [
+            "key",
+            "type"
+          ]
+        }
+      ]
+    },
+    "client": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `client` to the tool, first call the tool `expandSchema` with \"/properties/client\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "auth",
+    "client"
+  ]
+}

--- a/servers/xpipe/src/tools/handshake/schema/properties/client.ts
+++ b/servers/xpipe/src/tools/handshake/schema/properties/client.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.string()
+}

--- a/servers/xpipe/src/tools/handshake/schema/root.ts
+++ b/servers/xpipe/src/tools/handshake/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "auth": z.object({ "type": z.string(), "key": z.string().describe("The API key") }).describe("API key authentication"),
+  "client": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `client` to the tool, first call the tool `expandSchema` with \"/properties/client\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/xpipe/src/tools/shellexec/index.ts
+++ b/servers/xpipe/src/tools/shellexec/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "shellexec",
+  "toolDescription": "Run command in shell session",
+  "baseUrl": "http://localhost:21721",
+  "path": "/shell/exec",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection",
+      "command": "command"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/shellexec/schema-json/root.json
+++ b/servers/xpipe/src/tools/shellexec/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    },
+    "command": {
+      "type": "string",
+      "description": "The command to execute"
+    }
+  },
+  "required": [
+    "connection",
+    "command"
+  ]
+}

--- a/servers/xpipe/src/tools/shellexec/schema/root.ts
+++ b/servers/xpipe/src/tools/shellexec/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid"),
+  "command": z.string().describe("The command to execute")
+}

--- a/servers/xpipe/src/tools/shellstart/index.ts
+++ b/servers/xpipe/src/tools/shellstart/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "shellstart",
+  "toolDescription": "Start shell connection",
+  "baseUrl": "http://localhost:21721",
+  "path": "/shell/start",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/shellstart/schema-json/root.json
+++ b/servers/xpipe/src/tools/shellstart/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    }
+  },
+  "required": [
+    "connection"
+  ]
+}

--- a/servers/xpipe/src/tools/shellstart/schema/root.ts
+++ b/servers/xpipe/src/tools/shellstart/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid")
+}

--- a/servers/xpipe/src/tools/shellstop/index.ts
+++ b/servers/xpipe/src/tools/shellstop/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "shellstop",
+  "toolDescription": "Stop shell connection",
+  "baseUrl": "http://localhost:21721",
+  "path": "/shell/stop",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "connection": "connection"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/xpipe/src/tools/shellstop/schema-json/root.json
+++ b/servers/xpipe/src/tools/shellstop/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "The connection uuid"
+    }
+  },
+  "required": [
+    "connection"
+  ]
+}

--- a/servers/xpipe/src/tools/shellstop/schema/root.ts
+++ b/servers/xpipe/src/tools/shellstop/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "connection": z.string().describe("The connection uuid")
+}

--- a/servers/xpipe/tsconfig.json
+++ b/servers/xpipe/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `xpipe`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/xpipe`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "xpipe": {
      "command": "npx",
      "args": ["-y", "@open-mcp/xpipe"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.