### PR TITLE
Add MCP server `_soilgrids_v2_0`

### DIFF
--- a/servers/_soilgrids_v2_0/.npmignore
+++ b/servers/_soilgrids_v2_0/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_soilgrids_v2_0/README.md
+++ b/servers/_soilgrids_v2_0/README.md
@@ -1,0 +1,129 @@
+# @open-mcp/_soilgrids_v2_0
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "_soilgrids_v2_0": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/_soilgrids_v2_0@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/_soilgrids_v2_0@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add _soilgrids_v2_0 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add _soilgrids_v2_0 \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add _soilgrids_v2_0 \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_soilgrids_v2_0": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_soilgrids_v2_0"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### query_layer_wrb_classification_query_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `lon` (number)
+- `lat` (number)
+- `number_classes` (integer)
+
+### layers_properties_layers_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### query_layer_properties_properties_query_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `lon` (number)
+- `lat` (number)
+- `property` (array)
+- `depth` (array)
+- `value` (array)

--- a/servers/_soilgrids_v2_0/package.json
+++ b/servers/_soilgrids_v2_0/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/_soilgrids_v2_0",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "_soilgrids_v2_0": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/_soilgrids_v2_0/src/constants.ts
+++ b/servers/_soilgrids_v2_0/src/constants.ts
@@ -1,0 +1,8 @@
+export const OPENAPI_URL = "https://rest.isric.org/soilgrids/v2.0/openapi.json"
+export const SERVER_NAME = "_soilgrids_v2_0"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/query_layer_wrb_classification_query_get/index.js",
+  "./tools/layers_properties_layers_get/index.js",
+  "./tools/query_layer_properties_properties_query_get/index.js"
+]

--- a/servers/_soilgrids_v2_0/src/index.ts
+++ b/servers/_soilgrids_v2_0/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/_soilgrids_v2_0/src/server.ts
+++ b/servers/_soilgrids_v2_0/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_soilgrids_v2_0/src/tools/layers_properties_layers_get/index.ts
+++ b/servers/_soilgrids_v2_0/src/tools/layers_properties_layers_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "layers_properties_layers_get",
+  "toolDescription": "Gets the layer structure of soilgrids soil properties",
+  "baseUrl": "/soilgrids/v2.0",
+  "path": "/properties/layers",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_soilgrids_v2_0/src/tools/layers_properties_layers_get/schema-json/root.json
+++ b/servers/_soilgrids_v2_0/src/tools/layers_properties_layers_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_soilgrids_v2_0/src/tools/layers_properties_layers_get/schema/root.ts
+++ b/servers/_soilgrids_v2_0/src/tools/layers_properties_layers_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_soilgrids_v2_0/src/tools/query_layer_properties_properties_query_get/index.ts
+++ b/servers/_soilgrids_v2_0/src/tools/query_layer_properties_properties_query_get/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "query_layer_properties_properties_query_get",
+  "toolDescription": "Queries a single pixel for information",
+  "baseUrl": "/soilgrids/v2.0",
+  "path": "/properties/query",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "lon": "lon",
+      "lat": "lat",
+      "property": "property",
+      "depth": "depth",
+      "value": "value"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_soilgrids_v2_0/src/tools/query_layer_properties_properties_query_get/schema-json/root.json
+++ b/servers/_soilgrids_v2_0/src/tools/query_layer_properties_properties_query_get/schema-json/root.json
@@ -1,0 +1,76 @@
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "description": "Longitude coordinate between -180 and 180",
+      "title": "Lon coordinate",
+      "maximum": 180,
+      "minimum": -180,
+      "type": "number"
+    },
+    "lat": {
+      "description": "Latitude coordinate between 90 and 90",
+      "title": "Lat coordinate",
+      "maximum": 90,
+      "minimum": -90,
+      "type": "number"
+    },
+    "property": {
+      "title": "Property",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "bdod",
+        "cec",
+        "cfvo",
+        "clay",
+        "nitrogen",
+        "ocd",
+        "ocs",
+        "phh2o",
+        "sand",
+        "silt",
+        "soc",
+        "wv0010",
+        "wv0033",
+        "wv1500"
+      ]
+    },
+    "depth": {
+      "title": "Depth",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "0-5cm",
+        "0-30cm",
+        "5-15cm",
+        "15-30cm",
+        "30-60cm",
+        "60-100cm",
+        "100-200cm"
+      ]
+    },
+    "value": {
+      "title": "Value",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "Q0.5",
+        "Q0.05",
+        "Q0.95",
+        "mean",
+        "uncertainty"
+      ]
+    }
+  },
+  "required": [
+    "lon",
+    "lat"
+  ]
+}

--- a/servers/_soilgrids_v2_0/src/tools/query_layer_properties_properties_query_get/schema/root.ts
+++ b/servers/_soilgrids_v2_0/src/tools/query_layer_properties_properties_query_get/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "lon": z.number().gte(-180).lte(180).describe("Longitude coordinate between -180 and 180"),
+  "lat": z.number().gte(-90).lte(90).describe("Latitude coordinate between 90 and 90"),
+  "property": z.array(z.string()).optional(),
+  "depth": z.array(z.string()).optional(),
+  "value": z.array(z.string()).optional()
+}

--- a/servers/_soilgrids_v2_0/src/tools/query_layer_wrb_classification_query_get/index.ts
+++ b/servers/_soilgrids_v2_0/src/tools/query_layer_wrb_classification_query_get/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "query_layer_wrb_classification_query_get",
+  "toolDescription": "Queries the WRB layers to extract most probable class, and probably of other classes",
+  "baseUrl": "/soilgrids/v2.0",
+  "path": "/classification/query",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "lon": "lon",
+      "lat": "lat",
+      "number_classes": "number_classes"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_soilgrids_v2_0/src/tools/query_layer_wrb_classification_query_get/schema-json/root.json
+++ b/servers/_soilgrids_v2_0/src/tools/query_layer_wrb_classification_query_get/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "description": "Longitude coordinate between -180 and 180",
+      "title": "Lon coordinate",
+      "maximum": 180,
+      "minimum": -180,
+      "type": "number"
+    },
+    "lat": {
+      "description": "Latitude coordinate between 90 and 90",
+      "title": "Lat coordinate",
+      "maximum": 90,
+      "minimum": -90,
+      "type": "number"
+    },
+    "number_classes": {
+      "description": "Number of WRB probability classes that will be return, ordered from higher to lower percentage",
+      "title": "Number of WRB probablity classes ",
+      "type": "integer",
+      "default": 5
+    }
+  },
+  "required": [
+    "lon",
+    "lat"
+  ]
+}

--- a/servers/_soilgrids_v2_0/src/tools/query_layer_wrb_classification_query_get/schema/root.ts
+++ b/servers/_soilgrids_v2_0/src/tools/query_layer_wrb_classification_query_get/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "lon": z.number().gte(-180).lte(180).describe("Longitude coordinate between -180 and 180"),
+  "lat": z.number().gte(-90).lte(90).describe("Latitude coordinate between 90 and 90"),
+  "number_classes": z.number().int().describe("Number of WRB probability classes that will be return, ordered from higher to lower percentage").optional()
+}

--- a/servers/_soilgrids_v2_0/tsconfig.json
+++ b/servers/_soilgrids_v2_0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_soilgrids_v2_0`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_soilgrids_v2_0`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_soilgrids_v2_0": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_soilgrids_v2_0"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.