### PR TITLE
Add MCP server `currency_exchange_teststage_org_exchanger_api`

### DIFF
--- a/servers/currency_exchange_teststage_org_exchanger_api/.npmignore
+++ b/servers/currency_exchange_teststage_org_exchanger_api/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/currency_exchange_teststage_org_exchanger_api/README.md
+++ b/servers/currency_exchange_teststage_org_exchanger_api/README.md
@@ -1,0 +1,208 @@
+# @open-mcp/currency_exchange_teststage_org_exchanger_api
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "currency_exchange_teststage_org_exchanger_api": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/currency_exchange_teststage_org_exchanger_api@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/currency_exchange_teststage_org_exchanger_api@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add currency_exchange_teststage_org_exchanger_api \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add currency_exchange_teststage_org_exchanger_api \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add currency_exchange_teststage_org_exchanger_api \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "currency_exchange_teststage_org_exchanger_api": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/currency_exchange_teststage_org_exchanger_api"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### getcandleshistory
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `symbols` (array)
+- `providers` (array)
+- `from` (string)
+- `to` (string)
+- `limit` (integer)
+- `interval` (string)
+- `cursor` (string)
+
+### register
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `username` (string)
+- `password` (string)
+
+### auth
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `username` (string)
+- `password` (string)
+
+### refreshtime
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `customerId` (integer)
+- `desiredCapacity` (object)
+
+### getexchangerates
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `pageable` (object)
+
+### updateexchangerates
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### gethighestexchangerate
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `currency` (string)
+
+### getchronologicalhistory
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `currency` (string)
+- `from` (string)
+- `to` (string)
+- `pageable` (object)
+
+### getexchangerates_1
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `currency` (string)
+- `sum` (number)
+- `provider` (string)
+- `pageable` (object)
+
+### closesession
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `sessionId` (string)

--- a/servers/currency_exchange_teststage_org_exchanger_api/package.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/currency_exchange_teststage_org_exchanger_api",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "currency_exchange_teststage_org_exchanger_api": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/constants.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/constants.ts
@@ -1,0 +1,15 @@
+export const OPENAPI_URL = "https://currency-exchange.teststage.org/exchanger/api/v3/api-docs"
+export const SERVER_NAME = "currency_exchange_teststage_org_exchanger_api"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/getcandleshistory/index.js",
+  "./tools/register/index.js",
+  "./tools/auth/index.js",
+  "./tools/refreshtime/index.js",
+  "./tools/getexchangerates/index.js",
+  "./tools/updateexchangerates/index.js",
+  "./tools/gethighestexchangerate/index.js",
+  "./tools/getchronologicalhistory/index.js",
+  "./tools/getexchangerates_1/index.js",
+  "./tools/closesession/index.js"
+]

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/server.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/auth/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/auth/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "auth",
+  "toolDescription": "Authenticate user",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/auth/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "username": "username",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/auth/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/auth/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "type": "string",
+      "description": "Username for authentication",
+      "example": "username"
+    },
+    "password": {
+      "type": "string",
+      "description": "Password for authentication",
+      "example": "P@ssw0rd"
+    }
+  },
+  "required": [
+    "username",
+    "password"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/auth/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/auth/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("Username for authentication"),
+  "password": z.string().describe("Password for authentication")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/closesession/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/closesession/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "closesession",
+  "toolDescription": "Close WebSocket Session",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/ws",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "sessionId": "sessionId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/closesession/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/closesession/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "sessionId": {
+      "description": "Identifier of the WebSocket session to close.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "sessionId"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/closesession/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/closesession/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "sessionId": z.string().describe("Identifier of the WebSocket session to close.")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getcandleshistory/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getcandleshistory/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcandleshistory",
+  "toolDescription": "Retrieve historical candle data",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/ohlcv/history",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "symbols": "symbols",
+      "providers": "providers",
+      "from": "from",
+      "to": "to",
+      "limit": "limit",
+      "interval": "interval",
+      "cursor": "cursor"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getcandleshistory/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getcandleshistory/schema-json/root.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "properties": {
+    "symbols": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "providers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "BINANCE",
+          "KRAKEN",
+          "BITFINEX",
+          "COINBASE"
+        ]
+      }
+    },
+    "from": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "to": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "limit": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "interval": {
+      "type": "string"
+    },
+    "cursor": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "symbols",
+    "providers",
+    "interval"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getcandleshistory/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getcandleshistory/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "symbols": z.array(z.string()),
+  "providers": z.array(z.enum(["BINANCE","KRAKEN","BITFINEX","COINBASE"])),
+  "from": z.string().datetime({ offset: true }).optional(),
+  "to": z.string().datetime({ offset: true }).optional(),
+  "limit": z.number().int().optional(),
+  "interval": z.string(),
+  "cursor": z.string().optional()
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getchronologicalhistory",
+  "toolDescription": "Retrieve chronological exchange rate history",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/exchange-rates/history",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "currency": "currency",
+      "from": "from",
+      "to": "to",
+      "pageable": "pageable"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema-json/properties/pageable.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema-json/properties/pageable.json
@@ -1,0 +1,22 @@
+{
+  "description": "Pagination parameters (page, size, sort).",
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "integer",
+      "format": "int32",
+      "minimum": 0
+    },
+    "size": {
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1
+    },
+    "sort": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "currency": {
+      "description": "Currency code for which the history is requested.",
+      "type": "string"
+    },
+    "from": {
+      "description": "Start date-time filter in ISO format.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "to": {
+      "description": "End date-time filter in ISO format. Optional.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "pageable": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameters (page, size, sort).</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "currency",
+    "pageable"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema/properties/pageable.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema/properties/pageable.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().int().gte(0).optional(),
+  "size": z.number().int().gte(1).optional(),
+  "sort": z.array(z.string()).optional()
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getchronologicalhistory/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "currency": z.string().describe("Currency code for which the history is requested."),
+  "from": z.string().datetime({ offset: true }).describe("Start date-time filter in ISO format.").optional(),
+  "to": z.string().datetime({ offset: true }).describe("End date-time filter in ISO format. Optional.").optional(),
+  "pageable": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameters (page, size, sort).</property-description>")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getexchangerates",
+  "toolDescription": "Retrieve current exchange rates",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/exchange-rates",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "pageable": "pageable"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema-json/properties/pageable.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema-json/properties/pageable.json
@@ -1,0 +1,22 @@
+{
+  "description": "Pagination parameters.\nIf sort is not provided, the results will be sorted by exchange frequency desc.",
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "integer",
+      "format": "int32",
+      "minimum": 0
+    },
+    "size": {
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1
+    },
+    "sort": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "pageable": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameters.\nIf sort is not provided, the results will be sorted by exchange frequency desc.</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "pageable"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema/properties/pageable.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema/properties/pageable.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().int().gte(0).optional(),
+  "size": z.number().int().gte(1).optional(),
+  "sort": z.array(z.string()).optional()
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pageable": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameters.\nIf sort is not provided, the results will be sorted by exchange frequency desc.</property-description>")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getexchangerates_1",
+  "toolDescription": "Perform currency exchange",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/exchange-rates/exchange",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "currency": "currency",
+      "sum": "sum",
+      "provider": "provider",
+      "pageable": "pageable"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema-json/properties/pageable.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema-json/properties/pageable.json
@@ -1,0 +1,22 @@
+{
+  "description": "Pagination parameters",
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "integer",
+      "format": "int32",
+      "minimum": 0
+    },
+    "size": {
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1
+    },
+    "sort": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema-json/root.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "currency": {
+      "description": "Currency code to be exchanged",
+      "type": "string"
+    },
+    "sum": {
+      "description": "Amount to be exchanged",
+      "type": "number"
+    },
+    "provider": {
+      "description": "Specifies the coin provider. If not provided, exchange rates for all providers will be returned.",
+      "type": "string",
+      "enum": [
+        "BINANCE",
+        "KRAKEN",
+        "BITFINEX",
+        "COINBASE"
+      ]
+    },
+    "pageable": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameters</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "currency",
+    "sum",
+    "pageable"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema/properties/pageable.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema/properties/pageable.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().int().gte(0).optional(),
+  "size": z.number().int().gte(1).optional(),
+  "sort": z.array(z.string()).optional()
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/getexchangerates_1/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "currency": z.string().describe("Currency code to be exchanged"),
+  "sum": z.number().describe("Amount to be exchanged"),
+  "provider": z.enum(["BINANCE","KRAKEN","BITFINEX","COINBASE"]).describe("Specifies the coin provider. If not provided, exchange rates for all providers will be returned.").optional(),
+  "pageable": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `pageable` to the tool, first call the tool `expandSchema` with \"/properties/pageable\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Pagination parameters</property-description>")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/gethighestexchangerate/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/gethighestexchangerate/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gethighestexchangerate",
+  "toolDescription": "Retrieve highest exchange rate",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/exchange-rates/top-rate",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "currency": "currency"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/gethighestexchangerate/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/gethighestexchangerate/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "currency": {
+      "description": "Currency code to retrieve the highest exchange rate for",
+      "type": "string"
+    }
+  },
+  "required": [
+    "currency"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/gethighestexchangerate/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/gethighestexchangerate/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "currency": z.string().describe("Currency code to retrieve the highest exchange rate for")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "refreshtime",
+  "toolDescription": "Refresh WebSocket Subscription Time",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/ws/subscriptions/refresh",
+  "method": "patch",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "customerId": "customerId"
+    },
+    "body": {
+      "desiredCapacity": "desiredCapacity"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema-json/properties/desiredCapacity.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema-json/properties/desiredCapacity.json
@@ -1,0 +1,63 @@
+{
+  "type": "object",
+  "description": "Desired time for refreshing the WebSocket subscription",
+  "example": "PT15M",
+  "properties": {
+    "seconds": {
+      "type": "integer",
+      "format": "int64"
+    },
+    "zero": {
+      "type": "boolean"
+    },
+    "nano": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "negative": {
+      "type": "boolean"
+    },
+    "positive": {
+      "type": "boolean"
+    },
+    "units": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "durationEstimated": {
+            "type": "boolean"
+          },
+          "duration": {
+            "type": "object",
+            "properties": {
+              "seconds": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "zero": {
+                "type": "boolean"
+              },
+              "nano": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "negative": {
+                "type": "boolean"
+              },
+              "positive": {
+                "type": "boolean"
+              }
+            }
+          },
+          "timeBased": {
+            "type": "boolean"
+          },
+          "dateBased": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "customerId": {
+      "description": "Identifier of the customer whose WebSocket subscription time will be refreshed.",
+      "type": "integer",
+      "format": "int64"
+    },
+    "desiredCapacity": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `desiredCapacity` to the tool, first call the tool `expandSchema` with \"/properties/desiredCapacity\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Desired time for refreshing the WebSocket subscription</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "customerId"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema/properties/desiredCapacity.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema/properties/desiredCapacity.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "seconds": z.number().int().optional(),
+  "zero": z.boolean().optional(),
+  "nano": z.number().int().optional(),
+  "negative": z.boolean().optional(),
+  "positive": z.boolean().optional(),
+  "units": z.array(z.object({ "durationEstimated": z.boolean().optional(), "duration": z.object({ "seconds": z.number().int().optional(), "zero": z.boolean().optional(), "nano": z.number().int().optional(), "negative": z.boolean().optional(), "positive": z.boolean().optional() }).optional(), "timeBased": z.boolean().optional(), "dateBased": z.boolean().optional() })).optional()
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/refreshtime/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "customerId": z.number().int().describe("Identifier of the customer whose WebSocket subscription time will be refreshed."),
+  "desiredCapacity": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `desiredCapacity` to the tool, first call the tool `expandSchema` with \"/properties/desiredCapacity\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Desired time for refreshing the WebSocket subscription</property-description>").optional()
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/register/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/register/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "register",
+  "toolDescription": "Register a new user",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/auth/register",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "username": "username",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/register/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/register/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "type": "string",
+      "description": "Username for the new account",
+      "example": "username"
+    },
+    "password": {
+      "type": "string",
+      "description": "Password for the new account",
+      "example": "P@ssw0rd"
+    }
+  },
+  "required": [
+    "username",
+    "password"
+  ]
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/register/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/register/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "username": z.string().describe("Username for the new account"),
+  "password": z.string().describe("Password for the new account")
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/updateexchangerates/index.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/updateexchangerates/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updateexchangerates",
+  "toolDescription": "Update current exchange rates",
+  "baseUrl": "http://currency-exchange.teststage.org/exchanger/api",
+  "path": "/v1/exchange-rates",
+  "method": "patch",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/updateexchangerates/schema-json/root.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/updateexchangerates/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/currency_exchange_teststage_org_exchanger_api/src/tools/updateexchangerates/schema/root.ts
+++ b/servers/currency_exchange_teststage_org_exchanger_api/src/tools/updateexchangerates/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/currency_exchange_teststage_org_exchanger_api/tsconfig.json
+++ b/servers/currency_exchange_teststage_org_exchanger_api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `currency_exchange_teststage_org_exchanger_api`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/currency_exchange_teststage_org_exchanger_api`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "currency_exchange_teststage_org_exchanger_api": {
      "command": "npx",
      "args": ["-y", "@open-mcp/currency_exchange_teststage_org_exchanger_api"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.