### PR TITLE
Add MCP server `api_viu_tv_production`

### DIFF
--- a/servers/api_viu_tv_production/.npmignore
+++ b/servers/api_viu_tv_production/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_viu_tv_production/README.md
+++ b/servers/api_viu_tv_production/README.md
@@ -1,0 +1,165 @@
+# @open-mcp/api_viu_tv_production
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_viu_tv_production": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_viu_tv_production@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_viu_tv_production@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_viu_tv_production \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_viu_tv_production \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_viu_tv_production \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_viu_tv_production": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_viu_tv_production"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### programmes
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `progGenre` (string)
+- `progType` (string)
+- `progNature` (string)
+- `limit` (string)
+- `skip` (string)
+- `sort` (string)
+- `accept-language` (string)
+
+### programmesprogrammeslug
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `accept-language` (string)
+
+### parameters_programmes_programmeslug_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### programmesprogrammeslugvideos
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `type` (string)
+- `skip` (string)
+- `limit` (string)
+- `sort` (string)
+
+### parameters_programmes_programmeslug_videos
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### programmesfilters
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `accept-language` (string)

--- a/servers/api_viu_tv_production/package.json
+++ b/servers/api_viu_tv_production/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_viu_tv_production",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_viu_tv_production": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_viu_tv_production/src/constants.ts
+++ b/servers/api_viu_tv_production/src/constants.ts
@@ -1,0 +1,11 @@
+export const OPENAPI_URL = "https://config-service.viu.tv/static/poc-mcp-content-server/viutv-lambda-partial-openapi.json"
+export const SERVER_NAME = "api_viu_tv_production"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/programmes/index.js",
+  "./tools/programmesprogrammeslug/index.js",
+  "./tools/parameters_programmes_programmeslug_/index.js",
+  "./tools/programmesprogrammeslugvideos/index.js",
+  "./tools/parameters_programmes_programmeslug_videos/index.js",
+  "./tools/programmesfilters/index.js"
+]

--- a/servers/api_viu_tv_production/src/index.ts
+++ b/servers/api_viu_tv_production/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_viu_tv_production/src/server.ts
+++ b/servers/api_viu_tv_production/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_/index.ts
+++ b/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_programmes_programmeslug_",
+  "toolDescription": "",
+  "baseUrl": "https://api.viu.tv/production",
+  "path": "/programmes/{programmeSlug}",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_/schema-json/root.json
+++ b/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_/schema/root.ts
+++ b/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_videos/index.ts
+++ b/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_videos/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "parameters_programmes_programmeslug_videos",
+  "toolDescription": "",
+  "baseUrl": "https://api.viu.tv/production",
+  "path": "/programmes/{programmeSlug}/videos",
+  "method": "parameters",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_videos/schema-json/root.json
+++ b/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_videos/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_videos/schema/root.ts
+++ b/servers/api_viu_tv_production/src/tools/parameters_programmes_programmeslug_videos/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_viu_tv_production/src/tools/programmes/index.ts
+++ b/servers/api_viu_tv_production/src/tools/programmes/index.ts
@@ -1,0 +1,34 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "programmes",
+  "toolDescription": "programmes",
+  "baseUrl": "https://api.viu.tv/production",
+  "path": "/programmes",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "progGenre": "progGenre",
+      "progType": "progType",
+      "progNature": "progNature",
+      "limit": "limit",
+      "skip": "skip",
+      "sort": "sort"
+    },
+    "header": {
+      "accept-language": "accept-language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_viu_tv_production/src/tools/programmes/schema-json/root.json
+++ b/servers/api_viu_tv_production/src/tools/programmes/schema-json/root.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "progGenre": {
+      "description": "programme genre ID",
+      "type": "string",
+      "example": ""
+    },
+    "progType": {
+      "description": "programme type ID",
+      "type": "string",
+      "example": ""
+    },
+    "progNature": {
+      "description": "programme nature ID",
+      "type": "string",
+      "example": ""
+    },
+    "limit": {
+      "description": "pagination limit, integer",
+      "type": "string",
+      "example": ""
+    },
+    "skip": {
+      "description": "pagination skip, integer",
+      "type": "string",
+      "example": ""
+    },
+    "sort": {
+      "type": "string",
+      "example": "-view_count"
+    },
+    "accept-language": {
+      "type": "string",
+      "example": "en"
+    }
+  },
+  "required": []
+}

--- a/servers/api_viu_tv_production/src/tools/programmes/schema/root.ts
+++ b/servers/api_viu_tv_production/src/tools/programmes/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "progGenre": z.string().describe("programme genre ID").optional(),
+  "progType": z.string().describe("programme type ID").optional(),
+  "progNature": z.string().describe("programme nature ID").optional(),
+  "limit": z.string().describe("pagination limit, integer").optional(),
+  "skip": z.string().describe("pagination skip, integer").optional(),
+  "sort": z.string().optional(),
+  "accept-language": z.string().optional()
+}

--- a/servers/api_viu_tv_production/src/tools/programmesfilters/index.ts
+++ b/servers/api_viu_tv_production/src/tools/programmesfilters/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "programmesfilters",
+  "toolDescription": "programmes/filters",
+  "baseUrl": "https://api.viu.tv/production",
+  "path": "/programmes/filters",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "header": {
+      "accept-language": "accept-language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_viu_tv_production/src/tools/programmesfilters/schema-json/root.json
+++ b/servers/api_viu_tv_production/src/tools/programmesfilters/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "accept-language": {
+      "type": "string",
+      "example": "en"
+    }
+  },
+  "required": []
+}

--- a/servers/api_viu_tv_production/src/tools/programmesfilters/schema/root.ts
+++ b/servers/api_viu_tv_production/src/tools/programmesfilters/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "accept-language": z.string().optional()
+}

--- a/servers/api_viu_tv_production/src/tools/programmesprogrammeslug/index.ts
+++ b/servers/api_viu_tv_production/src/tools/programmesprogrammeslug/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "programmesprogrammeslug",
+  "toolDescription": "programmes/:programmeSlug",
+  "baseUrl": "https://api.viu.tv/production",
+  "path": "/programmes/{programmeSlug}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "header": {
+      "accept-language": "accept-language"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_viu_tv_production/src/tools/programmesprogrammeslug/schema-json/root.json
+++ b/servers/api_viu_tv_production/src/tools/programmesprogrammeslug/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "accept-language": {
+      "type": "string",
+      "example": "zh"
+    }
+  },
+  "required": []
+}

--- a/servers/api_viu_tv_production/src/tools/programmesprogrammeslug/schema/root.ts
+++ b/servers/api_viu_tv_production/src/tools/programmesprogrammeslug/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "accept-language": z.string().optional()
+}

--- a/servers/api_viu_tv_production/src/tools/programmesprogrammeslugvideos/index.ts
+++ b/servers/api_viu_tv_production/src/tools/programmesprogrammeslugvideos/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "programmesprogrammeslugvideos",
+  "toolDescription": "programmes/:programmeSlug/videos",
+  "baseUrl": "https://api.viu.tv/production",
+  "path": "/programmes/{programmeSlug}/videos",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "type": "type",
+      "skip": "skip",
+      "limit": "limit",
+      "sort": "sort"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_viu_tv_production/src/tools/programmesprogrammeslugvideos/schema-json/root.json
+++ b/servers/api_viu_tv_production/src/tools/programmesprogrammeslugvideos/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "product type, possible values are \"master\", \"trailer\", \"makingof\", \"interview\", \"comingsoon\"",
+      "type": "string",
+      "example": "master"
+    },
+    "skip": {
+      "description": "pagination skip, integer",
+      "type": "string",
+      "example": "0"
+    },
+    "limit": {
+      "description": "pagination limit, integer",
+      "type": "string",
+      "example": "100"
+    },
+    "sort": {
+      "description": "sorting method, possible values are \"asc\" \"desc\"",
+      "type": "string",
+      "example": "asc"
+    }
+  },
+  "required": []
+}

--- a/servers/api_viu_tv_production/src/tools/programmesprogrammeslugvideos/schema/root.ts
+++ b/servers/api_viu_tv_production/src/tools/programmesprogrammeslugvideos/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.string().describe("product type, possible values are \"master\", \"trailer\", \"makingof\", \"interview\", \"comingsoon\"").optional(),
+  "skip": z.string().describe("pagination skip, integer").optional(),
+  "limit": z.string().describe("pagination limit, integer").optional(),
+  "sort": z.string().describe("sorting method, possible values are \"asc\" \"desc\"").optional()
+}

--- a/servers/api_viu_tv_production/tsconfig.json
+++ b/servers/api_viu_tv_production/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_viu_tv_production`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_viu_tv_production`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_viu_tv_production": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_viu_tv_production"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.