### PR TITLE
Add MCP server `r_jina_ai`

### DIFF
--- a/servers/r_jina_ai/.npmignore
+++ b/servers/r_jina_ai/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/r_jina_ai/README.md
+++ b/servers/r_jina_ai/README.md
@@ -1,0 +1,110 @@
+# @open-mcp/r_jina_ai
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "r_jina_ai": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/r_jina_ai@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/r_jina_ai@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add r_jina_ai \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add r_jina_ai \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add r_jina_ai \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "r_jina_ai": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/r_jina_ai"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### extractwebcontent
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `url` (string)
+- `X-Return-Format` (string)
+- `X-Target-Selector` (string)
+- `X-Timeout` (integer)
+- `X-Wait-For-Selector` (string)

--- a/servers/r_jina_ai/package.json
+++ b/servers/r_jina_ai/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/r_jina_ai",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "r_jina_ai": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/r_jina_ai/src/constants.ts
+++ b/servers/r_jina_ai/src/constants.ts
@@ -1,0 +1,6 @@
+export const OPENAPI_URL = "https://openapisearch.com/openapi/jina-reader"
+export const SERVER_NAME = "r_jina_ai"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/extractwebcontent/index.js"
+]

--- a/servers/r_jina_ai/src/index.ts
+++ b/servers/r_jina_ai/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/r_jina_ai/src/server.ts
+++ b/servers/r_jina_ai/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/r_jina_ai/src/tools/extractwebcontent/index.ts
+++ b/servers/r_jina_ai/src/tools/extractwebcontent/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "extractwebcontent",
+  "toolDescription": "Extract web content",
+  "baseUrl": "https://r.jina.ai",
+  "path": "/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "url": "url"
+    },
+    "header": {
+      "X-Return-Format": "X-Return-Format",
+      "X-Target-Selector": "X-Target-Selector",
+      "X-Timeout": "X-Timeout",
+      "X-Wait-For-Selector": "X-Wait-For-Selector"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/r_jina_ai/src/tools/extractwebcontent/schema-json/root.json
+++ b/servers/r_jina_ai/src/tools/extractwebcontent/schema-json/root.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "description": "The URL of the web page to extract content from"
+    },
+    "X-Return-Format": {
+      "description": "Specifies the return format of the extracted content",
+      "type": "string",
+      "enum": [
+        "default",
+        "markdown",
+        "html",
+        "text",
+        "screenshot",
+        "pageshot"
+      ],
+      "default": "default"
+    },
+    "X-Target-Selector": {
+      "description": "CSS selector to target specific elements",
+      "type": "string"
+    },
+    "X-Timeout": {
+      "description": "Timeout in seconds for the request",
+      "type": "integer"
+    },
+    "X-Wait-For-Selector": {
+      "description": "CSS selector to wait for before processing the page",
+      "type": "string"
+    }
+  },
+  "required": [
+    "url"
+  ]
+}

--- a/servers/r_jina_ai/src/tools/extractwebcontent/schema/root.ts
+++ b/servers/r_jina_ai/src/tools/extractwebcontent/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "url": z.string().describe("The URL of the web page to extract content from"),
+  "X-Return-Format": z.enum(["default","markdown","html","text","screenshot","pageshot"]).describe("Specifies the return format of the extracted content").optional(),
+  "X-Target-Selector": z.string().describe("CSS selector to target specific elements").optional(),
+  "X-Timeout": z.number().int().describe("Timeout in seconds for the request").optional(),
+  "X-Wait-For-Selector": z.string().describe("CSS selector to wait for before processing the page").optional()
+}

--- a/servers/r_jina_ai/tsconfig.json
+++ b/servers/r_jina_ai/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `r_jina_ai`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/r_jina_ai`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "r_jina_ai": {
      "command": "npx",
      "args": ["-y", "@open-mcp/r_jina_ai"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.