### PR TITLE
Add MCP server `api_openepi_io_soil`

### DIFF
--- a/servers/api_openepi_io_soil/.npmignore
+++ b/servers/api_openepi_io_soil/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_openepi_io_soil/README.md
+++ b/servers/api_openepi_io_soil/README.md
@@ -1,0 +1,152 @@
+# @open-mcp/api_openepi_io_soil
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_openepi_io_soil": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_openepi_io_soil@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_openepi_io_soil@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_openepi_io_soil \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_openepi_io_soil \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_openepi_io_soil \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_openepi_io_soil": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_openepi_io_soil"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_soil_type_type_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `lon` (number)
+- `lat` (number)
+- `top_k` (integer)
+
+### get_soil_property_property_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `lon` (number)
+- `lat` (number)
+- `depths` (array)
+- `properties` (array)
+- `values` (array)
+
+### get_soil_type_summary_type_summary_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `min_lon` (number)
+- `max_lon` (number)
+- `min_lat` (number)
+- `max_lat` (number)
+
+### ready_ready_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### liveness_health_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters

--- a/servers/api_openepi_io_soil/package.json
+++ b/servers/api_openepi_io_soil/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_openepi_io_soil",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_openepi_io_soil": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_openepi_io_soil/src/constants.ts
+++ b/servers/api_openepi_io_soil/src/constants.ts
@@ -1,0 +1,10 @@
+export const OPENAPI_URL = "https://api.openepi.io/soil/openapi.json"
+export const SERVER_NAME = "api_openepi_io_soil"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_soil_type_type_get/index.js",
+  "./tools/get_soil_property_property_get/index.js",
+  "./tools/get_soil_type_summary_type_summary_get/index.js",
+  "./tools/ready_ready_get/index.js",
+  "./tools/liveness_health_get/index.js"
+]

--- a/servers/api_openepi_io_soil/src/index.ts
+++ b/servers/api_openepi_io_soil/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_openepi_io_soil/src/server.ts
+++ b/servers/api_openepi_io_soil/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_openepi_io_soil/src/tools/get_soil_property_property_get/index.ts
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_property_property_get/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_soil_property_property_get",
+  "toolDescription": "Get soil property",
+  "baseUrl": "https://api.openepi.io/soil",
+  "path": "/property",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "lon": "lon",
+      "lat": "lat",
+      "depths": "depths",
+      "properties": "properties",
+      "values": "values"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_openepi_io_soil/src/tools/get_soil_property_property_get/schema-json/root.json
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_property_property_get/schema-json/root.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "description": "Longitude",
+      "type": "number",
+      "maximum": 180,
+      "minimum": -180,
+      "title": "lon"
+    },
+    "lat": {
+      "description": "Latitude",
+      "type": "number",
+      "maximum": 90,
+      "minimum": -90,
+      "title": "lat"
+    },
+    "depths": {
+      "description": "List of depths to include in the query.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "0-5cm",
+          "0-30cm",
+          "5-15cm",
+          "15-30cm",
+          "30-60cm",
+          "60-100cm",
+          "100-200cm"
+        ],
+        "title": "SoilDepthLabels"
+      },
+      "minItems": 1,
+      "title": "depths to include"
+    },
+    "properties": {
+      "description": "List of soil properties to include in the query.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "bdod",
+          "cec",
+          "cfvo",
+          "clay",
+          "nitrogen",
+          "ocd",
+          "ocs",
+          "phh2o",
+          "sand",
+          "silt",
+          "soc"
+        ],
+        "title": "SoilPropertiesCodes"
+      },
+      "minItems": 1,
+      "title": "properties to include"
+    },
+    "values": {
+      "description": "List of values to include in the query.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "mean",
+          "Q0.05",
+          "Q0.5",
+          "Q0.95",
+          "uncertainty"
+        ],
+        "title": "SoilPropertyValueTypes"
+      },
+      "minItems": 1,
+      "title": "values to include"
+    }
+  },
+  "required": [
+    "lon",
+    "lat",
+    "depths",
+    "properties",
+    "values"
+  ]
+}

--- a/servers/api_openepi_io_soil/src/tools/get_soil_property_property_get/schema/root.ts
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_property_property_get/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "lon": z.number().gte(-180).lte(180).describe("Longitude"),
+  "lat": z.number().gte(-90).lte(90).describe("Latitude"),
+  "depths": z.array(z.enum(["0-5cm","0-30cm","5-15cm","15-30cm","30-60cm","60-100cm","100-200cm"])).min(1).describe("List of depths to include in the query."),
+  "properties": z.array(z.enum(["bdod","cec","cfvo","clay","nitrogen","ocd","ocs","phh2o","sand","silt","soc"])).min(1).describe("List of soil properties to include in the query."),
+  "values": z.array(z.enum(["mean","Q0.05","Q0.5","Q0.95","uncertainty"])).min(1).describe("List of values to include in the query.")
+}

--- a/servers/api_openepi_io_soil/src/tools/get_soil_type_summary_type_summary_get/index.ts
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_type_summary_type_summary_get/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_soil_type_summary_type_summary_get",
+  "toolDescription": "Get soil type summary",
+  "baseUrl": "https://api.openepi.io/soil",
+  "path": "/type/summary",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "min_lon": "min_lon",
+      "max_lon": "max_lon",
+      "min_lat": "min_lat",
+      "max_lat": "max_lat"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_openepi_io_soil/src/tools/get_soil_type_summary_type_summary_get/schema-json/root.json
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_type_summary_type_summary_get/schema-json/root.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "min_lon": {
+      "description": "Minimum longitude",
+      "type": "number",
+      "maximum": 180,
+      "minimum": -180,
+      "title": "min_lon"
+    },
+    "max_lon": {
+      "description": "Maximum longitude",
+      "type": "number",
+      "maximum": 180,
+      "minimum": -180,
+      "title": "max_lon"
+    },
+    "min_lat": {
+      "description": "Minimum latitude",
+      "type": "number",
+      "maximum": 90,
+      "minimum": -90,
+      "title": "min_lat"
+    },
+    "max_lat": {
+      "description": "Maximum latitude",
+      "type": "number",
+      "maximum": 90,
+      "minimum": -90,
+      "title": "max_lat"
+    }
+  },
+  "required": [
+    "min_lon",
+    "max_lon",
+    "min_lat",
+    "max_lat"
+  ]
+}

--- a/servers/api_openepi_io_soil/src/tools/get_soil_type_summary_type_summary_get/schema/root.ts
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_type_summary_type_summary_get/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "min_lon": z.number().gte(-180).lte(180).describe("Minimum longitude"),
+  "max_lon": z.number().gte(-180).lte(180).describe("Maximum longitude"),
+  "min_lat": z.number().gte(-90).lte(90).describe("Minimum latitude"),
+  "max_lat": z.number().gte(-90).lte(90).describe("Maximum latitude")
+}

--- a/servers/api_openepi_io_soil/src/tools/get_soil_type_type_get/index.ts
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_type_type_get/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_soil_type_type_get",
+  "toolDescription": "Get soil type",
+  "baseUrl": "https://api.openepi.io/soil",
+  "path": "/type",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "lon": "lon",
+      "lat": "lat",
+      "top_k": "top_k"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_openepi_io_soil/src/tools/get_soil_type_type_get/schema-json/root.json
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_type_type_get/schema-json/root.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "description": "Longitude",
+      "type": "number",
+      "maximum": 180,
+      "minimum": -180,
+      "title": "lon"
+    },
+    "lat": {
+      "description": "Latitude",
+      "type": "number",
+      "maximum": 90,
+      "minimum": -90,
+      "title": "lat"
+    },
+    "top_k": {
+      "description": "Number of most probable soil types that will be returned, sorted by probability in descending order",
+      "type": "integer",
+      "maximum": 30,
+      "minimum": 0,
+      "title": "top_k",
+      "default": 0
+    }
+  },
+  "required": [
+    "lon",
+    "lat"
+  ]
+}

--- a/servers/api_openepi_io_soil/src/tools/get_soil_type_type_get/schema/root.ts
+++ b/servers/api_openepi_io_soil/src/tools/get_soil_type_type_get/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "lon": z.number().gte(-180).lte(180).describe("Longitude"),
+  "lat": z.number().gte(-90).lte(90).describe("Latitude"),
+  "top_k": z.number().int().gte(0).lte(30).describe("Number of most probable soil types that will be returned, sorted by probability in descending order").optional()
+}

--- a/servers/api_openepi_io_soil/src/tools/liveness_health_get/index.ts
+++ b/servers/api_openepi_io_soil/src/tools/liveness_health_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "liveness_health_get",
+  "toolDescription": "Check if this service is alive",
+  "baseUrl": "https://api.openepi.io/soil",
+  "path": "/health",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_openepi_io_soil/src/tools/liveness_health_get/schema-json/root.json
+++ b/servers/api_openepi_io_soil/src/tools/liveness_health_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_openepi_io_soil/src/tools/liveness_health_get/schema/root.ts
+++ b/servers/api_openepi_io_soil/src/tools/liveness_health_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_openepi_io_soil/src/tools/ready_ready_get/index.ts
+++ b/servers/api_openepi_io_soil/src/tools/ready_ready_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "ready_ready_get",
+  "toolDescription": "Check if this service is ready to receive requests",
+  "baseUrl": "https://api.openepi.io/soil",
+  "path": "/ready",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_openepi_io_soil/src/tools/ready_ready_get/schema-json/root.json
+++ b/servers/api_openepi_io_soil/src/tools/ready_ready_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_openepi_io_soil/src/tools/ready_ready_get/schema/root.ts
+++ b/servers/api_openepi_io_soil/src/tools/ready_ready_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_openepi_io_soil/tsconfig.json
+++ b/servers/api_openepi_io_soil/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_openepi_io_soil`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_openepi_io_soil`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_openepi_io_soil": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_openepi_io_soil"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.