### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,123 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### post_api_url
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### get_api_url_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### get_api_url_url_id_artifact_artifact_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,8 @@
+export const OPENAPI_URL = "https://stream.agile-athletes.de/api/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/post_api_url/index.js",
+  "./tools/get_api_url_id_/index.js",
+  "./tools/get_api_url_url_id_artifact_artifact_id_/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/get_api_url_id_/index.ts
+++ b/servers/api_example_com/src/tools/get_api_url_id_/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_url_id_",
+  "toolDescription": "Get all information about a URL, including artifacts. This does not include any artifacts that are not yet generated but might be generated in the future.",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/url/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_api_url_id_/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_api_url_id_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_api_url_id_/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_api_url_id_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/get_api_url_url_id_artifact_artifact_id_/index.ts
+++ b/servers/api_example_com/src/tools/get_api_url_url_id_artifact_artifact_id_/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_api_url_url_id_artifact_artifact_id_",
+  "toolDescription": "Get an artifact by its ID",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/url/{url_id}/artifact/{artifact_id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_api_url_url_id_artifact_artifact_id_/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_api_url_url_id_artifact_artifact_id_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_api_url_url_id_artifact_artifact_id_/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_api_url_url_id_artifact_artifact_id_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/post_api_url/index.ts
+++ b/servers/api_example_com/src/tools/post_api_url/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_api_url",
+  "toolDescription": "Add new URLs to the user's account",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/url",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/post_api_url/schema-json/root.json
+++ b/servers/api_example_com/src/tools/post_api_url/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/post_api_url/schema/root.ts
+++ b/servers/api_example_com/src/tools/post_api_url/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.