### PR TITLE
Add MCP server `pro_api_solscan_io_v2_0`

### DIFF
--- a/servers/pro_api_solscan_io_v2_0/.npmignore
+++ b/servers/pro_api_solscan_io_v2_0/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/pro_api_solscan_io_v2_0/README.md
+++ b/servers/pro_api_solscan_io_v2_0/README.md
@@ -1,0 +1,399 @@
+# @open-mcp/pro_api_solscan_io_v2_0
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "pro_api_solscan_io_v2_0": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/pro_api_solscan_io_v2_0@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/pro_api_solscan_io_v2_0@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+TOKEN='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add pro_api_solscan_io_v2_0 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --TOKEN=$TOKEN
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add pro_api_solscan_io_v2_0 \
+  .cursor/mcp.json \
+  --TOKEN=$TOKEN
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add pro_api_solscan_io_v2_0 \
+  /path/to/client/config.json \
+  --TOKEN=$TOKEN
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "pro_api_solscan_io_v2_0": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/pro_api_solscan_io_v2_0"],
+      "env": {"TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `TOKEN` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_account_detail
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `address` (string)
+
+### get_account_transactions
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+- `before` (string)
+- `limit` (integer)
+
+### get_account_token_accounts
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_account_transfer
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_account_defi_activities
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_account_balance_change
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_account_stake
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+
+### get_account_exporttransactions
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+
+### get_account_reward_export
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `account` (string)
+
+### get_token_meta
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `token` (string)
+
+### get_token_holders
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `token` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_token_price
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `token` (string)
+
+### get_token_trending
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+
+### get_token_list
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+
+### get_token_markets
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `token` (string)
+
+### get_token_transfer
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `token` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_token_defi_activities
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `token` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_transaction_last
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+
+### get_transaction_actions
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `tx` (string)
+
+### get_transaction_details
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `tx` (string)
+
+### get_block_last
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+
+### get_block_transactions
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `block` (integer)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_block_detail
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `block` (integer)
+
+### get_nft_news
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+
+### get_nft_activities
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+
+### get_nft_collection_lists
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+
+### get_nft_collection_items
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+- `collection` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### get_monitor_usage
+
+**Environment variables**
+
+- `TOKEN`
+
+**Input schema**
+
+No input parameters

--- a/servers/pro_api_solscan_io_v2_0/package.json
+++ b/servers/pro_api_solscan_io_v2_0/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/pro_api_solscan_io_v2_0",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "pro_api_solscan_io_v2_0": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/pro_api_solscan_io_v2_0/src/constants.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/constants.ts
@@ -1,0 +1,33 @@
+export const OPENAPI_URL = "https://ywqesktuqvgsmrgraors.supabase.co/storage/v1/object/public/assets//openapi.json"
+export const SERVER_NAME = "pro_api_solscan_io_v2_0"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_account_detail/index.js",
+  "./tools/get_account_transactions/index.js",
+  "./tools/get_account_token_accounts/index.js",
+  "./tools/get_account_transfer/index.js",
+  "./tools/get_account_defi_activities/index.js",
+  "./tools/get_account_balance_change/index.js",
+  "./tools/get_account_stake/index.js",
+  "./tools/get_account_exporttransactions/index.js",
+  "./tools/get_account_reward_export/index.js",
+  "./tools/get_token_meta/index.js",
+  "./tools/get_token_holders/index.js",
+  "./tools/get_token_price/index.js",
+  "./tools/get_token_trending/index.js",
+  "./tools/get_token_list/index.js",
+  "./tools/get_token_markets/index.js",
+  "./tools/get_token_transfer/index.js",
+  "./tools/get_token_defi_activities/index.js",
+  "./tools/get_transaction_last/index.js",
+  "./tools/get_transaction_actions/index.js",
+  "./tools/get_transaction_details/index.js",
+  "./tools/get_block_last/index.js",
+  "./tools/get_block_transactions/index.js",
+  "./tools/get_block_detail/index.js",
+  "./tools/get_nft_news/index.js",
+  "./tools/get_nft_activities/index.js",
+  "./tools/get_nft_collection_lists/index.js",
+  "./tools/get_nft_collection_items/index.js",
+  "./tools/get_monitor_usage/index.js"
+]

--- a/servers/pro_api_solscan_io_v2_0/src/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/pro_api_solscan_io_v2_0/src/server.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_balance_change/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_balance_change/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_balance_change",
+  "toolDescription": "Get balance changes",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/balance_change",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_balance_change/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_balance_change/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_balance_change/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_balance_change/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_defi_activities/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_defi_activities/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_defi_activities",
+  "toolDescription": "Get DeFi activities",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/defi/activities",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_defi_activities/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_defi_activities/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_defi_activities/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_defi_activities/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_detail/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_detail/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_detail",
+  "toolDescription": "Get account details",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/detail",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "address": "address"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_detail/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_detail/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    }
+  },
+  "required": [
+    "address"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_detail/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_detail/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "address": z.string().describe("A wallet address on solana blockchain")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_exporttransactions/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_exporttransactions/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_exporttransactions",
+  "toolDescription": "Export transactions",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/exportTransactions",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_exporttransactions/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_exporttransactions/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_exporttransactions/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_exporttransactions/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_reward_export/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_reward_export/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_reward_export",
+  "toolDescription": "Export rewards",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/reward/export",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_reward_export/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_reward_export/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_reward_export/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_reward_export/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_stake/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_stake/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_stake",
+  "toolDescription": "Get stake information",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/stake",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_stake/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_stake/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_stake/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_stake/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_token_accounts/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_token_accounts/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_token_accounts",
+  "toolDescription": "Get token accounts",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/token-accounts",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_token_accounts/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_token_accounts/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_token_accounts/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_token_accounts/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transactions/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transactions/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_transactions",
+  "toolDescription": "Get account transactions",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/transactions",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account",
+      "before": "before",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transactions/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transactions/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    },
+    "before": {
+      "description": "The signature of the latest transaction of previous page",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transactions/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transactions/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain"),
+  "before": z.string().describe("The signature of the latest transaction of previous page").optional(),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transfer/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transfer/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_account_transfer",
+  "toolDescription": "Get account transfers",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/account/transfer",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "account": "account",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transfer/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transfer/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "account": {
+      "description": "A wallet address on solana blockchain",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "account"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transfer/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_account_transfer/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account": z.string().describe("A wallet address on solana blockchain"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_detail/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_detail/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_block_detail",
+  "toolDescription": "Get block details",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/block/detail",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "block": "block"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_detail/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_detail/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "block": {
+      "description": "Block number",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "block"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_detail/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_detail/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "block": z.number().int().describe("Block number")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_last/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_last/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_block_last",
+  "toolDescription": "Get last blocks",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/block/last",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_last/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_last/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_last/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_last/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_transactions/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_transactions/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_block_transactions",
+  "toolDescription": "Get block transactions",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/block/transactions",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "block": "block",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_transactions/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_transactions/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "block": {
+      "description": "Block number",
+      "type": "integer"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "block"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_block_transactions/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_block_transactions/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "block": z.number().int().describe("Block number"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_monitor_usage/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_monitor_usage/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_monitor_usage",
+  "toolDescription": "Get API usage",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/monitor/usage",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_monitor_usage/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_monitor_usage/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_monitor_usage/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_monitor_usage/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_activities/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_activities/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_nft_activities",
+  "toolDescription": "Get NFT activities",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/nft/activities",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_activities/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_activities/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_activities/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_activities/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_items/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_items/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_nft_collection_items",
+  "toolDescription": "Get NFT collection items",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/nft/collection/items",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "collection": "collection",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_items/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_items/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "collection": {
+      "description": "NFT collection address",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "collection"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_items/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_items/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "collection": z.string().describe("NFT collection address"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_lists/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_lists/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_nft_collection_lists",
+  "toolDescription": "Get NFT collection lists",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/nft/collection/lists",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_lists/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_lists/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_lists/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_collection_lists/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_news/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_news/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_nft_news",
+  "toolDescription": "Get NFT news",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/nft/news",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_news/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_news/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_news/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_nft_news/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_defi_activities/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_defi_activities/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_defi_activities",
+  "toolDescription": "Get token DeFi activities",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/defi/activities",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "token": "token",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_defi_activities/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_defi_activities/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "Token address",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_defi_activities/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_defi_activities/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().describe("Token address"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_holders/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_holders/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_holders",
+  "toolDescription": "Get token holders",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/holders",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "token": "token",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_holders/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_holders/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "Token address",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_holders/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_holders/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().describe("Token address"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_list/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_list/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_list",
+  "toolDescription": "Get token list",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/list",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_list/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_list/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_list/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_list/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_markets/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_markets/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_markets",
+  "toolDescription": "Get token markets",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/markets",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "token": "token"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_markets/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_markets/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "Token address",
+      "type": "string"
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_markets/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_markets/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().describe("Token address")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_meta/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_meta/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_meta",
+  "toolDescription": "Get token metadata",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/meta",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "token": "token"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_meta/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_meta/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "Token address",
+      "type": "string"
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_meta/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_meta/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().describe("Token address")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_price/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_price/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_price",
+  "toolDescription": "Get token price",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/price",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "token": "token"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_price/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_price/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "Token address",
+      "type": "string"
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_price/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_price/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().describe("Token address")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_transfer/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_transfer/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_transfer",
+  "toolDescription": "Get token transfers",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/transfer",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "token": "token",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_transfer/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_transfer/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "Token address",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    },
+    "offset": {
+      "description": "Number of items to skip",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_transfer/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_transfer/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "token": z.string().describe("Token address"),
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional(),
+  "offset": z.number().int().describe("Number of items to skip").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_trending/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_trending/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_token_trending",
+  "toolDescription": "Get trending tokens",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/token/trending",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_trending/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_trending/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_token_trending/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_token_trending/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_actions/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_actions/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_transaction_actions",
+  "toolDescription": "Get transaction actions",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/transaction/actions",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "tx": "tx"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_actions/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_actions/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "tx": {
+      "description": "Transaction signature",
+      "type": "string"
+    }
+  },
+  "required": [
+    "tx"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_actions/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_actions/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tx": z.string().describe("Transaction signature")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_details/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_details/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_transaction_details",
+  "toolDescription": "Get transaction details",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/transaction/details",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "tx": "tx"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_details/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_details/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "tx": {
+      "description": "Transaction signature",
+      "type": "string"
+    }
+  },
+  "required": [
+    "tx"
+  ]
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_details/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_details/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tx": z.string().describe("Transaction signature")
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_last/index.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_last/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_transaction_last",
+  "toolDescription": "Get last transactions",
+  "baseUrl": "https://pro-api.solscan.io/v2.0",
+  "path": "/transaction/last",
+  "method": "get",
+  "security": [
+    {
+      "key": "token",
+      "value": "<mcp-env-var>TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_last/schema-json/root.json
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_last/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Number of items to return",
+      "type": "integer",
+      "enum": [
+        10,
+        20,
+        30,
+        40
+      ],
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_last/schema/root.ts
+++ b/servers/pro_api_solscan_io_v2_0/src/tools/get_transaction_last/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.union([z.literal(10), z.literal(20), z.literal(30), z.literal(40)]).describe("Number of items to return").optional()
+}

--- a/servers/pro_api_solscan_io_v2_0/tsconfig.json
+++ b/servers/pro_api_solscan_io_v2_0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `pro_api_solscan_io_v2_0`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/pro_api_solscan_io_v2_0`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "pro_api_solscan_io_v2_0": {
      "command": "npx",
      "args": ["-y", "@open-mcp/pro_api_solscan_io_v2_0"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.