### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,278 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### api_cats
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `limit` (number)
+- `skip` (number)
+- `tags` (string)
+
+### api_count
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### api_tags
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### cat_random
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `type` (string)
+- `filter` (string)
+- `fit` (string)
+- `position` (string)
+- `width` (number)
+- `height` (number)
+- `blur` (number)
+- `r` (number)
+- `g` (number)
+- `b` (number)
+- `brightness` (number)
+- `saturation` (number)
+- `hue` (number)
+- `lightness` (number)
+- `html` (boolean)
+- `json` (boolean)
+
+### cat_random_text
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `text` (string)
+- `type` (string)
+- `filter` (string)
+- `fit` (string)
+- `position` (string)
+- `width` (number)
+- `height` (number)
+- `blur` (number)
+- `r` (number)
+- `g` (number)
+- `b` (number)
+- `brightness` (number)
+- `saturation` (number)
+- `hue` (number)
+- `lightness` (number)
+- `html` (boolean)
+- `json` (boolean)
+- `font` (string)
+- `fontSize` (number)
+- `fontColor` (string)
+- `fontBackground` (string)
+
+### cat_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+
+### cat_get_text
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+- `text` (string)
+- `type` (string)
+- `filter` (string)
+- `fit` (string)
+- `position` (string)
+- `width` (number)
+- `height` (number)
+- `blur` (number)
+- `r` (number)
+- `g` (number)
+- `b` (number)
+- `brightness` (number)
+- `saturation` (number)
+- `hue` (number)
+- `lightness` (number)
+- `html` (boolean)
+- `json` (boolean)
+- `font` (string)
+- `fontSize` (number)
+- `fontColor` (string)
+- `fontBackground` (string)
+
+### cat_random_tag
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `tag` (string)
+- `type` (string)
+- `filter` (string)
+- `fit` (string)
+- `position` (string)
+- `width` (number)
+- `height` (number)
+- `blur` (number)
+- `r` (number)
+- `g` (number)
+- `b` (number)
+- `brightness` (number)
+- `saturation` (number)
+- `hue` (number)
+- `lightness` (number)
+- `html` (boolean)
+- `json` (boolean)
+
+### cat_random_tag_text
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `tag` (string)
+- `text` (string)
+- `type` (string)
+- `filter` (string)
+- `fit` (string)
+- `position` (string)
+- `width` (number)
+- `height` (number)
+- `blur` (number)
+- `r` (number)
+- `g` (number)
+- `b` (number)
+- `brightness` (number)
+- `saturation` (number)
+- `hue` (number)
+- `lightness` (number)
+- `html` (boolean)
+- `json` (boolean)
+- `font` (string)
+- `fontSize` (number)
+- `fontColor` (string)
+- `fontBackground` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,14 @@
+export const OPENAPI_URL = "https://cataas.com/doc.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/api_cats/index.js",
+  "./tools/api_count/index.js",
+  "./tools/api_tags/index.js",
+  "./tools/cat_random/index.js",
+  "./tools/cat_random_text/index.js",
+  "./tools/cat_get/index.js",
+  "./tools/cat_get_text/index.js",
+  "./tools/cat_random_tag/index.js",
+  "./tools/cat_random_tag_text/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/api_cats/index.ts
+++ b/servers/api_example_com/src/tools/api_cats/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "api_cats",
+  "toolDescription": "Will return all cats",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/cats",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "skip": "skip",
+      "tags": "tags"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/api_cats/schema-json/root.json
+++ b/servers/api_example_com/src/tools/api_cats/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "type": "number",
+      "default": 10
+    },
+    "skip": {
+      "type": "number",
+      "default": 0
+    },
+    "tags": {
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/api_cats/schema/root.ts
+++ b/servers/api_example_com/src/tools/api_cats/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.number().optional(),
+  "skip": z.number().optional(),
+  "tags": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/api_count/index.ts
+++ b/servers/api_example_com/src/tools/api_count/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "api_count",
+  "toolDescription": "Count how many cat",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/count",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/api_count/schema-json/root.json
+++ b/servers/api_example_com/src/tools/api_count/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/api_count/schema/root.ts
+++ b/servers/api_example_com/src/tools/api_count/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/api_tags/index.ts
+++ b/servers/api_example_com/src/tools/api_tags/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "api_tags",
+  "toolDescription": "Will return all tags",
+  "baseUrl": "https://api.example.com",
+  "path": "/api/tags",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/api_tags/schema-json/root.json
+++ b/servers/api_example_com/src/tools/api_tags/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/api_tags/schema/root.ts
+++ b/servers/api_example_com/src/tools/api_tags/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/cat_get/index.ts
+++ b/servers/api_example_com/src/tools/cat_get/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cat_get",
+  "toolDescription": "Get cat by id",
+  "baseUrl": "https://api.example.com",
+  "path": "/cat/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/cat_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/cat_get/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_example_com/src/tools/cat_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/cat_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string()
+}

--- a/servers/api_example_com/src/tools/cat_get_text/index.ts
+++ b/servers/api_example_com/src/tools/cat_get_text/index.ts
@@ -1,0 +1,42 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cat_get_text",
+  "toolDescription": "Get cat by id saying text",
+  "baseUrl": "https://api.example.com",
+  "path": "/cat/{id}/says/{text}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id",
+      "text": "text"
+    },
+    "query": {
+      "type": "type",
+      "filter": "filter",
+      "fit": "fit",
+      "position": "position",
+      "width": "width",
+      "height": "height",
+      "blur": "blur",
+      "r": "r",
+      "g": "g",
+      "b": "b",
+      "brightness": "brightness",
+      "saturation": "saturation",
+      "hue": "hue",
+      "lightness": "lightness",
+      "html": "html",
+      "json": "json",
+      "font": "font",
+      "fontSize": "fontSize",
+      "fontColor": "fontColor",
+      "fontBackground": "fontBackground"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/cat_get_text/schema-json/root.json
+++ b/servers/api_example_com/src/tools/cat_get_text/schema-json/root.json
@@ -1,0 +1,128 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "square",
+        "medium",
+        "small",
+        "xsmall"
+      ]
+    },
+    "filter": {
+      "type": "string",
+      "enum": [
+        "mono",
+        "negate",
+        "custom"
+      ]
+    },
+    "fit": {
+      "type": "string",
+      "enum": [
+        "cover",
+        "contain",
+        "fill",
+        "inside",
+        "outside"
+      ]
+    },
+    "position": {
+      "type": "string",
+      "enum": [
+        "top",
+        "right top",
+        "right",
+        "right bottom",
+        "bottom",
+        "left bottom",
+        "left",
+        "left top",
+        "center"
+      ],
+      "default": "center"
+    },
+    "width": {
+      "type": "number"
+    },
+    "height": {
+      "type": "number"
+    },
+    "blur": {
+      "type": "number"
+    },
+    "r": {
+      "description": "With custom filter, define red value between 0 and 255",
+      "type": "number"
+    },
+    "g": {
+      "description": "With custom filter, define green value between 0 and 255",
+      "type": "number"
+    },
+    "b": {
+      "description": "With custom filter, define blue value between 0 and 255",
+      "type": "number"
+    },
+    "brightness": {
+      "description": "With custom filter, define brightness",
+      "type": "number"
+    },
+    "saturation": {
+      "description": "With custom filter, define saturation",
+      "type": "number"
+    },
+    "hue": {
+      "description": "With custom filter, define hue",
+      "type": "number"
+    },
+    "lightness": {
+      "description": "With custom filter, define lightness",
+      "type": "number"
+    },
+    "html": {
+      "type": "boolean"
+    },
+    "json": {
+      "type": "boolean"
+    },
+    "font": {
+      "type": "string",
+      "enum": [
+        "Andale Mono",
+        "Impact",
+        "Arial",
+        "Arial Black",
+        "Comic Sans MS",
+        "Courier New",
+        "Georgia",
+        "Times New Roman",
+        "Verdana",
+        "Webdings"
+      ],
+      "default": "Impact"
+    },
+    "fontSize": {
+      "type": "number",
+      "default": 50
+    },
+    "fontColor": {
+      "type": "string",
+      "default": "#fff"
+    },
+    "fontBackground": {
+      "type": "string",
+      "default": "none"
+    }
+  },
+  "required": [
+    "id",
+    "text"
+  ]
+}

--- a/servers/api_example_com/src/tools/cat_get_text/schema/root.ts
+++ b/servers/api_example_com/src/tools/cat_get_text/schema/root.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string(),
+  "text": z.string(),
+  "type": z.enum(["square","medium","small","xsmall"]).optional(),
+  "filter": z.enum(["mono","negate","custom"]).optional(),
+  "fit": z.enum(["cover","contain","fill","inside","outside"]).optional(),
+  "position": z.enum(["top","right top","right","right bottom","bottom","left bottom","left","left top","center"]).optional(),
+  "width": z.number().optional(),
+  "height": z.number().optional(),
+  "blur": z.number().optional(),
+  "r": z.number().describe("With custom filter, define red value between 0 and 255").optional(),
+  "g": z.number().describe("With custom filter, define green value between 0 and 255").optional(),
+  "b": z.number().describe("With custom filter, define blue value between 0 and 255").optional(),
+  "brightness": z.number().describe("With custom filter, define brightness").optional(),
+  "saturation": z.number().describe("With custom filter, define saturation").optional(),
+  "hue": z.number().describe("With custom filter, define hue").optional(),
+  "lightness": z.number().describe("With custom filter, define lightness").optional(),
+  "html": z.boolean().optional(),
+  "json": z.boolean().optional(),
+  "font": z.enum(["Andale Mono","Impact","Arial","Arial Black","Comic Sans MS","Courier New","Georgia","Times New Roman","Verdana","Webdings"]).optional(),
+  "fontSize": z.number().optional(),
+  "fontColor": z.string().optional(),
+  "fontBackground": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/cat_random/index.ts
+++ b/servers/api_example_com/src/tools/cat_random/index.ts
@@ -1,0 +1,34 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cat_random",
+  "toolDescription": "Get a random cat",
+  "baseUrl": "https://api.example.com",
+  "path": "/cat",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "type": "type",
+      "filter": "filter",
+      "fit": "fit",
+      "position": "position",
+      "width": "width",
+      "height": "height",
+      "blur": "blur",
+      "r": "r",
+      "g": "g",
+      "b": "b",
+      "brightness": "brightness",
+      "saturation": "saturation",
+      "hue": "hue",
+      "lightness": "lightness",
+      "html": "html",
+      "json": "json"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/cat_random/schema-json/root.json
+++ b/servers/api_example_com/src/tools/cat_random/schema-json/root.json
@@ -1,0 +1,91 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "square",
+        "medium",
+        "small",
+        "xsmall"
+      ]
+    },
+    "filter": {
+      "type": "string",
+      "enum": [
+        "mono",
+        "negate",
+        "custom"
+      ]
+    },
+    "fit": {
+      "type": "string",
+      "enum": [
+        "cover",
+        "contain",
+        "fill",
+        "inside",
+        "outside"
+      ]
+    },
+    "position": {
+      "type": "string",
+      "enum": [
+        "top",
+        "right top",
+        "right",
+        "right bottom",
+        "bottom",
+        "left bottom",
+        "left",
+        "left top",
+        "center"
+      ],
+      "default": "center"
+    },
+    "width": {
+      "type": "number"
+    },
+    "height": {
+      "type": "number"
+    },
+    "blur": {
+      "type": "number"
+    },
+    "r": {
+      "description": "With custom filter, define red value between 0 and 255",
+      "type": "number"
+    },
+    "g": {
+      "description": "With custom filter, define green value between 0 and 255",
+      "type": "number"
+    },
+    "b": {
+      "description": "With custom filter, define blue value between 0 and 255",
+      "type": "number"
+    },
+    "brightness": {
+      "description": "With custom filter, define brightness",
+      "type": "number"
+    },
+    "saturation": {
+      "description": "With custom filter, define saturation",
+      "type": "number"
+    },
+    "hue": {
+      "description": "With custom filter, define hue",
+      "type": "number"
+    },
+    "lightness": {
+      "description": "With custom filter, define lightness",
+      "type": "number"
+    },
+    "html": {
+      "type": "boolean"
+    },
+    "json": {
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/cat_random/schema/root.ts
+++ b/servers/api_example_com/src/tools/cat_random/schema/root.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.enum(["square","medium","small","xsmall"]).optional(),
+  "filter": z.enum(["mono","negate","custom"]).optional(),
+  "fit": z.enum(["cover","contain","fill","inside","outside"]).optional(),
+  "position": z.enum(["top","right top","right","right bottom","bottom","left bottom","left","left top","center"]).optional(),
+  "width": z.number().optional(),
+  "height": z.number().optional(),
+  "blur": z.number().optional(),
+  "r": z.number().describe("With custom filter, define red value between 0 and 255").optional(),
+  "g": z.number().describe("With custom filter, define green value between 0 and 255").optional(),
+  "b": z.number().describe("With custom filter, define blue value between 0 and 255").optional(),
+  "brightness": z.number().describe("With custom filter, define brightness").optional(),
+  "saturation": z.number().describe("With custom filter, define saturation").optional(),
+  "hue": z.number().describe("With custom filter, define hue").optional(),
+  "lightness": z.number().describe("With custom filter, define lightness").optional(),
+  "html": z.boolean().optional(),
+  "json": z.boolean().optional()
+}

--- a/servers/api_example_com/src/tools/cat_random_tag/index.ts
+++ b/servers/api_example_com/src/tools/cat_random_tag/index.ts
@@ -1,0 +1,37 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cat_random_tag",
+  "toolDescription": "Get random cat by tag",
+  "baseUrl": "https://api.example.com",
+  "path": "/cat/{tag}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "tag": "tag"
+    },
+    "query": {
+      "type": "type",
+      "filter": "filter",
+      "fit": "fit",
+      "position": "position",
+      "width": "width",
+      "height": "height",
+      "blur": "blur",
+      "r": "r",
+      "g": "g",
+      "b": "b",
+      "brightness": "brightness",
+      "saturation": "saturation",
+      "hue": "hue",
+      "lightness": "lightness",
+      "html": "html",
+      "json": "json"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/cat_random_tag/schema-json/root.json
+++ b/servers/api_example_com/src/tools/cat_random_tag/schema-json/root.json
@@ -1,0 +1,96 @@
+{
+  "type": "object",
+  "properties": {
+    "tag": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "square",
+        "medium",
+        "small",
+        "xsmall"
+      ]
+    },
+    "filter": {
+      "type": "string",
+      "enum": [
+        "mono",
+        "negate",
+        "custom"
+      ]
+    },
+    "fit": {
+      "type": "string",
+      "enum": [
+        "cover",
+        "contain",
+        "fill",
+        "inside",
+        "outside"
+      ]
+    },
+    "position": {
+      "type": "string",
+      "enum": [
+        "top",
+        "right top",
+        "right",
+        "right bottom",
+        "bottom",
+        "left bottom",
+        "left",
+        "left top",
+        "center"
+      ],
+      "default": "center"
+    },
+    "width": {
+      "type": "number"
+    },
+    "height": {
+      "type": "number"
+    },
+    "blur": {
+      "type": "number"
+    },
+    "r": {
+      "description": "With custom filter, define red value between 0 and 255",
+      "type": "number"
+    },
+    "g": {
+      "description": "With custom filter, define green value between 0 and 255",
+      "type": "number"
+    },
+    "b": {
+      "description": "With custom filter, define blue value between 0 and 255",
+      "type": "number"
+    },
+    "brightness": {
+      "description": "With custom filter, define brightness",
+      "type": "number"
+    },
+    "saturation": {
+      "description": "With custom filter, define saturation",
+      "type": "number"
+    },
+    "hue": {
+      "description": "With custom filter, define hue",
+      "type": "number"
+    },
+    "lightness": {
+      "description": "With custom filter, define lightness",
+      "type": "number"
+    },
+    "html": {
+      "type": "boolean"
+    },
+    "json": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "tag"
+  ]
+}

--- a/servers/api_example_com/src/tools/cat_random_tag/schema/root.ts
+++ b/servers/api_example_com/src/tools/cat_random_tag/schema/root.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tag": z.string(),
+  "type": z.enum(["square","medium","small","xsmall"]).optional(),
+  "filter": z.enum(["mono","negate","custom"]).optional(),
+  "fit": z.enum(["cover","contain","fill","inside","outside"]).optional(),
+  "position": z.enum(["top","right top","right","right bottom","bottom","left bottom","left","left top","center"]).optional(),
+  "width": z.number().optional(),
+  "height": z.number().optional(),
+  "blur": z.number().optional(),
+  "r": z.number().describe("With custom filter, define red value between 0 and 255").optional(),
+  "g": z.number().describe("With custom filter, define green value between 0 and 255").optional(),
+  "b": z.number().describe("With custom filter, define blue value between 0 and 255").optional(),
+  "brightness": z.number().describe("With custom filter, define brightness").optional(),
+  "saturation": z.number().describe("With custom filter, define saturation").optional(),
+  "hue": z.number().describe("With custom filter, define hue").optional(),
+  "lightness": z.number().describe("With custom filter, define lightness").optional(),
+  "html": z.boolean().optional(),
+  "json": z.boolean().optional()
+}

--- a/servers/api_example_com/src/tools/cat_random_tag_text/index.ts
+++ b/servers/api_example_com/src/tools/cat_random_tag_text/index.ts
@@ -1,0 +1,42 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cat_random_tag_text",
+  "toolDescription": "Get random cat by tag saying text",
+  "baseUrl": "https://api.example.com",
+  "path": "/cat/{tag}/says/{text}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "tag": "tag",
+      "text": "text"
+    },
+    "query": {
+      "type": "type",
+      "filter": "filter",
+      "fit": "fit",
+      "position": "position",
+      "width": "width",
+      "height": "height",
+      "blur": "blur",
+      "r": "r",
+      "g": "g",
+      "b": "b",
+      "brightness": "brightness",
+      "saturation": "saturation",
+      "hue": "hue",
+      "lightness": "lightness",
+      "html": "html",
+      "json": "json",
+      "font": "font",
+      "fontSize": "fontSize",
+      "fontColor": "fontColor",
+      "fontBackground": "fontBackground"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/cat_random_tag_text/schema-json/root.json
+++ b/servers/api_example_com/src/tools/cat_random_tag_text/schema-json/root.json
@@ -1,0 +1,128 @@
+{
+  "type": "object",
+  "properties": {
+    "tag": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "square",
+        "medium",
+        "small",
+        "xsmall"
+      ]
+    },
+    "filter": {
+      "type": "string",
+      "enum": [
+        "mono",
+        "negate",
+        "custom"
+      ]
+    },
+    "fit": {
+      "type": "string",
+      "enum": [
+        "cover",
+        "contain",
+        "fill",
+        "inside",
+        "outside"
+      ]
+    },
+    "position": {
+      "type": "string",
+      "enum": [
+        "top",
+        "right top",
+        "right",
+        "right bottom",
+        "bottom",
+        "left bottom",
+        "left",
+        "left top",
+        "center"
+      ],
+      "default": "center"
+    },
+    "width": {
+      "type": "number"
+    },
+    "height": {
+      "type": "number"
+    },
+    "blur": {
+      "type": "number"
+    },
+    "r": {
+      "description": "With custom filter, define red value between 0 and 255",
+      "type": "number"
+    },
+    "g": {
+      "description": "With custom filter, define green value between 0 and 255",
+      "type": "number"
+    },
+    "b": {
+      "description": "With custom filter, define blue value between 0 and 255",
+      "type": "number"
+    },
+    "brightness": {
+      "description": "With custom filter, define brightness",
+      "type": "number"
+    },
+    "saturation": {
+      "description": "With custom filter, define saturation",
+      "type": "number"
+    },
+    "hue": {
+      "description": "With custom filter, define hue",
+      "type": "number"
+    },
+    "lightness": {
+      "description": "With custom filter, define lightness",
+      "type": "number"
+    },
+    "html": {
+      "type": "boolean"
+    },
+    "json": {
+      "type": "boolean"
+    },
+    "font": {
+      "type": "string",
+      "enum": [
+        "Andale Mono",
+        "Impact",
+        "Arial",
+        "Arial Black",
+        "Comic Sans MS",
+        "Courier New",
+        "Georgia",
+        "Times New Roman",
+        "Verdana",
+        "Webdings"
+      ],
+      "default": "Impact"
+    },
+    "fontSize": {
+      "type": "number",
+      "default": 50
+    },
+    "fontColor": {
+      "type": "string",
+      "default": "#fff"
+    },
+    "fontBackground": {
+      "type": "string",
+      "default": "none"
+    }
+  },
+  "required": [
+    "tag",
+    "text"
+  ]
+}

--- a/servers/api_example_com/src/tools/cat_random_tag_text/schema/root.ts
+++ b/servers/api_example_com/src/tools/cat_random_tag_text/schema/root.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tag": z.string(),
+  "text": z.string(),
+  "type": z.enum(["square","medium","small","xsmall"]).optional(),
+  "filter": z.enum(["mono","negate","custom"]).optional(),
+  "fit": z.enum(["cover","contain","fill","inside","outside"]).optional(),
+  "position": z.enum(["top","right top","right","right bottom","bottom","left bottom","left","left top","center"]).optional(),
+  "width": z.number().optional(),
+  "height": z.number().optional(),
+  "blur": z.number().optional(),
+  "r": z.number().describe("With custom filter, define red value between 0 and 255").optional(),
+  "g": z.number().describe("With custom filter, define green value between 0 and 255").optional(),
+  "b": z.number().describe("With custom filter, define blue value between 0 and 255").optional(),
+  "brightness": z.number().describe("With custom filter, define brightness").optional(),
+  "saturation": z.number().describe("With custom filter, define saturation").optional(),
+  "hue": z.number().describe("With custom filter, define hue").optional(),
+  "lightness": z.number().describe("With custom filter, define lightness").optional(),
+  "html": z.boolean().optional(),
+  "json": z.boolean().optional(),
+  "font": z.enum(["Andale Mono","Impact","Arial","Arial Black","Comic Sans MS","Courier New","Georgia","Times New Roman","Verdana","Webdings"]).optional(),
+  "fontSize": z.number().optional(),
+  "fontColor": z.string().optional(),
+  "fontBackground": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/cat_random_text/index.ts
+++ b/servers/api_example_com/src/tools/cat_random_text/index.ts
@@ -1,0 +1,41 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cat_random_text",
+  "toolDescription": "Get random cat saying text",
+  "baseUrl": "https://api.example.com",
+  "path": "/cat/says/{text}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "text": "text"
+    },
+    "query": {
+      "type": "type",
+      "filter": "filter",
+      "fit": "fit",
+      "position": "position",
+      "width": "width",
+      "height": "height",
+      "blur": "blur",
+      "r": "r",
+      "g": "g",
+      "b": "b",
+      "brightness": "brightness",
+      "saturation": "saturation",
+      "hue": "hue",
+      "lightness": "lightness",
+      "html": "html",
+      "json": "json",
+      "font": "font",
+      "fontSize": "fontSize",
+      "fontColor": "fontColor",
+      "fontBackground": "fontBackground"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/cat_random_text/schema-json/root.json
+++ b/servers/api_example_com/src/tools/cat_random_text/schema-json/root.json
@@ -1,0 +1,124 @@
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "square",
+        "medium",
+        "small",
+        "xsmall"
+      ]
+    },
+    "filter": {
+      "type": "string",
+      "enum": [
+        "mono",
+        "negate",
+        "custom"
+      ]
+    },
+    "fit": {
+      "type": "string",
+      "enum": [
+        "cover",
+        "contain",
+        "fill",
+        "inside",
+        "outside"
+      ]
+    },
+    "position": {
+      "type": "string",
+      "enum": [
+        "top",
+        "right top",
+        "right",
+        "right bottom",
+        "bottom",
+        "left bottom",
+        "left",
+        "left top",
+        "center"
+      ],
+      "default": "center"
+    },
+    "width": {
+      "type": "number"
+    },
+    "height": {
+      "type": "number"
+    },
+    "blur": {
+      "type": "number"
+    },
+    "r": {
+      "description": "With custom filter, define red value between 0 and 255",
+      "type": "number"
+    },
+    "g": {
+      "description": "With custom filter, define green value between 0 and 255",
+      "type": "number"
+    },
+    "b": {
+      "description": "With custom filter, define blue value between 0 and 255",
+      "type": "number"
+    },
+    "brightness": {
+      "description": "With custom filter, define brightness",
+      "type": "number"
+    },
+    "saturation": {
+      "description": "With custom filter, define saturation",
+      "type": "number"
+    },
+    "hue": {
+      "description": "With custom filter, define hue",
+      "type": "number"
+    },
+    "lightness": {
+      "description": "With custom filter, define lightness",
+      "type": "number"
+    },
+    "html": {
+      "type": "boolean"
+    },
+    "json": {
+      "type": "boolean"
+    },
+    "font": {
+      "type": "string",
+      "enum": [
+        "Andale Mono",
+        "Impact",
+        "Arial",
+        "Arial Black",
+        "Comic Sans MS",
+        "Courier New",
+        "Georgia",
+        "Times New Roman",
+        "Verdana",
+        "Webdings"
+      ],
+      "default": "Impact"
+    },
+    "fontSize": {
+      "type": "number",
+      "default": 50
+    },
+    "fontColor": {
+      "type": "string",
+      "default": "#fff"
+    },
+    "fontBackground": {
+      "type": "string",
+      "default": "none"
+    }
+  },
+  "required": [
+    "text"
+  ]
+}

--- a/servers/api_example_com/src/tools/cat_random_text/schema/root.ts
+++ b/servers/api_example_com/src/tools/cat_random_text/schema/root.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "text": z.string(),
+  "type": z.enum(["square","medium","small","xsmall"]).optional(),
+  "filter": z.enum(["mono","negate","custom"]).optional(),
+  "fit": z.enum(["cover","contain","fill","inside","outside"]).optional(),
+  "position": z.enum(["top","right top","right","right bottom","bottom","left bottom","left","left top","center"]).optional(),
+  "width": z.number().optional(),
+  "height": z.number().optional(),
+  "blur": z.number().optional(),
+  "r": z.number().describe("With custom filter, define red value between 0 and 255").optional(),
+  "g": z.number().describe("With custom filter, define green value between 0 and 255").optional(),
+  "b": z.number().describe("With custom filter, define blue value between 0 and 255").optional(),
+  "brightness": z.number().describe("With custom filter, define brightness").optional(),
+  "saturation": z.number().describe("With custom filter, define saturation").optional(),
+  "hue": z.number().describe("With custom filter, define hue").optional(),
+  "lightness": z.number().describe("With custom filter, define lightness").optional(),
+  "html": z.boolean().optional(),
+  "json": z.boolean().optional(),
+  "font": z.enum(["Andale Mono","Impact","Arial","Arial Black","Comic Sans MS","Courier New","Georgia","Times New Roman","Verdana","Webdings"]).optional(),
+  "fontSize": z.number().optional(),
+  "fontColor": z.string().optional(),
+  "fontBackground": z.string().optional()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.