### PR TITLE
Add MCP server `api_personio_de_v1`

### DIFF
--- a/servers/api_personio_de_v1/.npmignore
+++ b/servers/api_personio_de_v1/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_personio_de_v1/README.md
+++ b/servers/api_personio_de_v1/README.md
@@ -1,0 +1,248 @@
+# @open-mcp/api_personio_de_v1
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_personio_de_v1": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_personio_de_v1@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_personio_de_v1@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_personio_de_v1 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_personio_de_v1 \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_personio_de_v1 \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_personio_de_v1": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_personio_de_v1"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_company_attendances
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `start_date` (string)
+- `end_date` (string)
+- `updated_from` (string)
+- `updated_to` (string)
+- `employees` (array)
+- `limit` (integer)
+- `offset` (integer)
+
+### post_company_attendances
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `attendances` (array)
+
+### delete_company_attendances_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (integer)
+
+### patch_company_attendances_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (integer)
+- `break` (integer)
+- `comment` (string)
+- `date` (string)
+- `end_time` (string)
+- `start_time` (string)
+
+### get_company_employees
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### post_company_employees
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### get_company_employees_employee_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `employee_id` (integer)
+
+### get_company_employees_employee_id_profile_picture_width_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `employee_id` (integer)
+- `width` (integer)
+
+### get_company_time_off_types
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+
+### get_company_time_offs
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `start_date` (string)
+- `end_date` (string)
+- `updated_from` (string)
+- `updated_to` (string)
+- `employees` (array)
+- `limit` (integer)
+- `offset` (integer)
+
+### post_company_time_offs
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `comment` (string)
+- `employee_id` (integer)
+- `end_date` (string)
+- `half_day_end` (boolean)
+- `half_day_start` (boolean)
+- `start_date` (string)
+- `time_off_type_id` (integer)
+
+### delete_company_time_offs_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (integer)
+
+### get_company_time_offs_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (integer)

--- a/servers/api_personio_de_v1/package.json
+++ b/servers/api_personio_de_v1/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_personio_de_v1",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_personio_de_v1": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_personio_de_v1/src/constants.ts
+++ b/servers/api_personio_de_v1/src/constants.ts
@@ -1,0 +1,18 @@
+export const OPENAPI_URL = "https://api.apis.guru/v2/specs/personio.de/personnel/1.0/openapi.yaml"
+export const SERVER_NAME = "api_personio_de_v1"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_company_attendances/index.js",
+  "./tools/post_company_attendances/index.js",
+  "./tools/delete_company_attendances_id_/index.js",
+  "./tools/patch_company_attendances_id_/index.js",
+  "./tools/get_company_employees/index.js",
+  "./tools/post_company_employees/index.js",
+  "./tools/get_company_employees_employee_id_/index.js",
+  "./tools/get_company_employees_employee_id_profile_picture_width_/index.js",
+  "./tools/get_company_time_off_types/index.js",
+  "./tools/get_company_time_offs/index.js",
+  "./tools/post_company_time_offs/index.js",
+  "./tools/delete_company_time_offs_id_/index.js",
+  "./tools/get_company_time_offs_id_/index.js"
+]

--- a/servers/api_personio_de_v1/src/index.ts
+++ b/servers/api_personio_de_v1/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_personio_de_v1/src/server.ts
+++ b/servers/api_personio_de_v1/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_personio_de_v1/src/tools/delete_company_attendances_id_/index.ts
+++ b/servers/api_personio_de_v1/src/tools/delete_company_attendances_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_company_attendances_id_",
+  "toolDescription": "This endpoint is responsible for deleting attendance data for the company employees.",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/attendances/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/delete_company_attendances_id_/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/delete_company_attendances_id_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of the attendance period to delete",
+      "format": "int32",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/delete_company_attendances_id_/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/delete_company_attendances_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("ID of the attendance period to delete")
+}

--- a/servers/api_personio_de_v1/src/tools/delete_company_time_offs_id_/index.ts
+++ b/servers/api_personio_de_v1/src/tools/delete_company_time_offs_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_company_time_offs_id_",
+  "toolDescription": "This endpoint is responsible for deleting absence period data for the company employees.",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/time-offs/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/delete_company_time_offs_id_/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/delete_company_time_offs_id_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of the absence period to delete",
+      "format": "int32",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/delete_company_time_offs_id_/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/delete_company_time_offs_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("ID of the absence period to delete")
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_attendances/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_attendances/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_attendances",
+  "toolDescription": "This endpoint is responsible for fetching attendance data for the company employees. It is possible to paginate results, filter by period, the date and/or time it was updated, and/or specific employees. The result will contain a list of att",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/attendances",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "start_date": "start_date",
+      "end_date": "end_date",
+      "updated_from": "updated_from",
+      "updated_to": "updated_to",
+      "employees": "employees",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_attendances/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_attendances/schema-json/root.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "properties": {
+    "start_date": {
+      "description": "First day of the period to be queried. It is inclusive, so the day specified as start_date will also be considered on the results",
+      "format": "date",
+      "type": "string"
+    },
+    "end_date": {
+      "description": "Last day of the period to be queried. It is inclusive, so the day specified as end_date will also be considered on the results.",
+      "format": "date",
+      "type": "string"
+    },
+    "updated_from": {
+      "description": "Datetime from when the queried periods have been updated. Same format as updated_at. It is inclusive, so the day specified as updated_from will also be considered on the results. Can be just the date, or the date and the time, with or without the timezone.",
+      "format": "datetime",
+      "type": "string"
+    },
+    "updated_to": {
+      "description": "Datetime until when the queried periods have been updated. Same format as updated_at. It is inclusive, so the day specified as updated_to will also be considered on the results. Can be just the date, or the date and the time, with or without the timezone.",
+      "format": "datetime",
+      "type": "string"
+    },
+    "employees": {
+      "description": "A list of Personio employee identifiers to filter the results. Only those employees specified here will be returned.",
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "limit": {
+      "description": "Pagination attribute to limit how many attendances will be returned per page",
+      "default": 200,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "offset": {
+      "description": "Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.",
+      "default": 0,
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "start_date",
+    "end_date"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_attendances/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_attendances/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "start_date": z.string().date().describe("First day of the period to be queried. It is inclusive, so the day specified as start_date will also be considered on the results"),
+  "end_date": z.string().date().describe("Last day of the period to be queried. It is inclusive, so the day specified as end_date will also be considered on the results."),
+  "updated_from": z.string().describe("Datetime from when the queried periods have been updated. Same format as updated_at. It is inclusive, so the day specified as updated_from will also be considered on the results. Can be just the date, or the date and the time, with or without the timezone.").optional(),
+  "updated_to": z.string().describe("Datetime until when the queried periods have been updated. Same format as updated_at. It is inclusive, so the day specified as updated_to will also be considered on the results. Can be just the date, or the date and the time, with or without the timezone.").optional(),
+  "employees": z.array(z.number().int()).describe("A list of Personio employee identifiers to filter the results. Only those employees specified here will be returned.").optional(),
+  "limit": z.number().int().gte(1).describe("Pagination attribute to limit how many attendances will be returned per page").optional(),
+  "offset": z.number().int().gte(0).describe("Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.").optional()
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_employees/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_employees",
+  "toolDescription": "List Employees",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/employees",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_employees/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_employees/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_employees_employee_id_",
+  "toolDescription": "Show employee by ID",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/employees/{employee_id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "employee_id": "employee_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "employee_id": {
+      "description": "Numeric `id` of the employee",
+      "format": "int32",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "employee_id"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "employee_id": z.number().int().describe("Numeric `id` of the employee")
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_profile_picture_width_/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_profile_picture_width_/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_employees_employee_id_profile_picture_width_",
+  "toolDescription": "Show employee profile picture",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/employees/{employee_id}/profile-picture/{width}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "employee_id": "employee_id",
+      "width": "width"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_profile_picture_width_/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_profile_picture_width_/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "employee_id": {
+      "description": "Numeric `id` of the employee",
+      "format": "int32",
+      "type": "integer"
+    },
+    "width": {
+      "description": "Width of the image. Default 75x75",
+      "format": "int32",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "employee_id",
+    "width"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_profile_picture_width_/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_employees_employee_id_profile_picture_width_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "employee_id": z.number().int().describe("Numeric `id` of the employee"),
+  "width": z.number().int().describe("Width of the image. Default 75x75")
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_time_off_types/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_off_types/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_time_off_types",
+  "toolDescription": "Provides a list of available time-off types, for example 'Paid vacation', 'Parental leave' or 'Home office'",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/time-off-types",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_time_off_types/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_off_types/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "Pagination attribute to limit how many records will be returned per page",
+      "default": 200,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "offset": {
+      "description": "Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.",
+      "default": 0,
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": []
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_time_off_types/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_off_types/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.number().int().gte(1).describe("Pagination attribute to limit how many records will be returned per page").optional(),
+  "offset": z.number().int().gte(0).describe("Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.").optional()
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_time_offs/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_offs/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_time_offs",
+  "toolDescription": "This endpoint is responsible for fetching absence data for the company employees. It is possible to paginate results, filter by period and/or specific employees. The result will contain a list of absence periods, structured as defined here.",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/time-offs",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "start_date": "start_date",
+      "end_date": "end_date",
+      "updated_from": "updated_from",
+      "updated_to": "updated_to",
+      "employees": "employees",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_time_offs/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_offs/schema-json/root.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "start_date": {
+      "description": "First day of the period to be queried. It is inclusive, so the day specified as start_date will also be considered on the results",
+      "format": "date",
+      "type": "string"
+    },
+    "end_date": {
+      "description": "Last day of the period to be queried. It is inclusive, so the day specified as end_date will also be considered on the results.",
+      "format": "date",
+      "type": "string"
+    },
+    "updated_from": {
+      "description": "Datetime from when the queried periods have been updated. It is inclusive, so the day specified as updated_from will also be considered on the results.",
+      "format": "datetime",
+      "type": "string"
+    },
+    "updated_to": {
+      "description": "Datetime until when the queried periods have been updated. It is inclusive, so the day specified as updated_to will also be considered on the results.",
+      "format": "datetime",
+      "type": "string"
+    },
+    "employees": {
+      "description": "A list of Personio employee identifiers to filter the results. Only those employees specified here will be returned.",
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "limit": {
+      "description": "Pagination attribute to limit how many attendances will be returned per page",
+      "default": 200,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "offset": {
+      "description": "Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.",
+      "default": 0,
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": []
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_time_offs/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_offs/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "start_date": z.string().date().describe("First day of the period to be queried. It is inclusive, so the day specified as start_date will also be considered on the results").optional(),
+  "end_date": z.string().date().describe("Last day of the period to be queried. It is inclusive, so the day specified as end_date will also be considered on the results.").optional(),
+  "updated_from": z.string().describe("Datetime from when the queried periods have been updated. It is inclusive, so the day specified as updated_from will also be considered on the results.").optional(),
+  "updated_to": z.string().describe("Datetime until when the queried periods have been updated. It is inclusive, so the day specified as updated_to will also be considered on the results.").optional(),
+  "employees": z.array(z.number().int()).describe("A list of Personio employee identifiers to filter the results. Only those employees specified here will be returned.").optional(),
+  "limit": z.number().int().gte(1).describe("Pagination attribute to limit how many attendances will be returned per page").optional(),
+  "offset": z.number().int().gte(0).describe("Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.").optional()
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_time_offs_id_/index.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_offs_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_company_time_offs_id_",
+  "toolDescription": "Absence Period",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/time-offs/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/get_company_time_offs_id_/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_offs_id_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Numeric `id` of the absence period",
+      "format": "int32",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/get_company_time_offs_id_/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/get_company_time_offs_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("Numeric `id` of the absence period")
+}

--- a/servers/api_personio_de_v1/src/tools/patch_company_attendances_id_/index.ts
+++ b/servers/api_personio_de_v1/src/tools/patch_company_attendances_id_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "patch_company_attendances_id_",
+  "toolDescription": "This endpoint is responsible for updating attendance data for the company employees. Attributes are not required and if not specified, the current value will be used. It is not possible to change the employee id.",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/attendances/{id}",
+  "method": "patch",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "body": {
+      "break": "break",
+      "comment": "comment",
+      "date": "date",
+      "end_time": "end_time",
+      "start_time": "start_time"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/patch_company_attendances_id_/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/patch_company_attendances_id_/schema-json/root.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of the attendance period to update",
+      "format": "int32",
+      "type": "integer"
+    },
+    "break": {
+      "description": "Break in minutes",
+      "format": "int32",
+      "type": "integer"
+    },
+    "comment": {
+      "description": "Optional comment",
+      "type": "string"
+    },
+    "date": {
+      "description": "Attendance date as YYYY-MM-DD",
+      "format": "date",
+      "type": "string"
+    },
+    "end_time": {
+      "description": "End time as HH:MM",
+      "pattern": "^\\d\\d:\\d\\d$",
+      "type": "string"
+    },
+    "start_time": {
+      "description": "Start time as HH:MM",
+      "pattern": "^\\d\\d:\\d\\d$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/patch_company_attendances_id_/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/patch_company_attendances_id_/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().int().describe("ID of the attendance period to update"),
+  "break": z.number().int().describe("Break in minutes").optional(),
+  "comment": z.string().describe("Optional comment").optional(),
+  "date": z.string().date().describe("Attendance date as YYYY-MM-DD").optional(),
+  "end_time": z.string().regex(new RegExp("^\\d\\d:\\d\\d$")).describe("End time as HH:MM").optional(),
+  "start_time": z.string().regex(new RegExp("^\\d\\d:\\d\\d$")).describe("Start time as HH:MM").optional()
+}

--- a/servers/api_personio_de_v1/src/tools/post_company_attendances/index.ts
+++ b/servers/api_personio_de_v1/src/tools/post_company_attendances/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_company_attendances",
+  "toolDescription": "This endpoint is responsible for adding attendance data for the company employees. It is possible to add attendances for one or many employees at the same time. The payload sent on the request should be a list of attendance periods, in the",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/attendances",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "attendances": "attendances"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/post_company_attendances/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/post_company_attendances/schema-json/root.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "properties": {
+    "attendances": {
+      "items": {
+        "properties": {
+          "break": {
+            "description": "Break in minutes",
+            "format": "int32",
+            "type": "integer"
+          },
+          "comment": {
+            "description": "Optional comment",
+            "type": "string"
+          },
+          "date": {
+            "description": "Attendance date as YYYY-MM-DD",
+            "format": "date",
+            "type": "string"
+          },
+          "employee": {
+            "description": "Employee identifier",
+            "type": "integer"
+          },
+          "end_time": {
+            "description": "End time as HH:MM",
+            "pattern": "^\\d\\d:\\d\\d$",
+            "type": "string"
+          },
+          "start_time": {
+            "description": "Start time as HH:MM",
+            "pattern": "^\\d\\d:\\d\\d$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "employee",
+          "date",
+          "start_time",
+          "end_time",
+          "break",
+          "comment"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": []
+}

--- a/servers/api_personio_de_v1/src/tools/post_company_attendances/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/post_company_attendances/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "attendances": z.array(z.object({ "break": z.number().int().describe("Break in minutes"), "comment": z.string().describe("Optional comment"), "date": z.string().date().describe("Attendance date as YYYY-MM-DD"), "employee": z.number().int().describe("Employee identifier"), "end_time": z.string().regex(new RegExp("^\\d\\d:\\d\\d$")).describe("End time as HH:MM"), "start_time": z.string().regex(new RegExp("^\\d\\d:\\d\\d$")).describe("Start time as HH:MM") })).optional()
+}

--- a/servers/api_personio_de_v1/src/tools/post_company_employees/index.ts
+++ b/servers/api_personio_de_v1/src/tools/post_company_employees/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_company_employees",
+  "toolDescription": "Create an employee",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/employees",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/post_company_employees/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/post_company_employees/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_personio_de_v1/src/tools/post_company_employees/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/post_company_employees/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_personio_de_v1/src/tools/post_company_time_offs/index.ts
+++ b/servers/api_personio_de_v1/src/tools/post_company_time_offs/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_company_time_offs",
+  "toolDescription": "This endpoint is responsible for adding absence data for the company employees.",
+  "baseUrl": "https://api.personio.de/v1",
+  "path": "/company/time-offs",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "comment": "comment",
+      "employee_id": "employee_id",
+      "end_date": "end_date",
+      "half_day_end": "half_day_end",
+      "half_day_start": "half_day_start",
+      "start_date": "start_date",
+      "time_off_type_id": "time_off_type_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_personio_de_v1/src/tools/post_company_time_offs/schema-json/root.json
+++ b/servers/api_personio_de_v1/src/tools/post_company_time_offs/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "comment": {
+      "description": "Optional comment",
+      "type": "string"
+    },
+    "employee_id": {
+      "description": "Employee identifier",
+      "type": "integer"
+    },
+    "end_date": {
+      "description": "Absence end date as YYYY-MM-DD",
+      "format": "date",
+      "type": "string"
+    },
+    "half_day_end": {
+      "description": "Weather the end date is a half-day off",
+      "type": "boolean"
+    },
+    "half_day_start": {
+      "description": "Weather the start date is a half-day off",
+      "type": "boolean"
+    },
+    "start_date": {
+      "description": "Absence start date as YYYY-MM-DD",
+      "format": "date",
+      "type": "string"
+    },
+    "time_off_type_id": {
+      "description": "Time-off type identifier",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "employee_id",
+    "end_date",
+    "half_day_end",
+    "half_day_start",
+    "start_date",
+    "time_off_type_id"
+  ]
+}

--- a/servers/api_personio_de_v1/src/tools/post_company_time_offs/schema/root.ts
+++ b/servers/api_personio_de_v1/src/tools/post_company_time_offs/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "comment": z.string().describe("Optional comment").optional(),
+  "employee_id": z.number().int().describe("Employee identifier"),
+  "end_date": z.string().date().describe("Absence end date as YYYY-MM-DD"),
+  "half_day_end": z.boolean().describe("Weather the end date is a half-day off"),
+  "half_day_start": z.boolean().describe("Weather the start date is a half-day off"),
+  "start_date": z.string().date().describe("Absence start date as YYYY-MM-DD"),
+  "time_off_type_id": z.number().int().describe("Time-off type identifier")
+}

--- a/servers/api_personio_de_v1/tsconfig.json
+++ b/servers/api_personio_de_v1/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_personio_de_v1`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_personio_de_v1`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_personio_de_v1": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_personio_de_v1"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.