### PR TITLE
Add MCP server `api_rds_crm_com_v1`

### DIFF
--- a/servers/api_rds_crm_com_v1/.npmignore
+++ b/servers/api_rds_crm_com_v1/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_rds_crm_com_v1/README.md
+++ b/servers/api_rds_crm_com_v1/README.md
@@ -1,0 +1,163 @@
+# @open-mcp/api_rds_crm_com_v1
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_rds_crm_com_v1": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_rds_crm_com_v1@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_rds_crm_com_v1@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_rds_crm_com_v1 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_rds_crm_com_v1 \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_rds_crm_com_v1 \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_rds_crm_com_v1": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_rds_crm_com_v1"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_contacts
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `q` (string)
+- `title` (string)
+- `limit` (integer)
+
+### post_contacts
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `name` (string)
+- `job_title` (string)
+- `emails` (array)
+- `phones` (array)
+- `birthday` (string)
+- `social_profiles` (array)
+- `organization_id` (string)
+- `notes` (string)
+- `custom_fields` (object)
+
+### get_contacts_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+
+### put_contacts_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+- `name` (string)
+- `job_title` (string)
+- `emails` (array)
+- `phones` (array)
+- `birthday` (string)
+- `social_profiles` (array)
+- `organization_id` (string)
+- `notes` (string)
+- `custom_fields` (object)
+
+### get_deals
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `query` (string)
+- `limit` (integer)

--- a/servers/api_rds_crm_com_v1/package.json
+++ b/servers/api_rds_crm_com_v1/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_rds_crm_com_v1",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_rds_crm_com_v1": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_rds_crm_com_v1/src/constants.ts
+++ b/servers/api_rds_crm_com_v1/src/constants.ts
@@ -1,0 +1,10 @@
+export const OPENAPI_URL = "https://1aff2dcfc03c.ngrok-free.app/openapi.json"
+export const SERVER_NAME = "api_rds_crm_com_v1"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_contacts/index.js",
+  "./tools/post_contacts/index.js",
+  "./tools/get_contacts_id_/index.js",
+  "./tools/put_contacts_id_/index.js",
+  "./tools/get_deals/index.js"
+]

--- a/servers/api_rds_crm_com_v1/src/index.ts
+++ b/servers/api_rds_crm_com_v1/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_rds_crm_com_v1/src/server.ts
+++ b/servers/api_rds_crm_com_v1/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_rds_crm_com_v1/src/tools/get_contacts/index.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/get_contacts/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_contacts",
+  "toolDescription": "Lista contatos",
+  "baseUrl": "https://api.rds-crm.com/v1",
+  "path": "/contacts",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "q": "q",
+      "title": "title",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_rds_crm_com_v1/src/tools/get_contacts/schema-json/root.json
+++ b/servers/api_rds_crm_com_v1/src/tools/get_contacts/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "q": {
+      "description": "Termo de busca para filtrar contatos por nome",
+      "type": "string"
+    },
+    "title": {
+      "description": "Filtrar por cargo/título",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Número máximo de contatos a retornar",
+      "type": "integer",
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/servers/api_rds_crm_com_v1/src/tools/get_contacts/schema/root.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/get_contacts/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "q": z.string().describe("Termo de busca para filtrar contatos por nome").optional(),
+  "title": z.string().describe("Filtrar por cargo/título").optional(),
+  "limit": z.number().int().describe("Número máximo de contatos a retornar").optional()
+}

--- a/servers/api_rds_crm_com_v1/src/tools/get_contacts_id_/index.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/get_contacts_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_contacts_id_",
+  "toolDescription": "Obtém um contato específico",
+  "baseUrl": "https://api.rds-crm.com/v1",
+  "path": "/contacts/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_rds_crm_com_v1/src/tools/get_contacts_id_/schema-json/root.json
+++ b/servers/api_rds_crm_com_v1/src/tools/get_contacts_id_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID do contato",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_rds_crm_com_v1/src/tools/get_contacts_id_/schema/root.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/get_contacts_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("ID do contato")
+}

--- a/servers/api_rds_crm_com_v1/src/tools/get_deals/index.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/get_deals/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_deals",
+  "toolDescription": "Lista oportunidades",
+  "baseUrl": "https://api.rds-crm.com/v1",
+  "path": "/deals",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "query": "query",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_rds_crm_com_v1/src/tools/get_deals/schema-json/root.json
+++ b/servers/api_rds_crm_com_v1/src/tools/get_deals/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "description": "Termo de busca para filtrar oportunidades",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Número máximo de oportunidades a retornar",
+      "type": "integer",
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/servers/api_rds_crm_com_v1/src/tools/get_deals/schema/root.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/get_deals/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "query": z.string().describe("Termo de busca para filtrar oportunidades").optional(),
+  "limit": z.number().int().describe("Número máximo de oportunidades a retornar").optional()
+}

--- a/servers/api_rds_crm_com_v1/src/tools/post_contacts/index.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/post_contacts/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_contacts",
+  "toolDescription": "Cria um novo contato",
+  "baseUrl": "https://api.rds-crm.com/v1",
+  "path": "/contacts",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "job_title": "job_title",
+      "emails": "emails",
+      "phones": "phones",
+      "birthday": "birthday",
+      "social_profiles": "social_profiles",
+      "organization_id": "organization_id",
+      "notes": "notes",
+      "custom_fields": "custom_fields"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema-json/properties/custom_fields.json
+++ b/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema-json/properties/custom_fields.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "description": "Campos personalizados do contato",
+  "additionalProperties": true,
+  "properties": {}
+}

--- a/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema-json/root.json
+++ b/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema-json/root.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Nome do contato",
+      "example": "João Silva"
+    },
+    "job_title": {
+      "type": "string",
+      "description": "Cargo do contato",
+      "example": "Gerente de Marketing"
+    },
+    "emails": {
+      "type": "array",
+      "description": "Lista de emails do contato",
+      "items": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Endereço de email",
+            "example": "contato@exemplo.com"
+          }
+        }
+      }
+    },
+    "phones": {
+      "type": "array",
+      "description": "Lista de telefones do contato",
+      "items": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "description": "Número de telefone",
+            "example": "+55 11 91234-5678"
+          }
+        }
+      }
+    },
+    "birthday": {
+      "type": "string",
+      "format": "date",
+      "description": "Data de aniversário (formato YYYY-MM-DD)",
+      "example": "1980-01-15"
+    },
+    "social_profiles": {
+      "type": "array",
+      "description": "Perfis sociais do contato",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Tipo de perfil social (facebook, linkedin, skype)",
+            "enum": [
+              "facebook",
+              "linkedin",
+              "skype"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "description": "URL ou identificador do perfil social"
+          }
+        }
+      }
+    },
+    "organization_id": {
+      "type": "string",
+      "description": "ID da organização associada ao contato"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Observações sobre o contato"
+    },
+    "custom_fields": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `custom_fields` to the tool, first call the tool `expandSchema` with \"/properties/custom_fields\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Campos personalizados do contato</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": []
+}

--- a/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema/properties/custom_fields.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema/properties/custom_fields.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema/root.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/post_contacts/schema/root.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string().describe("Nome do contato").optional(),
+  "job_title": z.string().describe("Cargo do contato").optional(),
+  "emails": z.array(z.object({ "email": z.string().describe("Endereço de email").optional() })).describe("Lista de emails do contato").optional(),
+  "phones": z.array(z.object({ "phone": z.string().describe("Número de telefone").optional() })).describe("Lista de telefones do contato").optional(),
+  "birthday": z.string().date().describe("Data de aniversário (formato YYYY-MM-DD)").optional(),
+  "social_profiles": z.array(z.object({ "type": z.enum(["facebook","linkedin","skype"]).describe("Tipo de perfil social (facebook, linkedin, skype)").optional(), "url": z.string().describe("URL ou identificador do perfil social").optional() })).describe("Perfis sociais do contato").optional(),
+  "organization_id": z.string().describe("ID da organização associada ao contato").optional(),
+  "notes": z.string().describe("Observações sobre o contato").optional(),
+  "custom_fields": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `custom_fields` to the tool, first call the tool `expandSchema` with \"/properties/custom_fields\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Campos personalizados do contato</property-description>").optional()
+}

--- a/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/index.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_contacts_id_",
+  "toolDescription": "Atualiza um contato",
+  "baseUrl": "https://api.rds-crm.com/v1",
+  "path": "/contacts/{id}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "body": {
+      "name": "name",
+      "job_title": "job_title",
+      "emails": "emails",
+      "phones": "phones",
+      "birthday": "birthday",
+      "social_profiles": "social_profiles",
+      "organization_id": "organization_id",
+      "notes": "notes",
+      "custom_fields": "custom_fields"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema-json/properties/custom_fields.json
+++ b/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema-json/properties/custom_fields.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "description": "Campos personalizados do contato",
+  "additionalProperties": true,
+  "properties": {}
+}

--- a/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema-json/root.json
+++ b/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema-json/root.json
@@ -1,0 +1,91 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID do contato",
+      "type": "string"
+    },
+    "name": {
+      "type": "string",
+      "description": "Nome do contato",
+      "example": "João Silva"
+    },
+    "job_title": {
+      "type": "string",
+      "description": "Cargo do contato",
+      "example": "Gerente de Marketing"
+    },
+    "emails": {
+      "type": "array",
+      "description": "Lista de emails do contato",
+      "items": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Endereço de email",
+            "example": "contato@exemplo.com"
+          }
+        }
+      }
+    },
+    "phones": {
+      "type": "array",
+      "description": "Lista de telefones do contato",
+      "items": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "description": "Número de telefone",
+            "example": "+55 11 91234-5678"
+          }
+        }
+      }
+    },
+    "birthday": {
+      "type": "string",
+      "format": "date",
+      "description": "Data de aniversário (formato YYYY-MM-DD)",
+      "example": "1980-01-15"
+    },
+    "social_profiles": {
+      "type": "array",
+      "description": "Perfis sociais do contato",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Tipo de perfil social (facebook, linkedin, skype)",
+            "enum": [
+              "facebook",
+              "linkedin",
+              "skype"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "description": "URL ou identificador do perfil social"
+          }
+        }
+      }
+    },
+    "organization_id": {
+      "type": "string",
+      "description": "ID da organização associada ao contato"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Observações sobre o contato"
+    },
+    "custom_fields": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `custom_fields` to the tool, first call the tool `expandSchema` with \"/properties/custom_fields\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Campos personalizados do contato</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema/properties/custom_fields.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema/properties/custom_fields.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema/root.ts
+++ b/servers/api_rds_crm_com_v1/src/tools/put_contacts_id_/schema/root.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("ID do contato"),
+  "name": z.string().describe("Nome do contato").optional(),
+  "job_title": z.string().describe("Cargo do contato").optional(),
+  "emails": z.array(z.object({ "email": z.string().describe("Endereço de email").optional() })).describe("Lista de emails do contato").optional(),
+  "phones": z.array(z.object({ "phone": z.string().describe("Número de telefone").optional() })).describe("Lista de telefones do contato").optional(),
+  "birthday": z.string().date().describe("Data de aniversário (formato YYYY-MM-DD)").optional(),
+  "social_profiles": z.array(z.object({ "type": z.enum(["facebook","linkedin","skype"]).describe("Tipo de perfil social (facebook, linkedin, skype)").optional(), "url": z.string().describe("URL ou identificador do perfil social").optional() })).describe("Perfis sociais do contato").optional(),
+  "organization_id": z.string().describe("ID da organização associada ao contato").optional(),
+  "notes": z.string().describe("Observações sobre o contato").optional(),
+  "custom_fields": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `custom_fields` to the tool, first call the tool `expandSchema` with \"/properties/custom_fields\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>Campos personalizados do contato</property-description>").optional()
+}

--- a/servers/api_rds_crm_com_v1/tsconfig.json
+++ b/servers/api_rds_crm_com_v1/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_rds_crm_com_v1`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_rds_crm_com_v1`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_rds_crm_com_v1": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_rds_crm_com_v1"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.