### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,493 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+X_API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {"API_KEY":"...","X_API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+- `X_API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### create_sshkey_sshkey_create_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `name` (string)
+- `ssh_key` (string)
+
+### view_user_sshkeys_sshkey_user_sshkeys_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### delete_sshkey_sshkey_key_id_delete
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `key_id` (integer)
+
+### get_floating_ips_by_user_organization_floating_ips_organization_
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### configure_reverse_dns_floating_ips_reverse_dns_configure_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `ip` (string)
+- `reverse_dns` (string)
+
+### configure_ddos_protection_floating_ips_ddos_protection_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `ip_address` (string)
+- `prefix` (integer)
+- `tcp_validation_level` (integer)
+- `tcp_validation_sym_level` (integer)
+- `udp_validation_level` (integer)
+- `fivem_protection_level` (integer)
+- `mc_java_protection_level` (integer)
+- `tls_validation_level` (integer)
+- `rdp_protection_level` (integer)
+
+### create_network_networks_create_network_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `name` (string)
+- `label` (other)
+- `location_name` (string)
+- `ip_range` (string)
+- `prefix` (integer)
+- `project_id` (integer)
+
+### update_network_networks_network_id_put
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `network_id` (integer)
+- `name` (other)
+- `label` (other)
+
+### delete_network_networks_network_id_delete
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `network_id` (integer)
+
+### create_vps_vps_create_project_id_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `project_id` (integer)
+- `label` (string)
+- `template_name` (string)
+- `plan_name` (string)
+- `location_name` (string)
+- `name` (string)
+- `ssh_key_name` (other)
+- `network_id` (other)
+- `user` (other)
+- `password` (other)
+
+### destroy_vps_vps_destroy_vps_id_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+
+### power_vps_vps_vps_id_power_power_type_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+- `power_type` (string)
+
+### resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+- `resize_plan` (string)
+
+### get_vnc_url_vps_vps_id_vnc_url_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+
+### reinstall_vps_vps_reinstall_vps_id_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+- `template_name` (string)
+
+### change_vps_password_vps_vps_id_change_password_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+- `password` (string)
+
+### update_vps_vps_update_vps_id_patch
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+- `label` (other)
+- `name` (other)
+
+### get_vps_metrics_vps_vps_id_metrics_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `vps_id` (integer)
+- `metrics` (other)
+- `time_range` (other)
+
+### list_countries_edge_acls_countries_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### list_prefix_lists_edge_acls_prefix_lists_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### create_prefix_list_edge_acls_prefix_lists_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `list_name` (string)
+
+### list_edge_acls_edge_acls_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### create_edge_acl_rule_edge_acls_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `src_ip` (string)
+- `src_prefixlen` (integer)
+- `src_prefix_uuid` (string)
+- `ip_proto` (integer)
+- `dest_ip` (string)
+- `dest_prefixlen` (integer)
+- `dst_port_start` (integer)
+- `dst_port_end` (integer)
+- `src_port_start` (integer)
+- `src_port_end` (integer)
+- `pkt_len_start` (integer)
+- `pkt_len_end` (integer)
+- `tcp_flags` (integer)
+- `action` (integer)
+- `rate_limit` (integer)
+- `comments` (string)
+
+### delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `prefix_list_uuid` (string)
+
+### add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `prefix_list_uuid` (string)
+- `cidr` (string)
+
+### delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `prefix_list_uuid` (string)
+- `cidr` (string)
+
+### delete_edge_acl_rule_edge_acls_rule_id_delete
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `rule_id` (integer)
+
+### get_attacks_ddos_attacks_attacks_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_attack_details_ddos_attacks_attacks_attack_id_details_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `attack_id` (integer)
+
+### get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+- `attack_id` (integer)
+
+### list_tunnels_tunnels_get
+
+**Environment variables**
+
+- `API_KEY`
+- `X_API_KEY`
+
+**Input schema**
+
+No input parameters

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,36 @@
+export const OPENAPI_URL = "https://api.cubepath.com/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/create_sshkey_sshkey_create_post/index.js",
+  "./tools/view_user_sshkeys_sshkey_user_sshkeys_get/index.js",
+  "./tools/delete_sshkey_sshkey_key_id_delete/index.js",
+  "./tools/get_floating_ips_by_user_organization_floating_ips_organization_/index.js",
+  "./tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/index.js",
+  "./tools/configure_ddos_protection_floating_ips_ddos_protection_post/index.js",
+  "./tools/create_network_networks_create_network_post/index.js",
+  "./tools/update_network_networks_network_id_put/index.js",
+  "./tools/delete_network_networks_network_id_delete/index.js",
+  "./tools/create_vps_vps_create_project_id_post/index.js",
+  "./tools/destroy_vps_vps_destroy_vps_id_post/index.js",
+  "./tools/power_vps_vps_vps_id_power_power_type_post/index.js",
+  "./tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/index.js",
+  "./tools/get_vnc_url_vps_vps_id_vnc_url_get/index.js",
+  "./tools/reinstall_vps_vps_reinstall_vps_id_post/index.js",
+  "./tools/change_vps_password_vps_vps_id_change_password_post/index.js",
+  "./tools/update_vps_vps_update_vps_id_patch/index.js",
+  "./tools/get_vps_metrics_vps_vps_id_metrics_get/index.js",
+  "./tools/list_countries_edge_acls_countries_get/index.js",
+  "./tools/list_prefix_lists_edge_acls_prefix_lists_get/index.js",
+  "./tools/create_prefix_list_edge_acls_prefix_lists_post/index.js",
+  "./tools/list_edge_acls_edge_acls_get/index.js",
+  "./tools/create_edge_acl_rule_edge_acls_post/index.js",
+  "./tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/index.js",
+  "./tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/index.js",
+  "./tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/index.js",
+  "./tools/delete_edge_acl_rule_edge_acls_rule_id_delete/index.js",
+  "./tools/get_attacks_ddos_attacks_attacks_get/index.js",
+  "./tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/index.js",
+  "./tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/index.js",
+  "./tools/list_tunnels_tunnels_get/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/index.ts
+++ b/servers/api_example_com/src/tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post",
+  "toolDescription": "Add Ip To Prefix List",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/prefix-lists/add-ip",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "prefix_list_uuid": "prefix_list_uuid",
+      "cidr": "cidr"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "prefix_list_uuid": {
+      "type": "string",
+      "title": "Prefix List Uuid"
+    },
+    "cidr": {
+      "type": "string",
+      "title": "Cidr"
+    }
+  },
+  "required": [
+    "prefix_list_uuid",
+    "cidr"
+  ]
+}

--- a/servers/api_example_com/src/tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/add_ip_to_prefix_list_edge_acls_prefix_lists_add_ip_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prefix_list_uuid": z.string(),
+  "cidr": z.string()
+}

--- a/servers/api_example_com/src/tools/change_vps_password_vps_vps_id_change_password_post/index.ts
+++ b/servers/api_example_com/src/tools/change_vps_password_vps_vps_id_change_password_post/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "change_vps_password_vps_vps_id_change_password_post",
+  "toolDescription": "Reset root password",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/{vps_id}/change-password",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id"
+    },
+    "body": {
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/change_vps_password_vps_vps_id_change_password_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/change_vps_password_vps_vps_id_change_password_post/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    },
+    "password": {
+      "type": "string",
+      "title": "Password",
+      "description": "New password must be at least 8 characters long."
+    }
+  },
+  "required": [
+    "vps_id",
+    "password"
+  ]
+}

--- a/servers/api_example_com/src/tools/change_vps_password_vps_vps_id_change_password_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/change_vps_password_vps_vps_id_change_password_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int(),
+  "password": z.string().describe("New password must be at least 8 characters long.")
+}

--- a/servers/api_example_com/src/tools/configure_ddos_protection_floating_ips_ddos_protection_post/index.ts
+++ b/servers/api_example_com/src/tools/configure_ddos_protection_floating_ips_ddos_protection_post/index.ts
@@ -1,0 +1,40 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "configure_ddos_protection_floating_ips_ddos_protection_post",
+  "toolDescription": "Configure DDoS protection",
+  "baseUrl": "https://api.example.com",
+  "path": "/floating_ips/ddos-protection",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "ip_address": "ip_address",
+      "prefix": "prefix",
+      "tcp_validation_level": "tcp_validation_level",
+      "tcp_validation_sym_level": "tcp_validation_sym_level",
+      "udp_validation_level": "udp_validation_level",
+      "fivem_protection_level": "fivem_protection_level",
+      "mc_java_protection_level": "mc_java_protection_level",
+      "tls_validation_level": "tls_validation_level",
+      "rdp_protection_level": "rdp_protection_level"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/configure_ddos_protection_floating_ips_ddos_protection_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/configure_ddos_protection_floating_ips_ddos_protection_post/schema-json/root.json
@@ -1,0 +1,77 @@
+{
+  "type": "object",
+  "properties": {
+    "ip_address": {
+      "type": "string",
+      "title": "Ip Address",
+      "description": "IP address to configure DDoS protection for"
+    },
+    "prefix": {
+      "type": "integer",
+      "maximum": 32,
+      "minimum": 1,
+      "title": "Prefix",
+      "description": "Prefix length (e.g., 32 for single IP, 24 for /24 subnet)",
+      "default": 32
+    },
+    "tcp_validation_level": {
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0,
+      "title": "Tcp Validation Level",
+      "description": "TCP validation level (0-1)"
+    },
+    "tcp_validation_sym_level": {
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0,
+      "title": "Tcp Validation Sym Level",
+      "description": "TCP Symmetric validation level (0-1)"
+    },
+    "udp_validation_level": {
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0,
+      "title": "Udp Validation Level",
+      "description": "UDP validation level (0-1)"
+    },
+    "fivem_protection_level": {
+      "type": "integer",
+      "maximum": 2,
+      "minimum": 0,
+      "title": "Fivem Protection Level",
+      "description": "FiveM protection level (0-2: 0=Disabled, 1=Layer7, 2=UDP+Layer7)"
+    },
+    "mc_java_protection_level": {
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0,
+      "title": "Mc Java Protection Level",
+      "description": "Minecraft Java protection level (0-1)"
+    },
+    "tls_validation_level": {
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0,
+      "title": "Tls Validation Level",
+      "description": "TLS validation level (0-1)"
+    },
+    "rdp_protection_level": {
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0,
+      "title": "Rdp Protection Level",
+      "description": "RDP protection level (0-1)"
+    }
+  },
+  "required": [
+    "ip_address",
+    "tcp_validation_level",
+    "tcp_validation_sym_level",
+    "udp_validation_level",
+    "fivem_protection_level",
+    "mc_java_protection_level",
+    "tls_validation_level",
+    "rdp_protection_level"
+  ]
+}

--- a/servers/api_example_com/src/tools/configure_ddos_protection_floating_ips_ddos_protection_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/configure_ddos_protection_floating_ips_ddos_protection_post/schema/root.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "ip_address": z.string().describe("IP address to configure DDoS protection for"),
+  "prefix": z.number().int().gte(1).lte(32).describe("Prefix length (e.g., 32 for single IP, 24 for /24 subnet)").optional(),
+  "tcp_validation_level": z.number().int().gte(0).lte(1).describe("TCP validation level (0-1)"),
+  "tcp_validation_sym_level": z.number().int().gte(0).lte(1).describe("TCP Symmetric validation level (0-1)"),
+  "udp_validation_level": z.number().int().gte(0).lte(1).describe("UDP validation level (0-1)"),
+  "fivem_protection_level": z.number().int().gte(0).lte(2).describe("FiveM protection level (0-2: 0=Disabled, 1=Layer7, 2=UDP+Layer7)"),
+  "mc_java_protection_level": z.number().int().gte(0).lte(1).describe("Minecraft Java protection level (0-1)"),
+  "tls_validation_level": z.number().int().gte(0).lte(1).describe("TLS validation level (0-1)"),
+  "rdp_protection_level": z.number().int().gte(0).lte(1).describe("RDP protection level (0-1)")
+}

--- a/servers/api_example_com/src/tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/index.ts
+++ b/servers/api_example_com/src/tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "configure_reverse_dns_floating_ips_reverse_dns_configure_post",
+  "toolDescription": "Configure reverse DNS",
+  "baseUrl": "https://api.example.com",
+  "path": "/floating_ips/reverse_dns/configure",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "ip": "ip",
+      "reverse_dns": "reverse_dns"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/schema-json/root.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "Floating IP address to configure reverse DNS for",
+      "type": "string",
+      "title": "Ip"
+    },
+    "reverse_dns": {
+      "description": "Reverse DNS hostname (e.g., 'myhost.example.com'). Leave empty to delete.",
+      "type": "string",
+      "default": "",
+      "title": "Reverse Dns"
+    }
+  },
+  "required": [
+    "ip"
+  ]
+}

--- a/servers/api_example_com/src/tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/configure_reverse_dns_floating_ips_reverse_dns_configure_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "ip": z.string().describe("Floating IP address to configure reverse DNS for"),
+  "reverse_dns": z.string().describe("Reverse DNS hostname (e.g., 'myhost.example.com'). Leave empty to delete.").optional()
+}

--- a/servers/api_example_com/src/tools/create_edge_acl_rule_edge_acls_post/index.ts
+++ b/servers/api_example_com/src/tools/create_edge_acl_rule_edge_acls_post/index.ts
@@ -1,0 +1,47 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_edge_acl_rule_edge_acls_post",
+  "toolDescription": "Create Edge Acl Rule",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "src_ip": "src_ip",
+      "src_prefixlen": "src_prefixlen",
+      "src_prefix_uuid": "src_prefix_uuid",
+      "ip_proto": "ip_proto",
+      "dest_ip": "dest_ip",
+      "dest_prefixlen": "dest_prefixlen",
+      "dst_port_start": "dst_port_start",
+      "dst_port_end": "dst_port_end",
+      "src_port_start": "src_port_start",
+      "src_port_end": "src_port_end",
+      "pkt_len_start": "pkt_len_start",
+      "pkt_len_end": "pkt_len_end",
+      "tcp_flags": "tcp_flags",
+      "action": "action",
+      "rate_limit": "rate_limit",
+      "comments": "comments"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/create_edge_acl_rule_edge_acls_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/create_edge_acl_rule_edge_acls_post/schema-json/root.json
@@ -1,0 +1,86 @@
+{
+  "type": "object",
+  "properties": {
+    "src_ip": {
+      "type": "string",
+      "default": "0.0.0.0",
+      "title": "Src Ip"
+    },
+    "src_prefixlen": {
+      "type": "integer",
+      "default": 0,
+      "title": "Src Prefixlen"
+    },
+    "src_prefix_uuid": {
+      "type": "string",
+      "default": "0",
+      "title": "Src Prefix Uuid"
+    },
+    "ip_proto": {
+      "type": "integer",
+      "default": 6,
+      "title": "Ip Proto"
+    },
+    "dest_ip": {
+      "type": "string",
+      "default": "",
+      "title": "Dest Ip"
+    },
+    "dest_prefixlen": {
+      "type": "integer",
+      "default": 0,
+      "title": "Dest Prefixlen"
+    },
+    "dst_port_start": {
+      "type": "integer",
+      "default": 0,
+      "title": "Dst Port Start"
+    },
+    "dst_port_end": {
+      "type": "integer",
+      "default": 65535,
+      "title": "Dst Port End"
+    },
+    "src_port_start": {
+      "type": "integer",
+      "default": 0,
+      "title": "Src Port Start"
+    },
+    "src_port_end": {
+      "type": "integer",
+      "default": 65535,
+      "title": "Src Port End"
+    },
+    "pkt_len_start": {
+      "type": "integer",
+      "default": 0,
+      "title": "Pkt Len Start"
+    },
+    "pkt_len_end": {
+      "type": "integer",
+      "default": 65535,
+      "title": "Pkt Len End"
+    },
+    "tcp_flags": {
+      "type": "integer",
+      "default": 0,
+      "title": "Tcp Flags"
+    },
+    "action": {
+      "type": "integer",
+      "default": 0,
+      "title": "Action"
+    },
+    "rate_limit": {
+      "type": "integer",
+      "default": 0,
+      "title": "Rate Limit"
+    },
+    "comments": {
+      "type": "string",
+      "default": "",
+      "title": "Comments"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/create_edge_acl_rule_edge_acls_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/create_edge_acl_rule_edge_acls_post/schema/root.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "src_ip": z.string().optional(),
+  "src_prefixlen": z.number().int().optional(),
+  "src_prefix_uuid": z.string().optional(),
+  "ip_proto": z.number().int().optional(),
+  "dest_ip": z.string().optional(),
+  "dest_prefixlen": z.number().int().optional(),
+  "dst_port_start": z.number().int().optional(),
+  "dst_port_end": z.number().int().optional(),
+  "src_port_start": z.number().int().optional(),
+  "src_port_end": z.number().int().optional(),
+  "pkt_len_start": z.number().int().optional(),
+  "pkt_len_end": z.number().int().optional(),
+  "tcp_flags": z.number().int().optional(),
+  "action": z.number().int().optional(),
+  "rate_limit": z.number().int().optional(),
+  "comments": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/create_network_networks_create_network_post/index.ts
+++ b/servers/api_example_com/src/tools/create_network_networks_create_network_post/index.ts
@@ -1,0 +1,37 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_network_networks_create_network_post",
+  "toolDescription": "Create private network",
+  "baseUrl": "https://api.example.com",
+  "path": "/networks/create_network",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "label": "label",
+      "location_name": "location_name",
+      "ip_range": "ip_range",
+      "prefix": "prefix",
+      "project_id": "project_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/create_network_networks_create_network_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/create_network_networks_create_network_post/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name"
+    },
+    "label": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Label"
+    },
+    "location_name": {
+      "type": "string",
+      "title": "Location Name"
+    },
+    "ip_range": {
+      "type": "string",
+      "title": "Ip Range"
+    },
+    "prefix": {
+      "type": "integer",
+      "title": "Prefix"
+    },
+    "project_id": {
+      "type": "integer",
+      "title": "Project Id"
+    }
+  },
+  "required": [
+    "name",
+    "location_name",
+    "ip_range",
+    "prefix",
+    "project_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/create_network_networks_create_network_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/create_network_networks_create_network_post/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string(),
+  "label": z.union([z.string(), z.null()]).optional(),
+  "location_name": z.string(),
+  "ip_range": z.string(),
+  "prefix": z.number().int(),
+  "project_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/create_prefix_list_edge_acls_prefix_lists_post/index.ts
+++ b/servers/api_example_com/src/tools/create_prefix_list_edge_acls_prefix_lists_post/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_prefix_list_edge_acls_prefix_lists_post",
+  "toolDescription": "Create Prefix List",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/prefix-lists/",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "list_name": "list_name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/create_prefix_list_edge_acls_prefix_lists_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/create_prefix_list_edge_acls_prefix_lists_post/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "list_name": {
+      "type": "string",
+      "title": "List Name"
+    }
+  },
+  "required": [
+    "list_name"
+  ]
+}

--- a/servers/api_example_com/src/tools/create_prefix_list_edge_acls_prefix_lists_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/create_prefix_list_edge_acls_prefix_lists_post/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "list_name": z.string()
+}

--- a/servers/api_example_com/src/tools/create_sshkey_sshkey_create_post/index.ts
+++ b/servers/api_example_com/src/tools/create_sshkey_sshkey_create_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_sshkey_sshkey_create_post",
+  "toolDescription": "Add SSH key",
+  "baseUrl": "https://api.example.com",
+  "path": "/sshkey/create",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "ssh_key": "ssh_key"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/create_sshkey_sshkey_create_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/create_sshkey_sshkey_create_post/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name"
+    },
+    "ssh_key": {
+      "type": "string",
+      "title": "Ssh Key"
+    }
+  },
+  "required": [
+    "name",
+    "ssh_key"
+  ]
+}

--- a/servers/api_example_com/src/tools/create_sshkey_sshkey_create_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/create_sshkey_sshkey_create_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string(),
+  "ssh_key": z.string()
+}

--- a/servers/api_example_com/src/tools/create_vps_vps_create_project_id_post/index.ts
+++ b/servers/api_example_com/src/tools/create_vps_vps_create_project_id_post/index.ts
@@ -1,0 +1,43 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_vps_vps_create_project_id_post",
+  "toolDescription": "Create new server",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/create/{project_id}",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "project_id": "project_id"
+    },
+    "body": {
+      "label": "label",
+      "template_name": "template_name",
+      "plan_name": "plan_name",
+      "location_name": "location_name",
+      "name": "name",
+      "ssh_key_name": "ssh_key_name",
+      "network_id": "network_id",
+      "user": "user",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/create_vps_vps_create_project_id_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/create_vps_vps_create_project_id_post/schema-json/root.json
@@ -1,0 +1,91 @@
+{
+  "type": "object",
+  "properties": {
+    "project_id": {
+      "type": "integer",
+      "title": "Project Id"
+    },
+    "label": {
+      "type": "string",
+      "title": "Label",
+      "example": "Production-Server"
+    },
+    "template_name": {
+      "type": "string",
+      "title": "Template Name",
+      "example": "Ubuntu 22"
+    },
+    "plan_name": {
+      "type": "string",
+      "title": "Plan Name",
+      "example": "rz.nano"
+    },
+    "location_name": {
+      "type": "string",
+      "title": "Location Name",
+      "example": "us-mia-1"
+    },
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "example": "my-vps-01"
+    },
+    "ssh_key_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Ssh Key Name",
+      "example": "my-ssh-key"
+    },
+    "network_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Network Id"
+    },
+    "user": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "User",
+      "description": "Will default to 'root' if empty.",
+      "example": ""
+    },
+    "password": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Password",
+      "description": "If empty, no root password is set. Minimum 8 characters if provided.",
+      "example": ""
+    }
+  },
+  "required": [
+    "project_id",
+    "label",
+    "template_name",
+    "plan_name",
+    "location_name",
+    "name"
+  ]
+}

--- a/servers/api_example_com/src/tools/create_vps_vps_create_project_id_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/create_vps_vps_create_project_id_post/schema/root.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "project_id": z.number().int(),
+  "label": z.string(),
+  "template_name": z.string(),
+  "plan_name": z.string(),
+  "location_name": z.string(),
+  "name": z.string(),
+  "ssh_key_name": z.union([z.string(), z.null()]).optional(),
+  "network_id": z.union([z.number().int(), z.null()]).optional(),
+  "user": z.union([z.string(), z.null()]).describe("Will default to 'root' if empty.").optional(),
+  "password": z.union([z.string(), z.null()]).describe("If empty, no root password is set. Minimum 8 characters if provided.").optional()
+}

--- a/servers/api_example_com/src/tools/delete_edge_acl_rule_edge_acls_rule_id_delete/index.ts
+++ b/servers/api_example_com/src/tools/delete_edge_acl_rule_edge_acls_rule_id_delete/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_edge_acl_rule_edge_acls_rule_id_delete",
+  "toolDescription": "Delete Edge Acl Rule",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/{rule_id}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "rule_id": "rule_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/delete_edge_acl_rule_edge_acls_rule_id_delete/schema-json/root.json
+++ b/servers/api_example_com/src/tools/delete_edge_acl_rule_edge_acls_rule_id_delete/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "rule_id": {
+      "type": "integer",
+      "title": "Rule Id"
+    }
+  },
+  "required": [
+    "rule_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/delete_edge_acl_rule_edge_acls_rule_id_delete/schema/root.ts
+++ b/servers/api_example_com/src/tools/delete_edge_acl_rule_edge_acls_rule_id_delete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "rule_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/index.ts
+++ b/servers/api_example_com/src/tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu",
+  "toolDescription": "Delete Ip From Prefix List",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/prefix-lists/{prefix_list_uuid}/ip",
+  "method": "delete",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "prefix_list_uuid": "prefix_list_uuid"
+    },
+    "query": {
+      "cidr": "cidr"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/schema-json/root.json
+++ b/servers/api_example_com/src/tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "prefix_list_uuid": {
+      "type": "string",
+      "title": "Prefix List Uuid"
+    },
+    "cidr": {
+      "type": "string",
+      "title": "Cidr"
+    }
+  },
+  "required": [
+    "prefix_list_uuid",
+    "cidr"
+  ]
+}

--- a/servers/api_example_com/src/tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/schema/root.ts
+++ b/servers/api_example_com/src/tools/delete_ip_from_prefix_list_edge_acls_prefix_lists_prefix_list_uu/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prefix_list_uuid": z.string(),
+  "cidr": z.string()
+}

--- a/servers/api_example_com/src/tools/delete_network_networks_network_id_delete/index.ts
+++ b/servers/api_example_com/src/tools/delete_network_networks_network_id_delete/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_network_networks_network_id_delete",
+  "toolDescription": "Delete network",
+  "baseUrl": "https://api.example.com",
+  "path": "/networks/{network_id}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "network_id": "network_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/delete_network_networks_network_id_delete/schema-json/root.json
+++ b/servers/api_example_com/src/tools/delete_network_networks_network_id_delete/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "network_id": {
+      "type": "integer",
+      "title": "Network Id"
+    }
+  },
+  "required": [
+    "network_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/delete_network_networks_network_id_delete/schema/root.ts
+++ b/servers/api_example_com/src/tools/delete_network_networks_network_id_delete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "network_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/index.ts
+++ b/servers/api_example_com/src/tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet",
+  "toolDescription": "Delete Prefix List",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/prefix-lists/{prefix_list_uuid}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "prefix_list_uuid": "prefix_list_uuid"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/schema-json/root.json
+++ b/servers/api_example_com/src/tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "prefix_list_uuid": {
+      "type": "string",
+      "title": "Prefix List Uuid"
+    }
+  },
+  "required": [
+    "prefix_list_uuid"
+  ]
+}

--- a/servers/api_example_com/src/tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/schema/root.ts
+++ b/servers/api_example_com/src/tools/delete_prefix_list_edge_acls_prefix_lists_prefix_list_uuid_delet/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "prefix_list_uuid": z.string()
+}

--- a/servers/api_example_com/src/tools/delete_sshkey_sshkey_key_id_delete/index.ts
+++ b/servers/api_example_com/src/tools/delete_sshkey_sshkey_key_id_delete/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_sshkey_sshkey_key_id_delete",
+  "toolDescription": "Delete SSH key",
+  "baseUrl": "https://api.example.com",
+  "path": "/sshkey/{key_id}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "key_id": "key_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/delete_sshkey_sshkey_key_id_delete/schema-json/root.json
+++ b/servers/api_example_com/src/tools/delete_sshkey_sshkey_key_id_delete/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "key_id": {
+      "type": "integer",
+      "title": "Key Id"
+    }
+  },
+  "required": [
+    "key_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/delete_sshkey_sshkey_key_id_delete/schema/root.ts
+++ b/servers/api_example_com/src/tools/delete_sshkey_sshkey_key_id_delete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "key_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/destroy_vps_vps_destroy_vps_id_post/index.ts
+++ b/servers/api_example_com/src/tools/destroy_vps_vps_destroy_vps_id_post/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "destroy_vps_vps_destroy_vps_id_post",
+  "toolDescription": "Delete server",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/destroy/{vps_id}",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/destroy_vps_vps_destroy_vps_id_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/destroy_vps_vps_destroy_vps_id_post/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    }
+  },
+  "required": [
+    "vps_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/destroy_vps_vps_destroy_vps_id_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/destroy_vps_vps_destroy_vps_id_post/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/index.ts
+++ b/servers/api_example_com/src/tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_attack_details_ddos_attacks_attacks_attack_id_details_get",
+  "toolDescription": "Get Attack Details",
+  "baseUrl": "https://api.example.com",
+  "path": "/ddos-attacks/attacks/{attack_id}/details",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "attack_id": "attack_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "attack_id": {
+      "type": "integer",
+      "title": "Attack Id"
+    }
+  },
+  "required": [
+    "attack_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_attack_details_ddos_attacks_attacks_attack_id_details_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "attack_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/index.ts
+++ b/servers/api_example_com/src/tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_",
+  "toolDescription": "Get Attack Traffic Graph",
+  "baseUrl": "https://api.example.com",
+  "path": "/ddos-attacks/attacks/{attack_id}/traffic-graph",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "attack_id": "attack_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "attack_id": {
+      "type": "integer",
+      "title": "Attack Id"
+    }
+  },
+  "required": [
+    "attack_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_attack_traffic_graph_ddos_attacks_attacks_attack_id_traffic_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "attack_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/get_attacks_ddos_attacks_attacks_get/index.ts
+++ b/servers/api_example_com/src/tools/get_attacks_ddos_attacks_attacks_get/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_attacks_ddos_attacks_attacks_get",
+  "toolDescription": "Get Attacks",
+  "baseUrl": "https://api.example.com",
+  "path": "/ddos-attacks/attacks",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_attacks_ddos_attacks_attacks_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_attacks_ddos_attacks_attacks_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_attacks_ddos_attacks_attacks_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_attacks_ddos_attacks_attacks_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/get_floating_ips_by_user_organization_floating_ips_organization_/index.ts
+++ b/servers/api_example_com/src/tools/get_floating_ips_by_user_organization_floating_ips_organization_/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_floating_ips_by_user_organization_floating_ips_organization_",
+  "toolDescription": "List floating IPs",
+  "baseUrl": "https://api.example.com",
+  "path": "/floating_ips/organization",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_floating_ips_by_user_organization_floating_ips_organization_/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_floating_ips_by_user_organization_floating_ips_organization_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_floating_ips_by_user_organization_floating_ips_organization_/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_floating_ips_by_user_organization_floating_ips_organization_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/get_vnc_url_vps_vps_id_vnc_url_get/index.ts
+++ b/servers/api_example_com/src/tools/get_vnc_url_vps_vps_id_vnc_url_get/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_vnc_url_vps_vps_id_vnc_url_get",
+  "toolDescription": "Get console access",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/{vps_id}/vnc-url",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_vnc_url_vps_vps_id_vnc_url_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_vnc_url_vps_vps_id_vnc_url_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    }
+  },
+  "required": [
+    "vps_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_vnc_url_vps_vps_id_vnc_url_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_vnc_url_vps_vps_id_vnc_url_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/get_vps_metrics_vps_vps_id_metrics_get/index.ts
+++ b/servers/api_example_com/src/tools/get_vps_metrics_vps_vps_id_metrics_get/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_vps_metrics_vps_vps_id_metrics_get",
+  "toolDescription": "View server metrics",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/{vps_id}/metrics",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id"
+    },
+    "query": {
+      "metrics": "metrics",
+      "time_range": "time_range"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_vps_metrics_vps_vps_id_metrics_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_vps_metrics_vps_vps_id_metrics_get/schema-json/root.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    },
+    "metrics": {
+      "description": "Comma-separated metrics",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Metrics"
+    },
+    "time_range": {
+      "description": "Time range like 1h, 7d, etc.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "1h",
+      "title": "Time Range"
+    }
+  },
+  "required": [
+    "vps_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_vps_metrics_vps_vps_id_metrics_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_vps_metrics_vps_vps_id_metrics_get/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int(),
+  "metrics": z.union([z.string(), z.null()]).describe("Comma-separated metrics").optional(),
+  "time_range": z.union([z.string(), z.null()]).describe("Time range like 1h, 7d, etc.").optional()
+}

--- a/servers/api_example_com/src/tools/list_countries_edge_acls_countries_get/index.ts
+++ b/servers/api_example_com/src/tools/list_countries_edge_acls_countries_get/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "list_countries_edge_acls_countries_get",
+  "toolDescription": "List Countries",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/countries",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/list_countries_edge_acls_countries_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/list_countries_edge_acls_countries_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/list_countries_edge_acls_countries_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/list_countries_edge_acls_countries_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/list_edge_acls_edge_acls_get/index.ts
+++ b/servers/api_example_com/src/tools/list_edge_acls_edge_acls_get/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "list_edge_acls_edge_acls_get",
+  "toolDescription": "List Edge Acls",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/list_edge_acls_edge_acls_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/list_edge_acls_edge_acls_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/list_edge_acls_edge_acls_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/list_edge_acls_edge_acls_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/list_prefix_lists_edge_acls_prefix_lists_get/index.ts
+++ b/servers/api_example_com/src/tools/list_prefix_lists_edge_acls_prefix_lists_get/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "list_prefix_lists_edge_acls_prefix_lists_get",
+  "toolDescription": "List Prefix Lists",
+  "baseUrl": "https://api.example.com",
+  "path": "/edge-acls/prefix-lists/",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/list_prefix_lists_edge_acls_prefix_lists_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/list_prefix_lists_edge_acls_prefix_lists_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/list_prefix_lists_edge_acls_prefix_lists_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/list_prefix_lists_edge_acls_prefix_lists_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/list_tunnels_tunnels_get/index.ts
+++ b/servers/api_example_com/src/tools/list_tunnels_tunnels_get/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "list_tunnels_tunnels_get",
+  "toolDescription": "List Tunnels",
+  "baseUrl": "https://api.example.com",
+  "path": "/tunnels/",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/list_tunnels_tunnels_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/list_tunnels_tunnels_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/list_tunnels_tunnels_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/list_tunnels_tunnels_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/src/tools/power_vps_vps_vps_id_power_power_type_post/index.ts
+++ b/servers/api_example_com/src/tools/power_vps_vps_vps_id_power_power_type_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "power_vps_vps_vps_id_power_power_type_post",
+  "toolDescription": "Control server power",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/{vps_id}/power/{power_type}",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id",
+      "power_type": "power_type"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/power_vps_vps_vps_id_power_power_type_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/power_vps_vps_vps_id_power_power_type_post/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    },
+    "power_type": {
+      "type": "string",
+      "enum": [
+        "start_vps",
+        "stop_vps",
+        "restart_vps"
+      ],
+      "title": "PowerTaskType"
+    }
+  },
+  "required": [
+    "vps_id",
+    "power_type"
+  ]
+}

--- a/servers/api_example_com/src/tools/power_vps_vps_vps_id_power_power_type_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/power_vps_vps_vps_id_power_power_type_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int(),
+  "power_type": z.enum(["start_vps","stop_vps","restart_vps"])
+}

--- a/servers/api_example_com/src/tools/reinstall_vps_vps_reinstall_vps_id_post/index.ts
+++ b/servers/api_example_com/src/tools/reinstall_vps_vps_reinstall_vps_id_post/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "reinstall_vps_vps_reinstall_vps_id_post",
+  "toolDescription": "Reinstall server OS",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/reinstall/{vps_id}",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id"
+    },
+    "body": {
+      "template_name": "template_name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/reinstall_vps_vps_reinstall_vps_id_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/reinstall_vps_vps_reinstall_vps_id_post/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    },
+    "template_name": {
+      "type": "string",
+      "title": "Template Name"
+    }
+  },
+  "required": [
+    "vps_id",
+    "template_name"
+  ]
+}

--- a/servers/api_example_com/src/tools/reinstall_vps_vps_reinstall_vps_id_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/reinstall_vps_vps_reinstall_vps_id_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int(),
+  "template_name": z.string()
+}

--- a/servers/api_example_com/src/tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/index.ts
+++ b/servers/api_example_com/src/tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post",
+  "toolDescription": "Upgrade/downgrade server",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/resize/vps_id/{vps_id}/resize_plan/{resize_plan}",
+  "method": "post",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id",
+      "resize_plan": "resize_plan"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    },
+    "resize_plan": {
+      "type": "string",
+      "title": "Resize Plan"
+    }
+  },
+  "required": [
+    "vps_id",
+    "resize_plan"
+  ]
+}

--- a/servers/api_example_com/src/tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/resize_vps_vps_resize_vps_id_vps_id_resize_plan_resize_plan_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int(),
+  "resize_plan": z.string()
+}

--- a/servers/api_example_com/src/tools/update_network_networks_network_id_put/index.ts
+++ b/servers/api_example_com/src/tools/update_network_networks_network_id_put/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "update_network_networks_network_id_put",
+  "toolDescription": "Update network settings",
+  "baseUrl": "https://api.example.com",
+  "path": "/networks/{network_id}",
+  "method": "put",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "network_id": "network_id"
+    },
+    "body": {
+      "name": "name",
+      "label": "label"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/update_network_networks_network_id_put/schema-json/root.json
+++ b/servers/api_example_com/src/tools/update_network_networks_network_id_put/schema-json/root.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "properties": {
+    "network_id": {
+      "type": "integer",
+      "title": "Network Id"
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Name"
+    },
+    "label": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Label"
+    }
+  },
+  "required": [
+    "network_id",
+    "name",
+    "label"
+  ]
+}

--- a/servers/api_example_com/src/tools/update_network_networks_network_id_put/schema/root.ts
+++ b/servers/api_example_com/src/tools/update_network_networks_network_id_put/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "network_id": z.number().int(),
+  "name": z.union([z.string(), z.null()]),
+  "label": z.union([z.string(), z.null()])
+}

--- a/servers/api_example_com/src/tools/update_vps_vps_update_vps_id_patch/index.ts
+++ b/servers/api_example_com/src/tools/update_vps_vps_update_vps_id_patch/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "update_vps_vps_update_vps_id_patch",
+  "toolDescription": "Update server details",
+  "baseUrl": "https://api.example.com",
+  "path": "/vps/update/{vps_id}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "vps_id": "vps_id"
+    },
+    "body": {
+      "label": "label",
+      "name": "name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/update_vps_vps_update_vps_id_patch/schema-json/root.json
+++ b/servers/api_example_com/src/tools/update_vps_vps_update_vps_id_patch/schema-json/root.json
@@ -1,0 +1,34 @@
+{
+  "type": "object",
+  "properties": {
+    "vps_id": {
+      "type": "integer",
+      "title": "Vps Id"
+    },
+    "label": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Label"
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Name"
+    }
+  },
+  "required": [
+    "vps_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/update_vps_vps_update_vps_id_patch/schema/root.ts
+++ b/servers/api_example_com/src/tools/update_vps_vps_update_vps_id_patch/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "vps_id": z.number().int(),
+  "label": z.union([z.string(), z.null()]).optional(),
+  "name": z.union([z.string(), z.null()]).optional()
+}

--- a/servers/api_example_com/src/tools/view_user_sshkeys_sshkey_user_sshkeys_get/index.ts
+++ b/servers/api_example_com/src/tools/view_user_sshkeys_sshkey_user_sshkeys_get/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "view_user_sshkeys_sshkey_user_sshkeys_get",
+  "toolDescription": "List SSH keys",
+  "baseUrl": "https://api.example.com",
+  "path": "/sshkey/user/sshkeys",
+  "method": "get",
+  "security": [
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    },
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/view_user_sshkeys_sshkey_user_sshkeys_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/view_user_sshkeys_sshkey_user_sshkeys_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/view_user_sshkeys_sshkey_user_sshkeys_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/view_user_sshkeys_sshkey_user_sshkeys_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.