### PR TITLE
Add MCP server `api_taskmanager_com_v1`

### DIFF
--- a/servers/api_taskmanager_com_v1/.npmignore
+++ b/servers/api_taskmanager_com_v1/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_taskmanager_com_v1/README.md
+++ b/servers/api_taskmanager_com_v1/README.md
@@ -1,0 +1,190 @@
+# @open-mcp/api_taskmanager_com_v1
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_taskmanager_com_v1": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_taskmanager_com_v1@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_taskmanager_com_v1@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_taskmanager_com_v1 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_taskmanager_com_v1 \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_taskmanager_com_v1 \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_taskmanager_com_v1": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_taskmanager_com_v1"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### gettasks
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `status` (string)
+- `limit` (integer)
+- `offset` (integer)
+
+### createtask
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `title` (string)
+- `description` (string)
+- `priority` (string)
+- `assigned_to` (string)
+- `due_date` (string)
+- `tags` (array)
+
+### gettask
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `taskId` (string)
+
+### updatetask
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `taskId` (string)
+- `title` (string)
+- `description` (string)
+- `status` (string)
+- `priority` (string)
+- `assigned_to` (string)
+- `due_date` (string)
+- `tags` (array)
+
+### deletetask
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `taskId` (string)
+
+### getusers
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### getuserprofile
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `userId` (string)
+
+### getusertasks
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `userId` (string)

--- a/servers/api_taskmanager_com_v1/package.json
+++ b/servers/api_taskmanager_com_v1/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_taskmanager_com_v1",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_taskmanager_com_v1": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_taskmanager_com_v1/src/constants.ts
+++ b/servers/api_taskmanager_com_v1/src/constants.ts
@@ -1,0 +1,13 @@
+export const OPENAPI_URL = "https://lsfwupgrade.oss-cn-hangzhou.aliyuncs.com/webstorage/products/nature/test/test1.json"
+export const SERVER_NAME = "api_taskmanager_com_v1"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/gettasks/index.js",
+  "./tools/createtask/index.js",
+  "./tools/gettask/index.js",
+  "./tools/updatetask/index.js",
+  "./tools/deletetask/index.js",
+  "./tools/getusers/index.js",
+  "./tools/getuserprofile/index.js",
+  "./tools/getusertasks/index.js"
+]

--- a/servers/api_taskmanager_com_v1/src/index.ts
+++ b/servers/api_taskmanager_com_v1/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_taskmanager_com_v1/src/server.ts
+++ b/servers/api_taskmanager_com_v1/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_taskmanager_com_v1/src/tools/createtask/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/createtask/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createtask",
+  "toolDescription": "Create a new task",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/tasks",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "title": "title",
+      "description": "description",
+      "priority": "priority",
+      "assigned_to": "assigned_to",
+      "due_date": "due_date",
+      "tags": "tags"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/createtask/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/createtask/schema-json/root.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "Task title",
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed description of the task",
+      "maxLength": 1000
+    },
+    "priority": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "urgent"
+      ],
+      "description": "Priority level of the task",
+      "default": "medium"
+    },
+    "assigned_to": {
+      "type": "string",
+      "format": "uuid",
+      "description": "ID of the user to assign this task to"
+    },
+    "due_date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Due date and time for the task"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Tags to associate with the task"
+    }
+  },
+  "required": [
+    "title"
+  ]
+}

--- a/servers/api_taskmanager_com_v1/src/tools/createtask/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/createtask/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "title": z.string().max(200).describe("Task title"),
+  "description": z.string().max(1000).describe("Detailed description of the task").optional(),
+  "priority": z.enum(["low","medium","high","urgent"]).describe("Priority level of the task").optional(),
+  "assigned_to": z.string().uuid().describe("ID of the user to assign this task to").optional(),
+  "due_date": z.string().datetime({ offset: true }).describe("Due date and time for the task").optional(),
+  "tags": z.array(z.string()).describe("Tags to associate with the task").optional()
+}

--- a/servers/api_taskmanager_com_v1/src/tools/deletetask/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/deletetask/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletetask",
+  "toolDescription": "Delete a task",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/tasks/{taskId}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "taskId": "taskId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/deletetask/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/deletetask/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "taskId": {
+      "description": "ID of the task to delete",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "taskId"
+  ]
+}

--- a/servers/api_taskmanager_com_v1/src/tools/deletetask/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/deletetask/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "taskId": z.string().uuid().describe("ID of the task to delete")
+}

--- a/servers/api_taskmanager_com_v1/src/tools/gettask/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/gettask/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettask",
+  "toolDescription": "Get a specific task",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/tasks/{taskId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "taskId": "taskId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/gettask/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/gettask/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "taskId": {
+      "description": "ID of the task to retrieve",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "taskId"
+  ]
+}

--- a/servers/api_taskmanager_com_v1/src/tools/gettask/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/gettask/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "taskId": z.string().uuid().describe("ID of the task to retrieve")
+}

--- a/servers/api_taskmanager_com_v1/src/tools/gettasks/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/gettasks/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettasks",
+  "toolDescription": "Get all tasks",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/tasks",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "status": "status",
+      "limit": "limit",
+      "offset": "offset"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/gettasks/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/gettasks/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "description": "Filter tasks by status",
+      "type": "string",
+      "enum": [
+        "pending",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "limit": {
+      "description": "Number of tasks to return",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20
+    },
+    "offset": {
+      "description": "Number of tasks to skip",
+      "type": "integer",
+      "minimum": 0,
+      "default": 0
+    }
+  },
+  "required": []
+}

--- a/servers/api_taskmanager_com_v1/src/tools/gettasks/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/gettasks/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "status": z.enum(["pending","in_progress","completed","cancelled"]).describe("Filter tasks by status").optional(),
+  "limit": z.number().int().gte(1).lte(100).describe("Number of tasks to return").optional(),
+  "offset": z.number().int().gte(0).describe("Number of tasks to skip").optional()
+}

--- a/servers/api_taskmanager_com_v1/src/tools/getuserprofile/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/getuserprofile/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getuserprofile",
+  "toolDescription": "Get user profile",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/users/{userId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/getuserprofile/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/getuserprofile/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the user",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "userId"
+  ]
+}

--- a/servers/api_taskmanager_com_v1/src/tools/getuserprofile/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/getuserprofile/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the user")
+}

--- a/servers/api_taskmanager_com_v1/src/tools/getusers/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/getusers/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getusers",
+  "toolDescription": "Get all users",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/users",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/getusers/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/getusers/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_taskmanager_com_v1/src/tools/getusers/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/getusers/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_taskmanager_com_v1/src/tools/getusertasks/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/getusertasks/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getusertasks",
+  "toolDescription": "Get user's tasks",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/users/{userId}/tasks",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "userId": "userId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/getusertasks/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/getusertasks/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "userId": {
+      "description": "ID of the user",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "userId"
+  ]
+}

--- a/servers/api_taskmanager_com_v1/src/tools/getusertasks/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/getusertasks/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "userId": z.string().uuid().describe("ID of the user")
+}

--- a/servers/api_taskmanager_com_v1/src/tools/updatetask/index.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/updatetask/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "updatetask",
+  "toolDescription": "Update a task",
+  "baseUrl": "https://api.taskmanager.com/v1",
+  "path": "/tasks/{taskId}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "taskId": "taskId"
+    },
+    "body": {
+      "title": "title",
+      "description": "description",
+      "status": "status",
+      "priority": "priority",
+      "assigned_to": "assigned_to",
+      "due_date": "due_date",
+      "tags": "tags"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_taskmanager_com_v1/src/tools/updatetask/schema-json/root.json
+++ b/servers/api_taskmanager_com_v1/src/tools/updatetask/schema-json/root.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "taskId": {
+      "description": "ID of the task to update",
+      "type": "string",
+      "format": "uuid"
+    },
+    "title": {
+      "type": "string",
+      "description": "Task title",
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed description of the task",
+      "maxLength": 1000
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ],
+      "description": "Current status of the task"
+    },
+    "priority": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "urgent"
+      ],
+      "description": "Priority level of the task"
+    },
+    "assigned_to": {
+      "type": "string",
+      "format": "uuid",
+      "description": "ID of the user to assign this task to"
+    },
+    "due_date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Due date and time for the task"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Tags to associate with the task"
+    }
+  },
+  "required": [
+    "taskId"
+  ]
+}

--- a/servers/api_taskmanager_com_v1/src/tools/updatetask/schema/root.ts
+++ b/servers/api_taskmanager_com_v1/src/tools/updatetask/schema/root.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "taskId": z.string().uuid().describe("ID of the task to update"),
+  "title": z.string().max(200).describe("Task title").optional(),
+  "description": z.string().max(1000).describe("Detailed description of the task").optional(),
+  "status": z.enum(["pending","in_progress","completed","cancelled"]).describe("Current status of the task").optional(),
+  "priority": z.enum(["low","medium","high","urgent"]).describe("Priority level of the task").optional(),
+  "assigned_to": z.string().uuid().describe("ID of the user to assign this task to").optional(),
+  "due_date": z.string().datetime({ offset: true }).describe("Due date and time for the task").optional(),
+  "tags": z.array(z.string()).describe("Tags to associate with the task").optional()
+}

--- a/servers/api_taskmanager_com_v1/tsconfig.json
+++ b/servers/api_taskmanager_com_v1/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_taskmanager_com_v1`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_taskmanager_com_v1`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_taskmanager_com_v1": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_taskmanager_com_v1"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.