### PR TITLE
Add MCP server `h_test2`

### DIFF
--- a/servers/h_test2/.npmignore
+++ b/servers/h_test2/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/h_test2/README.md
+++ b/servers/h_test2/README.md
@@ -1,0 +1,153 @@
+# @open-mcp/h_test2
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "h_test2": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/h_test2@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/h_test2@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add h_test2 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add h_test2 \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add h_test2 \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "h_test2": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/h_test2"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### processvoicecommand
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `text` (string)
+- `userId` (string)
+- `context` (object)
+
+### controldevice
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `deviceId` (string)
+- `action` (string)
+- `parameters` (object)
+
+### controldevicegroup
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `action` (string)
+- `deviceIds` (array)
+- `parameters` (object)
+
+### listdevices
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### executescene
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `sceneName` (string)
+- `parameters` (object)

--- a/servers/h_test2/package.json
+++ b/servers/h_test2/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/h_test2",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "h_test2": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/h_test2/src/constants.ts
+++ b/servers/h_test2/src/constants.ts
@@ -1,0 +1,10 @@
+export const OPENAPI_URL = "https://lsfwupgrade.oss-cn-hangzhou.aliyuncs.com/webstorage/products/nature/test/test2.json"
+export const SERVER_NAME = "h_test2"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/processvoicecommand/index.js",
+  "./tools/controldevice/index.js",
+  "./tools/controldevicegroup/index.js",
+  "./tools/listdevices/index.js",
+  "./tools/executescene/index.js"
+]

--- a/servers/h_test2/src/index.ts
+++ b/servers/h_test2/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/h_test2/src/server.ts
+++ b/servers/h_test2/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/h_test2/src/tools/controldevice/index.ts
+++ b/servers/h_test2/src/tools/controldevice/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "controldevice",
+  "toolDescription": "控制单个设备",
+  "baseUrl": "https://api.smarthome.com/v1",
+  "path": "/devices/{deviceId}/control",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "deviceId": "deviceId"
+    },
+    "body": {
+      "action": "action",
+      "parameters": "parameters"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/h_test2/src/tools/controldevice/schema-json/properties/parameters.json
+++ b/servers/h_test2/src/tools/controldevice/schema-json/properties/parameters.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "value": {
+      "type": "number",
+      "description": "设置值（如温度）"
+    },
+    "unit": {
+      "type": "string",
+      "description": "数值单位"
+    }
+  }
+}

--- a/servers/h_test2/src/tools/controldevice/schema-json/root.json
+++ b/servers/h_test2/src/tools/controldevice/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "deviceId": {
+      "description": "设备唯一标识符",
+      "type": "string"
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "TURN_ON",
+        "TURN_OFF",
+        "SET_VALUE"
+      ],
+      "description": "控制动作"
+    },
+    "parameters": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `parameters` to the tool, first call the tool `expandSchema` with \"/properties/parameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "deviceId",
+    "action"
+  ]
+}

--- a/servers/h_test2/src/tools/controldevice/schema/properties/parameters.ts
+++ b/servers/h_test2/src/tools/controldevice/schema/properties/parameters.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "value": z.number().describe("设置值（如温度）").optional(),
+  "unit": z.string().describe("数值单位").optional()
+}

--- a/servers/h_test2/src/tools/controldevice/schema/root.ts
+++ b/servers/h_test2/src/tools/controldevice/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "deviceId": z.string().describe("设备唯一标识符"),
+  "action": z.enum(["TURN_ON","TURN_OFF","SET_VALUE"]).describe("控制动作"),
+  "parameters": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `parameters` to the tool, first call the tool `expandSchema` with \"/properties/parameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/h_test2/src/tools/controldevicegroup/index.ts
+++ b/servers/h_test2/src/tools/controldevicegroup/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "controldevicegroup",
+  "toolDescription": "设备组控制",
+  "baseUrl": "https://api.smarthome.com/v1",
+  "path": "/devices/group-control",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "action": "action",
+      "deviceIds": "deviceIds",
+      "parameters": "parameters"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/h_test2/src/tools/controldevicegroup/schema-json/properties/parameters.json
+++ b/servers/h_test2/src/tools/controldevicegroup/schema-json/properties/parameters.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "properties": {}
+}

--- a/servers/h_test2/src/tools/controldevicegroup/schema-json/root.json
+++ b/servers/h_test2/src/tools/controldevicegroup/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "TURN_ON",
+        "TURN_OFF",
+        "SET_VALUE"
+      ]
+    },
+    "deviceIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "parameters": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `parameters` to the tool, first call the tool `expandSchema` with \"/properties/parameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "action",
+    "deviceIds"
+  ]
+}

--- a/servers/h_test2/src/tools/controldevicegroup/schema/properties/parameters.ts
+++ b/servers/h_test2/src/tools/controldevicegroup/schema/properties/parameters.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/h_test2/src/tools/controldevicegroup/schema/root.ts
+++ b/servers/h_test2/src/tools/controldevicegroup/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action": z.enum(["TURN_ON","TURN_OFF","SET_VALUE"]),
+  "deviceIds": z.array(z.string()).min(1),
+  "parameters": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `parameters` to the tool, first call the tool `expandSchema` with \"/properties/parameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/h_test2/src/tools/executescene/index.ts
+++ b/servers/h_test2/src/tools/executescene/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "executescene",
+  "toolDescription": "执行场景模式",
+  "baseUrl": "https://api.smarthome.com/v1",
+  "path": "/scenes",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "sceneName": "sceneName",
+      "parameters": "parameters"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/h_test2/src/tools/executescene/schema-json/properties/parameters.json
+++ b/servers/h_test2/src/tools/executescene/schema-json/properties/parameters.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "description": "场景参数",
+  "properties": {}
+}

--- a/servers/h_test2/src/tools/executescene/schema-json/root.json
+++ b/servers/h_test2/src/tools/executescene/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "sceneName": {
+      "type": "string",
+      "example": "回家模式",
+      "description": "场景名称"
+    },
+    "parameters": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `parameters` to the tool, first call the tool `expandSchema` with \"/properties/parameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>场景参数</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "sceneName"
+  ]
+}

--- a/servers/h_test2/src/tools/executescene/schema/properties/parameters.ts
+++ b/servers/h_test2/src/tools/executescene/schema/properties/parameters.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/h_test2/src/tools/executescene/schema/root.ts
+++ b/servers/h_test2/src/tools/executescene/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "sceneName": z.string().describe("场景名称"),
+  "parameters": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `parameters` to the tool, first call the tool `expandSchema` with \"/properties/parameters\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>场景参数</property-description>").optional()
+}

--- a/servers/h_test2/src/tools/listdevices/index.ts
+++ b/servers/h_test2/src/tools/listdevices/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "listdevices",
+  "toolDescription": "获取设备列表",
+  "baseUrl": "https://api.smarthome.com/v1",
+  "path": "/devices",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/h_test2/src/tools/listdevices/schema-json/root.json
+++ b/servers/h_test2/src/tools/listdevices/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/h_test2/src/tools/listdevices/schema/root.ts
+++ b/servers/h_test2/src/tools/listdevices/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/h_test2/src/tools/processvoicecommand/index.ts
+++ b/servers/h_test2/src/tools/processvoicecommand/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "processvoicecommand",
+  "toolDescription": "处理语音指令",
+  "baseUrl": "https://api.smarthome.com/v1",
+  "path": "/voice-commands",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "text": "text",
+      "userId": "userId",
+      "context": "context"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/h_test2/src/tools/processvoicecommand/schema-json/properties/context.json
+++ b/servers/h_test2/src/tools/processvoicecommand/schema-json/properties/context.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "location": {
+      "type": "string",
+      "description": "用户当前位置"
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "请求时间"
+    },
+    "preferences": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `preferences` to the tool, first call the tool `expandSchema` with \"/properties/context/properties/preferences\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>用户偏好设置</property-description>",
+      "additionalProperties": true
+    }
+  }
+}

--- a/servers/h_test2/src/tools/processvoicecommand/schema-json/properties/context/properties/preferences.json
+++ b/servers/h_test2/src/tools/processvoicecommand/schema-json/properties/context/properties/preferences.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "description": "用户偏好设置",
+  "properties": {}
+}

--- a/servers/h_test2/src/tools/processvoicecommand/schema-json/root.json
+++ b/servers/h_test2/src/tools/processvoicecommand/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string",
+      "example": "打开客厅空调并调到25度",
+      "description": "用户语音指令文本"
+    },
+    "userId": {
+      "type": "string",
+      "description": "用户唯一标识"
+    },
+    "context": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `context` to the tool, first call the tool `expandSchema` with \"/properties/context\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "text",
+    "userId"
+  ]
+}

--- a/servers/h_test2/src/tools/processvoicecommand/schema/properties/context.ts
+++ b/servers/h_test2/src/tools/processvoicecommand/schema/properties/context.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "location": z.string().describe("用户当前位置").optional(),
+  "time": z.string().datetime({ offset: true }).describe("请求时间").optional(),
+  "preferences": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `preferences` to the tool, first call the tool `expandSchema` with \"/properties/context/properties/preferences\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>用户偏好设置</property-description>").optional()
+}

--- a/servers/h_test2/src/tools/processvoicecommand/schema/properties/context/properties/preferences.ts
+++ b/servers/h_test2/src/tools/processvoicecommand/schema/properties/context/properties/preferences.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/h_test2/src/tools/processvoicecommand/schema/root.ts
+++ b/servers/h_test2/src/tools/processvoicecommand/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "text": z.string().describe("用户语音指令文本"),
+  "userId": z.string().describe("用户唯一标识"),
+  "context": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `context` to the tool, first call the tool `expandSchema` with \"/properties/context\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/h_test2/tsconfig.json
+++ b/servers/h_test2/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `h_test2`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/h_test2`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "h_test2": {
      "command": "npx",
      "args": ["-y", "@open-mcp/h_test2"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.