### PR TITLE
Add MCP server `api_prismacloud_io`

### DIFF
--- a/servers/api_prismacloud_io/.npmignore
+++ b/servers/api_prismacloud_io/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_prismacloud_io/README.md
+++ b/servers/api_prismacloud_io/README.md
@@ -1,0 +1,224 @@
+# @open-mcp/api_prismacloud_io
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_prismacloud_io": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_prismacloud_io@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_prismacloud_io@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_prismacloud_io \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_prismacloud_io \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_prismacloud_io \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_prismacloud_io": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_prismacloud_io"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### list_action_plans
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `x-redlock-auth` (string)
+
+### update_an_action_plan
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action-plan-id` (string)
+- `x-redlock-auth` (string)
+
+### update_an_action_plan_feedback
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action-plan-id` (string)
+- `x-redlock-auth` (string)
+
+### recommendation_summary_action_plan
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action-plan-id` (string)
+- `x-redlock-auth` (string)
+
+### action_plan_related_alerts
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action-plan-id` (string)
+- `limit` (integer)
+- `next_page_token` (string)
+- `x-redlock-auth` (string)
+
+### action_plan_impacted_assets
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action-plan-id` (string)
+- `limit` (integer)
+- `next_page_token` (string)
+- `x-redlock-auth` (string)
+
+### action_plan_notification_service
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action-plan-id` (string)
+- `x-redlock-auth` (string)
+
+### get_action_plan_names
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `x-redlock-auth` (string)
+
+### list_action_plans_names
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `x-redlock-auth` (string)
+
+### action_plan_business_criticality_assets
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `x-redlock-auth` (string)
+
+### action_plan_set_asset_criticality
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `x-redlock-auth` (string)
+
+### action_plan_check_asset_criticality
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `asset-id` (string)
+- `x-redlock-auth` (string)

--- a/servers/api_prismacloud_io/package.json
+++ b/servers/api_prismacloud_io/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_prismacloud_io",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_prismacloud_io": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_prismacloud_io/src/constants.ts
+++ b/servers/api_prismacloud_io/src/constants.ts
@@ -1,0 +1,17 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/PaloAltoNetworks/pan.dev/refs/heads/master/openapi-specs/action-plan/arya-action-plan.yml"
+export const SERVER_NAME = "api_prismacloud_io"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/list_action_plans/index.js",
+  "./tools/update_an_action_plan/index.js",
+  "./tools/update_an_action_plan_feedback/index.js",
+  "./tools/recommendation_summary_action_plan/index.js",
+  "./tools/action_plan_related_alerts/index.js",
+  "./tools/action_plan_impacted_assets/index.js",
+  "./tools/action_plan_notification_service/index.js",
+  "./tools/get_action_plan_names/index.js",
+  "./tools/list_action_plans_names/index.js",
+  "./tools/action_plan_business_criticality_assets/index.js",
+  "./tools/action_plan_set_asset_criticality/index.js",
+  "./tools/action_plan_check_asset_criticality/index.js"
+]

--- a/servers/api_prismacloud_io/src/index.ts
+++ b/servers/api_prismacloud_io/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_prismacloud_io/src/server.ts
+++ b/servers/api_prismacloud_io/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_business_criticality_assets/index.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_business_criticality_assets/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "action_plan_business_criticality_assets",
+  "toolDescription": "List Filtered Critical Assets",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/critical-asset",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/action_plan_business_criticality_assets/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/action_plan_business_criticality_assets/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_business_criticality_assets/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_business_criticality_assets/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_check_asset_criticality/index.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_check_asset_criticality/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "action_plan_check_asset_criticality",
+  "toolDescription": "Check Asset Criticality",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/asset-criticality/{asset-id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "asset-id": "asset-id"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/action_plan_check_asset_criticality/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/action_plan_check_asset_criticality/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "asset-id": {
+      "description": "asset id",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "asset-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_check_asset_criticality/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_check_asset_criticality/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "asset-id": z.string().describe("asset id"),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_impacted_assets/index.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_impacted_assets/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "action_plan_impacted_assets",
+  "toolDescription": "List Impacted Assets",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/{action-plan-id}/impacted-assets",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "action-plan-id": "action-plan-id"
+    },
+    "query": {
+      "limit": "limit",
+      "next_page_token": "next_page_token"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/action_plan_impacted_assets/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/action_plan_impacted_assets/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "action-plan-id": {
+      "description": "action plan id",
+      "type": "string"
+    },
+    "limit": {
+      "description": "page limit, default 100",
+      "type": "integer"
+    },
+    "next_page_token": {
+      "description": "page token",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action-plan-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_impacted_assets/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_impacted_assets/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action-plan-id": z.string().describe("action plan id"),
+  "limit": z.number().int().describe("page limit, default 100").optional(),
+  "next_page_token": z.string().describe("page token").optional(),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_notification_service/index.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_notification_service/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "action_plan_notification_service",
+  "toolDescription": "Send Notification",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/{action-plan-id}/notification/ondemand",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "action-plan-id": "action-plan-id"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/action_plan_notification_service/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/action_plan_notification_service/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "action-plan-id": {
+      "description": "action plan id",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action-plan-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_notification_service/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_notification_service/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action-plan-id": z.string().describe("action plan id"),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_related_alerts/index.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_related_alerts/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "action_plan_related_alerts",
+  "toolDescription": "List Related Alerts",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/{action-plan-id}/related-alerts",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "action-plan-id": "action-plan-id"
+    },
+    "query": {
+      "limit": "limit",
+      "next_page_token": "next_page_token"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/action_plan_related_alerts/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/action_plan_related_alerts/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "action-plan-id": {
+      "description": "action plan id",
+      "type": "string"
+    },
+    "limit": {
+      "description": "page limit, default 100",
+      "type": "integer"
+    },
+    "next_page_token": {
+      "description": "page token",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action-plan-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_related_alerts/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_related_alerts/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action-plan-id": z.string().describe("action plan id"),
+  "limit": z.number().int().describe("page limit, default 100").optional(),
+  "next_page_token": z.string().describe("page token").optional(),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_set_asset_criticality/index.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_set_asset_criticality/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "action_plan_set_asset_criticality",
+  "toolDescription": "Set Asset Criticality",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/asset-criticality",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/action_plan_set_asset_criticality/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/action_plan_set_asset_criticality/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/action_plan_set_asset_criticality/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/action_plan_set_asset_criticality/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/get_action_plan_names/index.ts
+++ b/servers/api_prismacloud_io/src/tools/get_action_plan_names/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_action_plan_names",
+  "toolDescription": "List Action Plan Names",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/names",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/get_action_plan_names/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/get_action_plan_names/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/get_action_plan_names/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/get_action_plan_names/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/list_action_plans/index.ts
+++ b/servers/api_prismacloud_io/src/tools/list_action_plans/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "list_action_plans",
+  "toolDescription": "List Action Plans",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/list_action_plans/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/list_action_plans/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/list_action_plans/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/list_action_plans/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/list_action_plans_names/index.ts
+++ b/servers/api_prismacloud_io/src/tools/list_action_plans_names/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "list_action_plans_names",
+  "toolDescription": "Suggest Filters",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/filter/action-plan/suggest",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/list_action_plans_names/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/list_action_plans_names/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/list_action_plans_names/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/list_action_plans_names/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/recommendation_summary_action_plan/index.ts
+++ b/servers/api_prismacloud_io/src/tools/recommendation_summary_action_plan/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "recommendation_summary_action_plan",
+  "toolDescription": "Recommendation Summary",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/{action-plan-id}/recommendation-summary",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "action-plan-id": "action-plan-id"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/recommendation_summary_action_plan/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/recommendation_summary_action_plan/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "action-plan-id": {
+      "description": "action plan id",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action-plan-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/recommendation_summary_action_plan/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/recommendation_summary_action_plan/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action-plan-id": z.string().describe("action plan id"),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/update_an_action_plan/index.ts
+++ b/servers/api_prismacloud_io/src/tools/update_an_action_plan/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "update_an_action_plan",
+  "toolDescription": "Update Action Plan Status or Assignee",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/{action-plan-id}/status-assignee",
+  "method": "patch",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "action-plan-id": "action-plan-id"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/update_an_action_plan/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/update_an_action_plan/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "action-plan-id": {
+      "description": "action plan id",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action-plan-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/update_an_action_plan/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/update_an_action_plan/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action-plan-id": z.string().describe("action plan id"),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/src/tools/update_an_action_plan_feedback/index.ts
+++ b/servers/api_prismacloud_io/src/tools/update_an_action_plan_feedback/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "update_an_action_plan_feedback",
+  "toolDescription": "Update Action Plan Feedback",
+  "baseUrl": "https://api.prismacloud.io",
+  "path": "/apm/api/v1/action-plan/{action-plan-id}/feedback",
+  "method": "patch",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "action-plan-id": "action-plan-id"
+    },
+    "header": {
+      "x-redlock-auth": "x-redlock-auth"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_prismacloud_io/src/tools/update_an_action_plan_feedback/schema-json/root.json
+++ b/servers/api_prismacloud_io/src/tools/update_an_action_plan_feedback/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "action-plan-id": {
+      "description": "action plan id",
+      "type": "string"
+    },
+    "x-redlock-auth": {
+      "description": "Authorize using Authentication token",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action-plan-id",
+    "x-redlock-auth"
+  ]
+}

--- a/servers/api_prismacloud_io/src/tools/update_an_action_plan_feedback/schema/root.ts
+++ b/servers/api_prismacloud_io/src/tools/update_an_action_plan_feedback/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action-plan-id": z.string().describe("action plan id"),
+  "x-redlock-auth": z.string().describe("Authorize using Authentication token")
+}

--- a/servers/api_prismacloud_io/tsconfig.json
+++ b/servers/api_prismacloud_io/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_prismacloud_io`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_prismacloud_io`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_prismacloud_io": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_prismacloud_io"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.