### PR TITLE
Add MCP server `encharge`

### DIFF
--- a/servers/encharge/.npmignore
+++ b/servers/encharge/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/encharge/README.md
+++ b/servers/encharge/README.md
@@ -1,0 +1,266 @@
+# @open-mcp/encharge
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "encharge": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/encharge@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/encharge@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+OAUTH2_TOKEN='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add encharge \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add encharge \
+  .cursor/mcp.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add encharge \
+  /path/to/client/config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "encharge": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/encharge"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `OAUTH2_TOKEN` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### createwebhook
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `eventType` (string)
+- `targetUrl` (string)
+
+### archivepeople
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `people` (object)
+- `force` (boolean)
+
+### getspecificpeople
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `people` (object)
+
+### createupdatepeople
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### getinfo
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### deletewebhook
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (number)
+
+### getfields
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### createfields
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### editfield
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `fieldName` (string)
+- `name` (string)
+- `title` (string)
+- `type` (string)
+- `format` (string)
+- `readOnly` (boolean)
+- `tooltip` (string)
+- `icon` (string)
+- `array` (boolean)
+- `canMapFrom` (boolean)
+- `firstClassField` (boolean)
+- `createdBy` (other)
+
+### deletefield
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `fieldName` (string)
+
+### getsegments
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### getpeopleinsegment
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `segmentId` (number)
+- `limit` (number)
+- `offset` (number)
+- `attributes` (array)
+- `sort` (string)
+- `order` (string)
+
+### addtag
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### removetag
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### unsubscribeperson
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `email` (string)
+- `userId` (string)
+- `id` (string)

--- a/servers/encharge/package.json
+++ b/servers/encharge/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/encharge",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "encharge": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/encharge/src/constants.ts
+++ b/servers/encharge/src/constants.ts
@@ -1,0 +1,20 @@
+export const OPENAPI_URL = "https://encharge-app-resources.s3.amazonaws.com/merged.yaml"
+export const SERVER_NAME = "encharge"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/createwebhook/index.js",
+  "./tools/archivepeople/index.js",
+  "./tools/getspecificpeople/index.js",
+  "./tools/createupdatepeople/index.js",
+  "./tools/getinfo/index.js",
+  "./tools/deletewebhook/index.js",
+  "./tools/getfields/index.js",
+  "./tools/createfields/index.js",
+  "./tools/editfield/index.js",
+  "./tools/deletefield/index.js",
+  "./tools/getsegments/index.js",
+  "./tools/getpeopleinsegment/index.js",
+  "./tools/addtag/index.js",
+  "./tools/removetag/index.js",
+  "./tools/unsubscribeperson/index.js"
+]

--- a/servers/encharge/src/index.ts
+++ b/servers/encharge/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/encharge/src/server.ts
+++ b/servers/encharge/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/encharge/src/tools/addtag/index.ts
+++ b/servers/encharge/src/tools/addtag/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "addtag",
+  "toolDescription": "Add tag(s) to an existing user.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/tags",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/addtag/schema-json/root.json
+++ b/servers/encharge/src/tools/addtag/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/addtag/schema/root.ts
+++ b/servers/encharge/src/tools/addtag/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/archivepeople/index.ts
+++ b/servers/encharge/src/tools/archivepeople/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "archivepeople",
+  "toolDescription": "Archive or delete one or multiple people.\n\nArchiving is the preferred method of removing users in Encharge.\n\nAlternatively, you can delete a person and all their data for GDPR purposes.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/people",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "people": "people",
+      "force": "force"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/archivepeople/schema-json/properties/people.json
+++ b/servers/encharge/src/tools/archivepeople/schema-json/properties/people.json
@@ -1,0 +1,19 @@
+{
+  "description": "People can be specified by any ID. \nFor example, for a person with an email `slav@encharge.io` use the following query: \n\n`?people[0][email]=slav@encharge.io`\n\nFor multiple people, pass multiple ids in the query like so:\n\n`?people[0][userId]=abc&people[1][userId]=xyz`. \n\nThis will specify people who have userId of `abc` and `xyz`.\n\nEmails, userIds and other IDs can used together in a single query.\n",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Encharge ID of the person. An UUID.\n\nAt least one of id/userId/email must be specified."
+    },
+    "userId": {
+      "type": "string",
+      "description": "UserID of the person.\n\nAt least one of id/userId/email must be specified."
+    },
+    "email": {
+      "type": "string",
+      "description": "Email of the person.\n\nAt least one of id/userId/email must be specified."
+    }
+  },
+  "additionalProperties": {},
+  "type": "object"
+}

--- a/servers/encharge/src/tools/archivepeople/schema-json/root.json
+++ b/servers/encharge/src/tools/archivepeople/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "people": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `people` to the tool, first call the tool `expandSchema` with \"/properties/people\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>People can be specified by any ID. \nFor example, for a person with an email `slav@encharge.io` use the following query: \n\n`?people[0][email]=slav@encharge.io`\n\nFor multiple people, pass multiple ids in the query like so:\n\n`?people[0][userId]=abc&people[1][userId]=xyz`. \n\nThis will specify people who have userId of `abc` and `xyz`.\n\nEmails, userIds and other IDs can used together in a single query.\n</property-description>",
+      "additionalProperties": true
+    },
+    "force": {
+      "description": "If set to `true`, will delete the person's data. This is useful for GDPR-compliant removal of user data.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "people"
+  ]
+}

--- a/servers/encharge/src/tools/archivepeople/schema/properties/people.ts
+++ b/servers/encharge/src/tools/archivepeople/schema/properties/people.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("Encharge ID of the person. An UUID.\n\nAt least one of id/userId/email must be specified.").optional(),
+  "userId": z.string().describe("UserID of the person.\n\nAt least one of id/userId/email must be specified.").optional(),
+  "email": z.string().describe("Email of the person.\n\nAt least one of id/userId/email must be specified.").optional()
+}

--- a/servers/encharge/src/tools/archivepeople/schema/root.ts
+++ b/servers/encharge/src/tools/archivepeople/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "people": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `people` to the tool, first call the tool `expandSchema` with \"/properties/people\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>People can be specified by any ID. \nFor example, for a person with an email `slav@encharge.io` use the following query: \n\n`?people[0][email]=slav@encharge.io`\n\nFor multiple people, pass multiple ids in the query like so:\n\n`?people[0][userId]=abc&people[1][userId]=xyz`. \n\nThis will specify people who have userId of `abc` and `xyz`.\n\nEmails, userIds and other IDs can used together in a single query.\n</property-description>"),
+  "force": z.boolean().describe("If set to `true`, will delete the person's data. This is useful for GDPR-compliant removal of user data.").optional()
+}

--- a/servers/encharge/src/tools/createfields/index.ts
+++ b/servers/encharge/src/tools/createfields/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createfields",
+  "toolDescription": "Create Person Fields",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/fields",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/createfields/schema-json/root.json
+++ b/servers/encharge/src/tools/createfields/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/createfields/schema/root.ts
+++ b/servers/encharge/src/tools/createfields/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/createupdatepeople/index.ts
+++ b/servers/encharge/src/tools/createupdatepeople/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createupdatepeople",
+  "toolDescription": "Create/Update People",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/people",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/createupdatepeople/schema-json/root.json
+++ b/servers/encharge/src/tools/createupdatepeople/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/createupdatepeople/schema/root.ts
+++ b/servers/encharge/src/tools/createupdatepeople/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/createwebhook/index.ts
+++ b/servers/encharge/src/tools/createwebhook/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createwebhook",
+  "toolDescription": "Subscribe to events happening in Encharge.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/event-subscriptions",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "eventType": "eventType",
+      "targetUrl": "targetUrl"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/createwebhook/schema-json/root.json
+++ b/servers/encharge/src/tools/createwebhook/schema-json/root.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "description": "Event to trigger on"
+    },
+    "targetUrl": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "eventType",
+    "targetUrl"
+  ]
+}

--- a/servers/encharge/src/tools/createwebhook/schema/root.ts
+++ b/servers/encharge/src/tools/createwebhook/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "eventType": z.string().describe("Event to trigger on"),
+  "targetUrl": z.string()
+}

--- a/servers/encharge/src/tools/deletefield/index.ts
+++ b/servers/encharge/src/tools/deletefield/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletefield",
+  "toolDescription": "Delete Person Field",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/fields/{fieldName}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "fieldName": "fieldName"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/deletefield/schema-json/root.json
+++ b/servers/encharge/src/tools/deletefield/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "fieldName": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "fieldName"
+  ]
+}

--- a/servers/encharge/src/tools/deletefield/schema/root.ts
+++ b/servers/encharge/src/tools/deletefield/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "fieldName": z.string()
+}

--- a/servers/encharge/src/tools/deletewebhook/index.ts
+++ b/servers/encharge/src/tools/deletewebhook/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "deletewebhook",
+  "toolDescription": "Delete an existing event subscription.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/event-subscriptions/{id}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/deletewebhook/schema-json/root.json
+++ b/servers/encharge/src/tools/deletewebhook/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Id of the event subscription.",
+      "format": "double",
+      "type": "number"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/encharge/src/tools/deletewebhook/schema/root.ts
+++ b/servers/encharge/src/tools/deletewebhook/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.number().describe("Id of the event subscription.")
+}

--- a/servers/encharge/src/tools/editfield/index.ts
+++ b/servers/encharge/src/tools/editfield/index.ts
@@ -1,0 +1,39 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "editfield",
+  "toolDescription": "Modify Person Field",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/fields/{fieldName}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "fieldName": "fieldName"
+    },
+    "body": {
+      "name": "name",
+      "title": "title",
+      "type": "type",
+      "format": "format",
+      "readOnly": "readOnly",
+      "tooltip": "tooltip",
+      "icon": "icon",
+      "array": "array",
+      "canMapFrom": "canMapFrom",
+      "firstClassField": "firstClassField",
+      "createdBy": "createdBy"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/editfield/schema-json/root.json
+++ b/servers/encharge/src/tools/editfield/schema-json/root.json
@@ -1,0 +1,82 @@
+{
+  "type": "object",
+  "properties": {
+    "fieldName": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string",
+      "description": "Unique ID of the field.\n\nUse this \"name\" to refer to this field in any API operations."
+    },
+    "title": {
+      "type": "string",
+      "description": "Human readable name of the field."
+    },
+    "type": {
+      "description": "Type of the field. JSON schema compatible",
+      "type": "string",
+      "enum": [
+        "string",
+        "number",
+        "boolean",
+        "integer",
+        "any"
+      ]
+    },
+    "format": {
+      "description": "Format of the field. Applies to String fields only. JSON schema compatible",
+      "type": "string",
+      "enum": [
+        "date",
+        "date-time"
+      ],
+      "nullable": true
+    },
+    "readOnly": {
+      "type": "boolean",
+      "description": "Whether this field can be changed by the user or via the API."
+    },
+    "tooltip": {
+      "type": "string",
+      "description": "More information about this field (to be shown in a tooltip)"
+    },
+    "icon": {
+      "type": "string",
+      "description": "Field icon, if set."
+    },
+    "array": {
+      "type": "boolean",
+      "description": "Whether this field holds an array of values."
+    },
+    "canMapFrom": {
+      "type": "boolean",
+      "description": "Internal"
+    },
+    "firstClassField": {
+      "type": "boolean",
+      "description": "Internal."
+    },
+    "createdBy": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "system",
+            "user"
+          ]
+        }
+      ],
+      "description": "Internal. Field creator."
+    }
+  },
+  "required": [
+    "fieldName",
+    "name",
+    "type",
+    "readOnly",
+    "array"
+  ]
+}

--- a/servers/encharge/src/tools/editfield/schema/root.ts
+++ b/servers/encharge/src/tools/editfield/schema/root.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "fieldName": z.string(),
+  "name": z.string().describe("Unique ID of the field.\n\nUse this \"name\" to refer to this field in any API operations."),
+  "title": z.string().describe("Human readable name of the field.").optional(),
+  "type": z.enum(["string","number","boolean","integer","any"]).describe("Type of the field. JSON schema compatible"),
+  "format": z.enum(["date","date-time"]).nullable().describe("Format of the field. Applies to String fields only. JSON schema compatible").optional(),
+  "readOnly": z.boolean().describe("Whether this field can be changed by the user or via the API."),
+  "tooltip": z.string().describe("More information about this field (to be shown in a tooltip)").optional(),
+  "icon": z.string().describe("Field icon, if set.").optional(),
+  "array": z.boolean().describe("Whether this field holds an array of values."),
+  "canMapFrom": z.boolean().describe("Internal").optional(),
+  "firstClassField": z.boolean().describe("Internal.").optional(),
+  "createdBy": z.union([z.string(), z.enum(["system","user"])]).describe("Internal. Field creator.").optional()
+}

--- a/servers/encharge/src/tools/getfields/index.ts
+++ b/servers/encharge/src/tools/getfields/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getfields",
+  "toolDescription": "Get all Person Fields.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/fields",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/getfields/schema-json/root.json
+++ b/servers/encharge/src/tools/getfields/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/getfields/schema/root.ts
+++ b/servers/encharge/src/tools/getfields/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/getinfo/index.ts
+++ b/servers/encharge/src/tools/getinfo/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinfo",
+  "toolDescription": "Get information about your account.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/accounts/info",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/getinfo/schema-json/root.json
+++ b/servers/encharge/src/tools/getinfo/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/getinfo/schema/root.ts
+++ b/servers/encharge/src/tools/getinfo/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/getpeopleinsegment/index.ts
+++ b/servers/encharge/src/tools/getpeopleinsegment/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpeopleinsegment",
+  "toolDescription": "Get people in Segment.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/segments/{segmentId}/people",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "segmentId": "segmentId"
+    },
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "attributes": "attributes",
+      "sort": "sort",
+      "order": "order"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/getpeopleinsegment/schema-json/root.json
+++ b/servers/encharge/src/tools/getpeopleinsegment/schema-json/root.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "segmentId": {
+      "description": "Id of the segment.",
+      "format": "double",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of people to retrieve.",
+      "format": "double",
+      "type": "number"
+    },
+    "offset": {
+      "description": "Number of records to skip",
+      "default": 0,
+      "format": "double",
+      "type": "number"
+    },
+    "attributes": {
+      "description": "Person Fields to retrieve. See [Person Fields](#tag/PersonFields) for possible field names.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sort": {
+      "type": "string"
+    },
+    "order": {
+      "type": "string",
+      "enum": [
+        "asc",
+        "desc"
+      ]
+    }
+  },
+  "required": [
+    "segmentId"
+  ]
+}

--- a/servers/encharge/src/tools/getpeopleinsegment/schema/root.ts
+++ b/servers/encharge/src/tools/getpeopleinsegment/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "segmentId": z.number().describe("Id of the segment."),
+  "limit": z.number().describe("Number of people to retrieve.").optional(),
+  "offset": z.number().describe("Number of records to skip").optional(),
+  "attributes": z.array(z.string()).describe("Person Fields to retrieve. See [Person Fields](#tag/PersonFields) for possible field names.").optional(),
+  "sort": z.string().optional(),
+  "order": z.enum(["asc","desc"]).optional()
+}

--- a/servers/encharge/src/tools/getsegments/index.ts
+++ b/servers/encharge/src/tools/getsegments/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getsegments",
+  "toolDescription": "Get all dynamic Segments in your account.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/segments",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/getsegments/schema-json/root.json
+++ b/servers/encharge/src/tools/getsegments/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/getsegments/schema/root.ts
+++ b/servers/encharge/src/tools/getsegments/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/getspecificpeople/index.ts
+++ b/servers/encharge/src/tools/getspecificpeople/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getspecificpeople",
+  "toolDescription": "Retrive specific people in your account.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/people",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "people": "people"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/getspecificpeople/schema-json/properties/people.json
+++ b/servers/encharge/src/tools/getspecificpeople/schema-json/properties/people.json
@@ -1,0 +1,19 @@
+{
+  "description": "People can be specified by any ID. \nFor example, for a person with an email `slav@encharge.io` use the following query: \n\n`?people[0][email]=slav@encharge.io`\n\nFor multiple people, pass multiple ids in the query like so:\n\n`?people[0][userId]=abc&people[1][userId]=xyz`. \n\nThis will specify people who have userId of `abc` and `xyz`.\n\nEmails, userIds and other IDs can used together in a single query.\n",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Encharge ID of the person. An UUID.\n\nAt least one of id/userId/email must be specified."
+    },
+    "userId": {
+      "type": "string",
+      "description": "UserID of the person.\n\nAt least one of id/userId/email must be specified."
+    },
+    "email": {
+      "type": "string",
+      "description": "Email of the person.\n\nAt least one of id/userId/email must be specified."
+    }
+  },
+  "additionalProperties": {},
+  "type": "object"
+}

--- a/servers/encharge/src/tools/getspecificpeople/schema-json/root.json
+++ b/servers/encharge/src/tools/getspecificpeople/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "people": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `people` to the tool, first call the tool `expandSchema` with \"/properties/people\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>People can be specified by any ID. \nFor example, for a person with an email `slav@encharge.io` use the following query: \n\n`?people[0][email]=slav@encharge.io`\n\nFor multiple people, pass multiple ids in the query like so:\n\n`?people[0][userId]=abc&people[1][userId]=xyz`. \n\nThis will specify people who have userId of `abc` and `xyz`.\n\nEmails, userIds and other IDs can used together in a single query.\n</property-description>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "people"
+  ]
+}

--- a/servers/encharge/src/tools/getspecificpeople/schema/properties/people.ts
+++ b/servers/encharge/src/tools/getspecificpeople/schema/properties/people.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("Encharge ID of the person. An UUID.\n\nAt least one of id/userId/email must be specified.").optional(),
+  "userId": z.string().describe("UserID of the person.\n\nAt least one of id/userId/email must be specified.").optional(),
+  "email": z.string().describe("Email of the person.\n\nAt least one of id/userId/email must be specified.").optional()
+}

--- a/servers/encharge/src/tools/getspecificpeople/schema/root.ts
+++ b/servers/encharge/src/tools/getspecificpeople/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "people": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `people` to the tool, first call the tool `expandSchema` with \"/properties/people\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>\n<property-description>People can be specified by any ID. \nFor example, for a person with an email `slav@encharge.io` use the following query: \n\n`?people[0][email]=slav@encharge.io`\n\nFor multiple people, pass multiple ids in the query like so:\n\n`?people[0][userId]=abc&people[1][userId]=xyz`. \n\nThis will specify people who have userId of `abc` and `xyz`.\n\nEmails, userIds and other IDs can used together in a single query.\n</property-description>")
+}

--- a/servers/encharge/src/tools/removetag/index.ts
+++ b/servers/encharge/src/tools/removetag/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "removetag",
+  "toolDescription": "Remove tag(s) from existing user.",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/tags",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/removetag/schema-json/root.json
+++ b/servers/encharge/src/tools/removetag/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/encharge/src/tools/removetag/schema/root.ts
+++ b/servers/encharge/src/tools/removetag/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/encharge/src/tools/unsubscribeperson/index.ts
+++ b/servers/encharge/src/tools/unsubscribeperson/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "unsubscribeperson",
+  "toolDescription": "Unsubscribe a Person",
+  "baseUrl": "https://api.encharge.io/v1",
+  "path": "/people/unsubscribe",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "email": "email",
+      "userId": "userId",
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/encharge/src/tools/unsubscribeperson/schema-json/root.json
+++ b/servers/encharge/src/tools/unsubscribeperson/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "email": {
+      "description": "Email of the person to unsubscribe.\n\nAt least one of id/userId/email must be specified.",
+      "type": "string"
+    },
+    "userId": {
+      "description": "userId of the person to unsubscribe.\n\nAt least one of id/userId/email must be specified.",
+      "type": "string"
+    },
+    "id": {
+      "description": "Encharge ID of the person to unsubscribe.\n\nAt least one of id/userId/email must be specified.",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/encharge/src/tools/unsubscribeperson/schema/root.ts
+++ b/servers/encharge/src/tools/unsubscribeperson/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email": z.string().describe("Email of the person to unsubscribe.\n\nAt least one of id/userId/email must be specified.").optional(),
+  "userId": z.string().describe("userId of the person to unsubscribe.\n\nAt least one of id/userId/email must be specified.").optional(),
+  "id": z.string().describe("Encharge ID of the person to unsubscribe.\n\nAt least one of id/userId/email must be specified.").optional()
+}

--- a/servers/encharge/tsconfig.json
+++ b/servers/encharge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `encharge`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/encharge`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "encharge": {
      "command": "npx",
      "args": ["-y", "@open-mcp/encharge"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.