### PR TITLE
Add MCP server `apis_data_go_kr_1230000_as_scsbidinfoservice`

### DIFF
--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/.npmignore
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/README.md
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/README.md
@@ -1,0 +1,189 @@
+# @open-mcp/apis_data_go_kr_1230000_as_scsbidinfoservice
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "apis_data_go_kr_1230000_as_scsbidinfoservice": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/apis_data_go_kr_1230000_as_scsbidinfoservice@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/apis_data_go_kr_1230000_as_scsbidinfoservice@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+SERVICEKEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add apis_data_go_kr_1230000_as_scsbidinfoservice \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --SERVICEKEY=$SERVICEKEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add apis_data_go_kr_1230000_as_scsbidinfoservice \
+  .cursor/mcp.json \
+  --SERVICEKEY=$SERVICEKEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add apis_data_go_kr_1230000_as_scsbidinfoservice \
+  /path/to/client/config.json \
+  --SERVICEKEY=$SERVICEKEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "apis_data_go_kr_1230000_as_scsbidinfoservice": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/apis_data_go_kr_1230000_as_scsbidinfoservice"],
+      "env": {"SERVICEKEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `SERVICEKEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_getscsbidliststtusthng
+
+**Environment variables**
+
+- `SERVICEKEY`
+
+**Input schema**
+
+- `inqryDiv` (string)
+- `inqryBgnDt` (string)
+- `inqryEndDt` (string)
+- `pageNo` (integer)
+- `numOfRows` (integer)
+
+### get_getscsbidliststtusthngppssrch
+
+**Environment variables**
+
+- `SERVICEKEY`
+
+**Input schema**
+
+- `inqryDiv` (string)
+- `inqryBgnDt` (string)
+- `inqryEndDt` (string)
+- `pageNo` (integer)
+- `numOfRows` (integer)
+- `bidNtceNm` (string)
+- `ntceInsttNm` (string)
+- `dminsttNm` (string)
+- `indstrytyNm` (string)
+- `refNo` (string)
+
+### get_getopengresultlistinfothng
+
+**Environment variables**
+
+- `SERVICEKEY`
+
+**Input schema**
+
+- `bidNtceNo` (string)
+- `bidNtceOrd` (string)
+- `bidClsfcNo` (string)
+- `rbidNo` (string)
+- `pageNo` (integer)
+- `numOfRows` (integer)
+
+### get_getopengresultlistinfothngpreparpcdetail
+
+**Environment variables**
+
+- `SERVICEKEY`
+
+**Input schema**
+
+- `bidNtceNo` (string)
+- `bidNtceOrd` (string)
+- `bidClsfcNo` (string)
+- `rbidNo` (string)
+- `pageNo` (integer)
+- `numOfRows` (integer)
+
+### get_getopengresultlistinfofailing
+
+**Environment variables**
+
+- `SERVICEKEY`
+
+**Input schema**
+
+- `bidNtceNo` (string)
+- `bidNtceOrd` (string)
+- `bidClsfcNo` (string)
+- `rbidNo` (string)
+- `pageNo` (integer)
+- `numOfRows` (integer)
+
+### get_getopengresultlistinforebid
+
+**Environment variables**
+
+- `SERVICEKEY`
+
+**Input schema**
+
+- `bidNtceNo` (string)
+- `bidNtceOrd` (string)
+- `bidClsfcNo` (string)
+- `rbidNo` (string)
+- `pageNo` (integer)
+- `numOfRows` (integer)

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/package.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/apis_data_go_kr_1230000_as_scsbidinfoservice",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "apis_data_go_kr_1230000_as_scsbidinfoservice": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/constants.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/constants.ts
@@ -1,0 +1,11 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/alphago2580/api-test/refs/heads/main/openapi/ScsbidInfoService.yaml"
+export const SERVER_NAME = "apis_data_go_kr_1230000_as_scsbidinfoservice"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_getscsbidliststtusthng/index.js",
+  "./tools/get_getscsbidliststtusthngppssrch/index.js",
+  "./tools/get_getopengresultlistinfothng/index.js",
+  "./tools/get_getopengresultlistinfothngpreparpcdetail/index.js",
+  "./tools/get_getopengresultlistinfofailing/index.js",
+  "./tools/get_getopengresultlistinforebid/index.js"
+]

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/server.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfofailing/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfofailing/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_getopengresultlistinfofailing",
+  "toolDescription": "유찰 이력 조회",
+  "baseUrl": "http://apis.data.go.kr/1230000/as/ScsbidInfoService",
+  "path": "/getOpengResultListInfoFailing",
+  "method": "get",
+  "security": [
+    {
+      "key": "ServiceKey",
+      "value": "<mcp-env-var>SERVICEKEY</mcp-env-var>",
+      "in": "query",
+      "envVarName": "SERVICEKEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "bidNtceNo": "bidNtceNo",
+      "bidNtceOrd": "bidNtceOrd",
+      "bidClsfcNo": "bidClsfcNo",
+      "rbidNo": "rbidNo",
+      "pageNo": "pageNo",
+      "numOfRows": "numOfRows"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfofailing/schema-json/root.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfofailing/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "bidNtceNo": {
+      "description": "공고번호",
+      "type": "string",
+      "example": "20250712345"
+    },
+    "bidNtceOrd": {
+      "description": "입찰 차수",
+      "type": "string",
+      "example": "00"
+    },
+    "bidClsfcNo": {
+      "description": "입찰분류번호",
+      "type": "string",
+      "example": "0"
+    },
+    "rbidNo": {
+      "description": "재입찰번호",
+      "type": "string",
+      "example": "000"
+    },
+    "pageNo": {
+      "description": "페이지 번호",
+      "type": "integer",
+      "example": 1
+    },
+    "numOfRows": {
+      "description": "페이지당 건수",
+      "type": "integer",
+      "example": 20
+    }
+  },
+  "required": [
+    "bidNtceNo",
+    "bidNtceOrd",
+    "bidClsfcNo",
+    "rbidNo",
+    "pageNo",
+    "numOfRows"
+  ]
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfofailing/schema/root.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfofailing/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "bidNtceNo": z.string().describe("공고번호"),
+  "bidNtceOrd": z.string().describe("입찰 차수"),
+  "bidClsfcNo": z.string().describe("입찰분류번호"),
+  "rbidNo": z.string().describe("재입찰번호"),
+  "pageNo": z.number().int().describe("페이지 번호"),
+  "numOfRows": z.number().int().describe("페이지당 건수")
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinforebid/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinforebid/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_getopengresultlistinforebid",
+  "toolDescription": "재입찰 이력 조회",
+  "baseUrl": "http://apis.data.go.kr/1230000/as/ScsbidInfoService",
+  "path": "/getOpengResultListInfoRebid",
+  "method": "get",
+  "security": [
+    {
+      "key": "ServiceKey",
+      "value": "<mcp-env-var>SERVICEKEY</mcp-env-var>",
+      "in": "query",
+      "envVarName": "SERVICEKEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "bidNtceNo": "bidNtceNo",
+      "bidNtceOrd": "bidNtceOrd",
+      "bidClsfcNo": "bidClsfcNo",
+      "rbidNo": "rbidNo",
+      "pageNo": "pageNo",
+      "numOfRows": "numOfRows"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinforebid/schema-json/root.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinforebid/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "bidNtceNo": {
+      "description": "공고번호",
+      "type": "string",
+      "example": "20250712345"
+    },
+    "bidNtceOrd": {
+      "description": "입찰 차수",
+      "type": "string",
+      "example": "00"
+    },
+    "bidClsfcNo": {
+      "description": "입찰분류번호",
+      "type": "string",
+      "example": "0"
+    },
+    "rbidNo": {
+      "description": "재입찰번호",
+      "type": "string",
+      "example": "000"
+    },
+    "pageNo": {
+      "description": "페이지 번호",
+      "type": "integer",
+      "example": 1
+    },
+    "numOfRows": {
+      "description": "페이지당 건수",
+      "type": "integer",
+      "example": 20
+    }
+  },
+  "required": [
+    "bidNtceNo",
+    "bidNtceOrd",
+    "bidClsfcNo",
+    "rbidNo",
+    "pageNo",
+    "numOfRows"
+  ]
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinforebid/schema/root.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinforebid/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "bidNtceNo": z.string().describe("공고번호"),
+  "bidNtceOrd": z.string().describe("입찰 차수"),
+  "bidClsfcNo": z.string().describe("입찰분류번호"),
+  "rbidNo": z.string().describe("재입찰번호"),
+  "pageNo": z.number().int().describe("페이지 번호"),
+  "numOfRows": z.number().int().describe("페이지당 건수")
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothng/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothng/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_getopengresultlistinfothng",
+  "toolDescription": "개찰결과 물품 목록 조회",
+  "baseUrl": "http://apis.data.go.kr/1230000/as/ScsbidInfoService",
+  "path": "/getOpengResultListInfoThng",
+  "method": "get",
+  "security": [
+    {
+      "key": "ServiceKey",
+      "value": "<mcp-env-var>SERVICEKEY</mcp-env-var>",
+      "in": "query",
+      "envVarName": "SERVICEKEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "bidNtceNo": "bidNtceNo",
+      "bidNtceOrd": "bidNtceOrd",
+      "bidClsfcNo": "bidClsfcNo",
+      "rbidNo": "rbidNo",
+      "pageNo": "pageNo",
+      "numOfRows": "numOfRows"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothng/schema-json/root.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothng/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "bidNtceNo": {
+      "description": "공고번호",
+      "type": "string",
+      "example": "20250712345"
+    },
+    "bidNtceOrd": {
+      "description": "입찰 차수",
+      "type": "string",
+      "example": "00"
+    },
+    "bidClsfcNo": {
+      "description": "입찰분류번호",
+      "type": "string",
+      "example": "0"
+    },
+    "rbidNo": {
+      "description": "재입찰번호",
+      "type": "string",
+      "example": "000"
+    },
+    "pageNo": {
+      "description": "페이지 번호",
+      "type": "integer",
+      "example": 1
+    },
+    "numOfRows": {
+      "description": "페이지당 건수",
+      "type": "integer",
+      "example": 20
+    }
+  },
+  "required": [
+    "bidNtceNo",
+    "bidNtceOrd",
+    "bidClsfcNo",
+    "rbidNo",
+    "pageNo",
+    "numOfRows"
+  ]
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothng/schema/root.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothng/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "bidNtceNo": z.string().describe("공고번호"),
+  "bidNtceOrd": z.string().describe("입찰 차수"),
+  "bidClsfcNo": z.string().describe("입찰분류번호"),
+  "rbidNo": z.string().describe("재입찰번호"),
+  "pageNo": z.number().int().describe("페이지 번호"),
+  "numOfRows": z.number().int().describe("페이지당 건수")
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothngpreparpcdetail/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothngpreparpcdetail/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_getopengresultlistinfothngpreparpcdetail",
+  "toolDescription": "예비가격 상세 조회",
+  "baseUrl": "http://apis.data.go.kr/1230000/as/ScsbidInfoService",
+  "path": "/getOpengResultListInfoThngPreparPcDetail",
+  "method": "get",
+  "security": [
+    {
+      "key": "ServiceKey",
+      "value": "<mcp-env-var>SERVICEKEY</mcp-env-var>",
+      "in": "query",
+      "envVarName": "SERVICEKEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "bidNtceNo": "bidNtceNo",
+      "bidNtceOrd": "bidNtceOrd",
+      "bidClsfcNo": "bidClsfcNo",
+      "rbidNo": "rbidNo",
+      "pageNo": "pageNo",
+      "numOfRows": "numOfRows"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothngpreparpcdetail/schema-json/root.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothngpreparpcdetail/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "bidNtceNo": {
+      "description": "공고번호",
+      "type": "string",
+      "example": "20250712345"
+    },
+    "bidNtceOrd": {
+      "description": "입찰 차수",
+      "type": "string",
+      "example": "00"
+    },
+    "bidClsfcNo": {
+      "description": "입찰분류번호",
+      "type": "string",
+      "example": "0"
+    },
+    "rbidNo": {
+      "description": "재입찰번호",
+      "type": "string",
+      "example": "000"
+    },
+    "pageNo": {
+      "description": "페이지 번호",
+      "type": "integer",
+      "example": 1
+    },
+    "numOfRows": {
+      "description": "페이지당 건수",
+      "type": "integer",
+      "example": 20
+    }
+  },
+  "required": [
+    "bidNtceNo",
+    "bidNtceOrd",
+    "bidClsfcNo",
+    "rbidNo",
+    "pageNo",
+    "numOfRows"
+  ]
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothngpreparpcdetail/schema/root.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getopengresultlistinfothngpreparpcdetail/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "bidNtceNo": z.string().describe("공고번호"),
+  "bidNtceOrd": z.string().describe("입찰 차수"),
+  "bidClsfcNo": z.string().describe("입찰분류번호"),
+  "rbidNo": z.string().describe("재입찰번호"),
+  "pageNo": z.number().int().describe("페이지 번호"),
+  "numOfRows": z.number().int().describe("페이지당 건수")
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthng/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthng/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_getscsbidliststtusthng",
+  "toolDescription": "물품 낙찰 현황 조회",
+  "baseUrl": "http://apis.data.go.kr/1230000/as/ScsbidInfoService",
+  "path": "/getScsbidListSttusThng",
+  "method": "get",
+  "security": [
+    {
+      "key": "ServiceKey",
+      "value": "<mcp-env-var>SERVICEKEY</mcp-env-var>",
+      "in": "query",
+      "envVarName": "SERVICEKEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "inqryDiv": "inqryDiv",
+      "inqryBgnDt": "inqryBgnDt",
+      "inqryEndDt": "inqryEndDt",
+      "pageNo": "pageNo",
+      "numOfRows": "numOfRows"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthng/schema-json/root.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthng/schema-json/root.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "inqryDiv": {
+      "description": "조회구분 (1=날짜)",
+      "type": "string",
+      "example": "1"
+    },
+    "inqryBgnDt": {
+      "description": "조회 시작일시 (YYYYMMDDHHMM)",
+      "type": "string",
+      "example": "202507010000"
+    },
+    "inqryEndDt": {
+      "description": "조회 종료일시 (YYYYMMDDHHMM)",
+      "type": "string",
+      "example": "202507202359"
+    },
+    "pageNo": {
+      "description": "페이지 번호",
+      "type": "integer",
+      "example": 1
+    },
+    "numOfRows": {
+      "description": "페이지당 건수",
+      "type": "integer",
+      "example": 20
+    }
+  },
+  "required": [
+    "inqryDiv",
+    "inqryBgnDt",
+    "inqryEndDt",
+    "pageNo",
+    "numOfRows"
+  ]
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthng/schema/root.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthng/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "inqryDiv": z.string().describe("조회구분 (1=날짜)"),
+  "inqryBgnDt": z.string().describe("조회 시작일시 (YYYYMMDDHHMM)"),
+  "inqryEndDt": z.string().describe("조회 종료일시 (YYYYMMDDHHMM)"),
+  "pageNo": z.number().int().describe("페이지 번호"),
+  "numOfRows": z.number().int().describe("페이지당 건수")
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthngppssrch/index.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthngppssrch/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_getscsbidliststtusthngppssrch",
+  "toolDescription": "검색조건 기반 물품 낙찰 현황 조회",
+  "baseUrl": "http://apis.data.go.kr/1230000/as/ScsbidInfoService",
+  "path": "/getScsbidListSttusThngPPSSrch",
+  "method": "get",
+  "security": [
+    {
+      "key": "ServiceKey",
+      "value": "<mcp-env-var>SERVICEKEY</mcp-env-var>",
+      "in": "query",
+      "envVarName": "SERVICEKEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "inqryDiv": "inqryDiv",
+      "inqryBgnDt": "inqryBgnDt",
+      "inqryEndDt": "inqryEndDt",
+      "pageNo": "pageNo",
+      "numOfRows": "numOfRows",
+      "bidNtceNm": "bidNtceNm",
+      "ntceInsttNm": "ntceInsttNm",
+      "dminsttNm": "dminsttNm",
+      "indstrytyNm": "indstrytyNm",
+      "refNo": "refNo"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthngppssrch/schema-json/root.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthngppssrch/schema-json/root.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "properties": {
+    "inqryDiv": {
+      "description": "조회구분 (1=날짜)",
+      "type": "string",
+      "example": "1"
+    },
+    "inqryBgnDt": {
+      "description": "조회 시작일시 (YYYYMMDDHHMM)",
+      "type": "string",
+      "example": "202507010000"
+    },
+    "inqryEndDt": {
+      "description": "조회 종료일시 (YYYYMMDDHHMM)",
+      "type": "string",
+      "example": "202507202359"
+    },
+    "pageNo": {
+      "description": "페이지 번호",
+      "type": "integer",
+      "example": 1
+    },
+    "numOfRows": {
+      "description": "페이지당 건수",
+      "type": "integer",
+      "example": 20
+    },
+    "bidNtceNm": {
+      "description": "입찰공고명 키워드 (부분 일치)",
+      "type": "string",
+      "example": "노트북"
+    },
+    "ntceInsttNm": {
+      "description": "공고기관명 키워드 (부분 일치)",
+      "type": "string",
+      "example": "환경부"
+    },
+    "dminsttNm": {
+      "description": "수요기관명 키워드 (부분 일치)",
+      "type": "string",
+      "example": "환경부"
+    },
+    "indstrytyNm": {
+      "description": "업종명 키워드 (부분 일치)",
+      "type": "string",
+      "example": "서버"
+    },
+    "refNo": {
+      "description": "참조번호 키워드 (부분 일치)",
+      "type": "string",
+      "example": "ABC123"
+    }
+  },
+  "required": [
+    "inqryDiv",
+    "inqryBgnDt",
+    "inqryEndDt",
+    "pageNo",
+    "numOfRows"
+  ]
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthngppssrch/schema/root.ts
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/src/tools/get_getscsbidliststtusthngppssrch/schema/root.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "inqryDiv": z.string().describe("조회구분 (1=날짜)"),
+  "inqryBgnDt": z.string().describe("조회 시작일시 (YYYYMMDDHHMM)"),
+  "inqryEndDt": z.string().describe("조회 종료일시 (YYYYMMDDHHMM)"),
+  "pageNo": z.number().int().describe("페이지 번호"),
+  "numOfRows": z.number().int().describe("페이지당 건수"),
+  "bidNtceNm": z.string().describe("입찰공고명 키워드 (부분 일치)").optional(),
+  "ntceInsttNm": z.string().describe("공고기관명 키워드 (부분 일치)").optional(),
+  "dminsttNm": z.string().describe("수요기관명 키워드 (부분 일치)").optional(),
+  "indstrytyNm": z.string().describe("업종명 키워드 (부분 일치)").optional(),
+  "refNo": z.string().describe("참조번호 키워드 (부분 일치)").optional()
+}

--- a/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/tsconfig.json
+++ b/servers/apis_data_go_kr_1230000_as_scsbidinfoservice/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `apis_data_go_kr_1230000_as_scsbidinfoservice`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/apis_data_go_kr_1230000_as_scsbidinfoservice`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "apis_data_go_kr_1230000_as_scsbidinfoservice": {
      "command": "npx",
      "args": ["-y", "@open-mcp/apis_data_go_kr_1230000_as_scsbidinfoservice"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.