### PR TITLE
Add MCP server `chabadplugin_reshapecreative_com`

### DIFF
--- a/servers/chabadplugin_reshapecreative_com/.npmignore
+++ b/servers/chabadplugin_reshapecreative_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/chabadplugin_reshapecreative_com/README.md
+++ b/servers/chabadplugin_reshapecreative_com/README.md
@@ -1,0 +1,156 @@
+# @open-mcp/chabadplugin_reshapecreative_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "chabadplugin_reshapecreative_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/chabadplugin_reshapecreative_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/chabadplugin_reshapecreative_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add chabadplugin_reshapecreative_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add chabadplugin_reshapecreative_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add chabadplugin_reshapecreative_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "chabadplugin_reshapecreative_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/chabadplugin_reshapecreative_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### listallcenters
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### listcentertypes
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### getcenterinfo
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `mosad-id` (string)
+
+### searchcenters
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `quantity` (string)
+- `query` (string)
+- `type` (string)
+- `name` (string)
+
+### getcentersbyzipcode
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+
+### getchabadcenterevents
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `mosad-id` (string)

--- a/servers/chabadplugin_reshapecreative_com/package.json
+++ b/servers/chabadplugin_reshapecreative_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/chabadplugin_reshapecreative_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "chabadplugin_reshapecreative_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/chabadplugin_reshapecreative_com/src/constants.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/constants.ts
@@ -1,0 +1,11 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/sisbell/chatgpt-plugin-store/main/specs/chabadplugin.reshapecreative.com.yaml"
+export const SERVER_NAME = "chabadplugin_reshapecreative_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/listallcenters/index.js",
+  "./tools/listcentertypes/index.js",
+  "./tools/getcenterinfo/index.js",
+  "./tools/searchcenters/index.js",
+  "./tools/getcentersbyzipcode/index.js",
+  "./tools/getchabadcenterevents/index.js"
+]

--- a/servers/chabadplugin_reshapecreative_com/src/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/chabadplugin_reshapecreative_com/src/server.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getcenterinfo/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getcenterinfo/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcenterinfo",
+  "toolDescription": "Get Center Info",
+  "baseUrl": "https://chabadplugin.reshapecreative.com",
+  "path": "/center",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "mosad-id": "mosad-id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getcenterinfo/schema-json/root.json
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getcenterinfo/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "mosad-id": {
+      "description": "the center's mosad id, it can be found using other api requests.",
+      "type": "string",
+      "example": "334256"
+    }
+  },
+  "required": []
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getcenterinfo/schema/root.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getcenterinfo/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "mosad-id": z.string().describe("the center's mosad id, it can be found using other api requests.").optional()
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getcentersbyzipcode/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getcentersbyzipcode/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcentersbyzipcode",
+  "toolDescription": "Get Centers By Zip Code",
+  "baseUrl": "https://chabadplugin.reshapecreative.com",
+  "path": "/location",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getcentersbyzipcode/schema-json/root.json
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getcentersbyzipcode/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "2- followed by zipcode, ex. 2-32246",
+      "type": "string",
+      "example": "2-10001"
+    }
+  },
+  "required": []
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getcentersbyzipcode/schema/root.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getcentersbyzipcode/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("2- followed by zipcode, ex. 2-32246").optional()
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getchabadcenterevents/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getchabadcenterevents/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getchabadcenterevents",
+  "toolDescription": "Get Chabad Center Events",
+  "baseUrl": "https://chabadplugin.reshapecreative.com",
+  "path": "/events",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "mosad-id": "mosad-id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getchabadcenterevents/schema-json/root.json
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getchabadcenterevents/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "mosad-id": {
+      "description": "the center's mosad id, it can be found using other api requests.",
+      "type": "string",
+      "example": "118653"
+    }
+  },
+  "required": []
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/getchabadcenterevents/schema/root.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/getchabadcenterevents/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "mosad-id": z.string().describe("the center's mosad id, it can be found using other api requests.").optional()
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/listallcenters/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/listallcenters/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "listallcenters",
+  "toolDescription": "List All Centers",
+  "baseUrl": "https://chabadplugin.reshapecreative.com",
+  "path": "/centers",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/chabadplugin_reshapecreative_com/src/tools/listallcenters/schema-json/root.json
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/listallcenters/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/listallcenters/schema/root.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/listallcenters/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/listcentertypes/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/listcentertypes/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "listcentertypes",
+  "toolDescription": "List Center Types",
+  "baseUrl": "https://chabadplugin.reshapecreative.com",
+  "path": "/center-types",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/chabadplugin_reshapecreative_com/src/tools/listcentertypes/schema-json/root.json
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/listcentertypes/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/listcentertypes/schema/root.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/listcentertypes/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/searchcenters/index.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/searchcenters/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "searchcenters",
+  "toolDescription": "Search Centers",
+  "baseUrl": "https://chabadplugin.reshapecreative.com",
+  "path": "/search",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "quantity": "quantity",
+      "query": "query",
+      "type": "type",
+      "name": "name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/chabadplugin_reshapecreative_com/src/tools/searchcenters/schema-json/root.json
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/searchcenters/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "quantity": {
+      "description": "Amount of results you want the api to return, defualts tp 10 if left blank",
+      "type": "string",
+      "example": "10"
+    },
+    "query": {
+      "description": "The query string you are searching by / for",
+      "type": "string",
+      "example": "southside"
+    },
+    "type": {
+      "description": "The id of the center type you would like to filter by, get all center types and their using \"List Center Types\" (https://www.chabad.org/api/v2/chabadorg/centers/types)",
+      "type": "string",
+      "example": "7157"
+    },
+    "name": {
+      "description": "Search by shliach's last name. For example if you want to search for someone named \"Shmuli Novack\", Search for \"Novack\".",
+      "type": "string",
+      "example": "novack"
+    }
+  },
+  "required": []
+}

--- a/servers/chabadplugin_reshapecreative_com/src/tools/searchcenters/schema/root.ts
+++ b/servers/chabadplugin_reshapecreative_com/src/tools/searchcenters/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "quantity": z.string().describe("Amount of results you want the api to return, defualts tp 10 if left blank").optional(),
+  "query": z.string().describe("The query string you are searching by / for").optional(),
+  "type": z.string().describe("The id of the center type you would like to filter by, get all center types and their using \"List Center Types\" (https://www.chabad.org/api/v2/chabadorg/centers/types)").optional(),
+  "name": z.string().describe("Search by shliach's last name. For example if you want to search for someone named \"Shmuli Novack\", Search for \"Novack\".").optional()
+}

--- a/servers/chabadplugin_reshapecreative_com/tsconfig.json
+++ b/servers/chabadplugin_reshapecreative_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `chabadplugin_reshapecreative_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/chabadplugin_reshapecreative_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "chabadplugin_reshapecreative_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/chabadplugin_reshapecreative_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.