### PR TITLE
Add MCP server `demo_erpnext_com_api`

### DIFF
--- a/servers/demo_erpnext_com_api/.npmignore
+++ b/servers/demo_erpnext_com_api/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/demo_erpnext_com_api/README.md
+++ b/servers/demo_erpnext_com_api/README.md
@@ -1,0 +1,193 @@
+# @open-mcp/demo_erpnext_com_api
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "demo_erpnext_com_api": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/demo_erpnext_com_api@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/demo_erpnext_com_api@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add demo_erpnext_com_api \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add demo_erpnext_com_api \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add demo_erpnext_com_api \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "demo_erpnext_com_api": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/demo_erpnext_com_api"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### login
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `usr` (string)
+- `pwd` (string)
+- `b_usr` (string)
+- `b_pwd` (string)
+
+### get_method_logout
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### authgetloggeduser
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### get_method_version
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### post_resource_doctype_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `DocType` (string)
+
+### get_resource_doctype_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `DocType` (string)
+- `fields` (array)
+- `filters` (array)
+- `limit_page_length` (integer)
+- `limit_start` (integer)
+
+### get_resource_doctype_documentname_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `DocType` (string)
+- `DocumentName` (string)
+
+### put_resource_doctype_documentname_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `DocType` (string)
+- `DocumentName` (string)
+
+### delete_resource_doctype_documentname_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `DocType` (string)
+- `DocumentName` (string)

--- a/servers/demo_erpnext_com_api/package.json
+++ b/servers/demo_erpnext_com_api/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/demo_erpnext_com_api",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "demo_erpnext_com_api": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/demo_erpnext_com_api/src/constants.ts
+++ b/servers/demo_erpnext_com_api/src/constants.ts
@@ -1,0 +1,14 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/alyf-de/frappe_api-docs/refs/heads/master/open-api-3.yaml"
+export const SERVER_NAME = "demo_erpnext_com_api"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/login/index.js",
+  "./tools/get_method_logout/index.js",
+  "./tools/authgetloggeduser/index.js",
+  "./tools/get_method_version/index.js",
+  "./tools/post_resource_doctype_/index.js",
+  "./tools/get_resource_doctype_/index.js",
+  "./tools/get_resource_doctype_documentname_/index.js",
+  "./tools/put_resource_doctype_documentname_/index.js",
+  "./tools/delete_resource_doctype_documentname_/index.js"
+]

--- a/servers/demo_erpnext_com_api/src/index.ts
+++ b/servers/demo_erpnext_com_api/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/demo_erpnext_com_api/src/server.ts
+++ b/servers/demo_erpnext_com_api/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/demo_erpnext_com_api/src/tools/authgetloggeduser/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/authgetloggeduser/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "authgetloggeduser",
+  "toolDescription": "Get the user that is logged in",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/method/frappe.auth.get_logged_user",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/authgetloggeduser/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/authgetloggeduser/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/demo_erpnext_com_api/src/tools/authgetloggeduser/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/authgetloggeduser/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/demo_erpnext_com_api/src/tools/delete_resource_doctype_documentname_/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/delete_resource_doctype_documentname_/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_resource_doctype_documentname_",
+  "toolDescription": "Delete a specific document",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/resource/{DocType}/{DocumentName}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "DocType": "DocType",
+      "DocumentName": "DocumentName"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/delete_resource_doctype_documentname_/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/delete_resource_doctype_documentname_/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "DocType": {
+      "description": "The type of the document you'd like to delete. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n",
+      "type": "string"
+    },
+    "DocumentName": {
+      "description": "The name (ID) of the document you'd like to delete. For example EMP001 (of type Employee).\n",
+      "type": "string"
+    }
+  },
+  "required": [
+    "DocType",
+    "DocumentName"
+  ]
+}

--- a/servers/demo_erpnext_com_api/src/tools/delete_resource_doctype_documentname_/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/delete_resource_doctype_documentname_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "DocType": z.string().describe("The type of the document you'd like to delete. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n"),
+  "DocumentName": z.string().describe("The name (ID) of the document you'd like to delete. For example EMP001 (of type Employee).\n")
+}

--- a/servers/demo_erpnext_com_api/src/tools/get_method_logout/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_method_logout/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_method_logout",
+  "toolDescription": "Logout from current session",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/method/logout",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/get_method_logout/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/get_method_logout/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/demo_erpnext_com_api/src/tools/get_method_logout/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_method_logout/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/demo_erpnext_com_api/src/tools/get_method_version/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_method_version/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_method_version",
+  "toolDescription": "Get the version of the app",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/method/version",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/get_method_version/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/get_method_version/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/demo_erpnext_com_api/src/tools/get_method_version/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_method_version/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_/index.ts
@@ -1,0 +1,25 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_resource_doctype_",
+  "toolDescription": "Get a list of documents",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/resource/{DocType}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "DocType": "DocType"
+    },
+    "query": {
+      "fields": "fields",
+      "filters": "filters",
+      "limit_page_length": "limit_page_length",
+      "limit_start": "limit_start"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_/schema-json/root.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "DocType": {
+      "description": "The DocType you'd like to receive. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n",
+      "type": "string"
+    },
+    "fields": {
+      "description": "By default, only the \"name\" field is included in the listing, to add more fields, \nyou can pass the fields param to GET request. For example, fields=[\"name\",\"country\"]\n",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "name"
+      ]
+    },
+    "filters": {
+      "description": "You can filter the listing using sql conditions by passing them as the filters GET param.\nEach condition is an array of the format, [{doctype}, {field}, {operator}, {value}].\nFor example, filters=[[\"Customer\", \"country\", \"=\", \"India\"]]\n",
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "limit_page_length": {
+      "description": "By default, all listings are returned paginated. With this parameter you can change the \npage size (how many items are teturned at once).\n",
+      "type": "integer",
+      "default": 20
+    },
+    "limit_start": {
+      "description": "To request successive pages, pass a multiple of your limit_page_length as limit_start. \nFor Example, to request the second page, pass limit_start as 20.\n",
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "required": [
+    "DocType"
+  ]
+}

--- a/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "DocType": z.string().describe("The DocType you'd like to receive. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n"),
+  "fields": z.array(z.string()).describe("By default, only the \"name\" field is included in the listing, to add more fields, \nyou can pass the fields param to GET request. For example, fields=[\"name\",\"country\"]\n").optional(),
+  "filters": z.array(z.array(z.string())).describe("You can filter the listing using sql conditions by passing them as the filters GET param.\nEach condition is an array of the format, [{doctype}, {field}, {operator}, {value}].\nFor example, filters=[[\"Customer\", \"country\", \"=\", \"India\"]]\n").optional(),
+  "limit_page_length": z.number().int().describe("By default, all listings are returned paginated. With this parameter you can change the \npage size (how many items are teturned at once).\n").optional(),
+  "limit_start": z.number().int().describe("To request successive pages, pass a multiple of your limit_page_length as limit_start. \nFor Example, to request the second page, pass limit_start as 20.\n").optional()
+}

--- a/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_documentname_/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_documentname_/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_resource_doctype_documentname_",
+  "toolDescription": "Get a specific document",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/resource/{DocType}/{DocumentName}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "DocType": "DocType",
+      "DocumentName": "DocumentName"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_documentname_/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_documentname_/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "DocType": {
+      "description": "The DocType you'd like to receive. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n",
+      "type": "string"
+    },
+    "DocumentName": {
+      "description": "The name (ID) of the document you'd like to receive. For example EMP001 (of type Employee).\n",
+      "type": "string"
+    }
+  },
+  "required": [
+    "DocType",
+    "DocumentName"
+  ]
+}

--- a/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_documentname_/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/get_resource_doctype_documentname_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "DocType": z.string().describe("The DocType you'd like to receive. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n"),
+  "DocumentName": z.string().describe("The name (ID) of the document you'd like to receive. For example EMP001 (of type Employee).\n")
+}

--- a/servers/demo_erpnext_com_api/src/tools/login/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/login/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "login",
+  "toolDescription": "Authenticate yourself",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/method/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "usr": "usr",
+      "pwd": "pwd"
+    },
+    "body": {
+      "usr": "b_usr",
+      "pwd": "b_pwd"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/login/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/login/schema-json/root.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "usr": {
+      "description": "Your username",
+      "type": "string",
+      "example": "Administrator"
+    },
+    "pwd": {
+      "description": "Your password",
+      "type": "string",
+      "example": "admin"
+    },
+    "b_usr": {
+      "type": "string",
+      "example": "Administrator"
+    },
+    "b_pwd": {
+      "type": "string",
+      "example": "admin"
+    }
+  },
+  "required": []
+}

--- a/servers/demo_erpnext_com_api/src/tools/login/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/login/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "usr": z.string().describe("Your username").optional(),
+  "pwd": z.string().describe("Your password").optional(),
+  "b_usr": z.string().optional(),
+  "b_pwd": z.string().optional()
+}

--- a/servers/demo_erpnext_com_api/src/tools/post_resource_doctype_/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/post_resource_doctype_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_resource_doctype_",
+  "toolDescription": "Create a new document",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/resource/{DocType}",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "DocType": "DocType"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/post_resource_doctype_/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/post_resource_doctype_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "DocType": {
+      "description": "The DocType you'd like to receive. For example, Customer.\n",
+      "type": "string",
+      "example": "Customer"
+    }
+  },
+  "required": [
+    "DocType"
+  ]
+}

--- a/servers/demo_erpnext_com_api/src/tools/post_resource_doctype_/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/post_resource_doctype_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "DocType": z.string().describe("The DocType you'd like to receive. For example, Customer.\n")
+}

--- a/servers/demo_erpnext_com_api/src/tools/put_resource_doctype_documentname_/index.ts
+++ b/servers/demo_erpnext_com_api/src/tools/put_resource_doctype_documentname_/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_resource_doctype_documentname_",
+  "toolDescription": "Update a specific document",
+  "baseUrl": "https://demo.erpnext.com/api",
+  "path": "/resource/{DocType}/{DocumentName}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "DocType": "DocType",
+      "DocumentName": "DocumentName"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/demo_erpnext_com_api/src/tools/put_resource_doctype_documentname_/schema-json/root.json
+++ b/servers/demo_erpnext_com_api/src/tools/put_resource_doctype_documentname_/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "DocType": {
+      "description": "The DocType you'd like to update. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n",
+      "type": "string"
+    },
+    "DocumentName": {
+      "description": "The name (ID) of the document you'd like to update. For example EMP001 (of type Employee).\n",
+      "type": "string"
+    }
+  },
+  "required": [
+    "DocType",
+    "DocumentName"
+  ]
+}

--- a/servers/demo_erpnext_com_api/src/tools/put_resource_doctype_documentname_/schema/root.ts
+++ b/servers/demo_erpnext_com_api/src/tools/put_resource_doctype_documentname_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "DocType": z.string().describe("The DocType you'd like to update. For example Customer, Supplier, \nEmployee, Account, Lead, Company, Sales Invoice, Purchase Invoice, Stock Entry, etc.\n"),
+  "DocumentName": z.string().describe("The name (ID) of the document you'd like to update. For example EMP001 (of type Employee).\n")
+}

--- a/servers/demo_erpnext_com_api/tsconfig.json
+++ b/servers/demo_erpnext_com_api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `demo_erpnext_com_api`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/demo_erpnext_com_api`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "demo_erpnext_com_api": {
      "command": "npx",
      "args": ["-y", "@open-mcp/demo_erpnext_com_api"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.