### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,177 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_tasklist
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `search` (string)
+- `page` (string)
+- `limit` (string)
+
+### post_taskcreate
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `name` (string)
+- `slug` (string)
+- `description` (string)
+- `completed` (boolean)
+- `due_date` (string)
+
+### get_taskread
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+
+### put_taskupdate
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+- `name` (string)
+- `slug` (string)
+- `description` (string)
+- `completed` (boolean)
+- `due_date` (string)
+
+### delete_taskdelete
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+
+### post_linewebhook
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `destination` (string)
+- `events` (array)
+- `x-line-signature` (string)
+
+### example_endpoint
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `slug` (string)
+- `name` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,12 @@
+export const OPENAPI_URL = "https://line-rag-chat-backend.atk721.workers.dev/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_tasklist/index.js",
+  "./tools/post_taskcreate/index.js",
+  "./tools/get_taskread/index.js",
+  "./tools/put_taskupdate/index.js",
+  "./tools/delete_taskdelete/index.js",
+  "./tools/post_linewebhook/index.js",
+  "./tools/example_endpoint/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/delete_taskdelete/index.ts
+++ b/servers/api_example_com/src/tools/delete_taskdelete/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_taskdelete",
+  "toolDescription": "Delete a Task",
+  "baseUrl": "https://api.example.com",
+  "path": "/tasks/{id}",
+  "method": "delete",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/delete_taskdelete/schema-json/root.json
+++ b/servers/api_example_com/src/tools/delete_taskdelete/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_example_com/src/tools/delete_taskdelete/schema/root.ts
+++ b/servers/api_example_com/src/tools/delete_taskdelete/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string()
+}

--- a/servers/api_example_com/src/tools/example_endpoint/index.ts
+++ b/servers/api_example_com/src/tools/example_endpoint/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "example_endpoint",
+  "toolDescription": "this endpoint is an example",
+  "baseUrl": "https://api.example.com",
+  "path": "/dummy/{slug}",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "slug": "slug"
+    },
+    "body": {
+      "name": "name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/example_endpoint/schema-json/root.json
+++ b/servers/api_example_com/src/tools/example_endpoint/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "slug": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "slug",
+    "name"
+  ]
+}

--- a/servers/api_example_com/src/tools/example_endpoint/schema/root.ts
+++ b/servers/api_example_com/src/tools/example_endpoint/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "slug": z.string(),
+  "name": z.string()
+}

--- a/servers/api_example_com/src/tools/get_tasklist/index.ts
+++ b/servers/api_example_com/src/tools/get_tasklist/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_tasklist",
+  "toolDescription": "List Tasks",
+  "baseUrl": "https://api.example.com",
+  "path": "/tasks",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "search": "search",
+      "page": "page",
+      "limit": "limit"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_tasklist/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_tasklist/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "search": {
+      "type": "string"
+    },
+    "page": {
+      "type": "string",
+      "default": "1"
+    },
+    "limit": {
+      "type": "string",
+      "default": "10"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_tasklist/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_tasklist/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "search": z.string().optional(),
+  "page": z.string().optional(),
+  "limit": z.string().optional()
+}

--- a/servers/api_example_com/src/tools/get_taskread/index.ts
+++ b/servers/api_example_com/src/tools/get_taskread/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_taskread",
+  "toolDescription": "Get a single Task",
+  "baseUrl": "https://api.example.com",
+  "path": "/tasks/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_taskread/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_taskread/schema-json/root.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_taskread/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_taskread/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string()
+}

--- a/servers/api_example_com/src/tools/post_linewebhook/index.ts
+++ b/servers/api_example_com/src/tools/post_linewebhook/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_linewebhook",
+  "toolDescription": "Handle LINE webhook events",
+  "baseUrl": "https://api.example.com",
+  "path": "/line/webhook",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "destination": "destination",
+      "events": "events"
+    },
+    "header": {
+      "x-line-signature": "x-line-signature"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/post_linewebhook/schema-json/root.json
+++ b/servers/api_example_com/src/tools/post_linewebhook/schema-json/root.json
@@ -1,0 +1,115 @@
+{
+  "type": "object",
+  "properties": {
+    "destination": {
+      "type": "string"
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "userId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "userId"
+            ]
+          },
+          "webhookEventId": {
+            "type": "string"
+          },
+          "deliveryContext": {
+            "type": "object",
+            "properties": {
+              "isRedelivery": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "isRedelivery"
+            ]
+          },
+          "message": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "image"
+                ]
+              },
+              "quoteToken": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              },
+              "contentProvider": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "originalContentUrl": {
+                    "type": "string"
+                  },
+                  "previewImageUrl": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          },
+          "replyToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "timestamp",
+          "source",
+          "webhookEventId",
+          "deliveryContext",
+          "replyToken"
+        ]
+      }
+    },
+    "x-line-signature": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "destination",
+    "events",
+    "x-line-signature"
+  ]
+}

--- a/servers/api_example_com/src/tools/post_linewebhook/schema/root.ts
+++ b/servers/api_example_com/src/tools/post_linewebhook/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "destination": z.string(),
+  "events": z.array(z.object({ "type": z.string(), "mode": z.string().optional(), "timestamp": z.number(), "source": z.object({ "type": z.string(), "userId": z.string() }), "webhookEventId": z.string(), "deliveryContext": z.object({ "isRedelivery": z.boolean() }), "message": z.object({ "id": z.string(), "type": z.enum(["text","image"]), "quoteToken": z.string().optional(), "text": z.string().optional(), "contentProvider": z.object({ "type": z.string(), "originalContentUrl": z.string().optional(), "previewImageUrl": z.string().optional() }).optional() }).optional(), "replyToken": z.string() })),
+  "x-line-signature": z.string()
+}

--- a/servers/api_example_com/src/tools/post_taskcreate/index.ts
+++ b/servers/api_example_com/src/tools/post_taskcreate/index.ts
@@ -1,0 +1,23 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_taskcreate",
+  "toolDescription": "Create a new Task",
+  "baseUrl": "https://api.example.com",
+  "path": "/tasks",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "name": "name",
+      "slug": "slug",
+      "description": "description",
+      "completed": "completed",
+      "due_date": "due_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/post_taskcreate/schema-json/root.json
+++ b/servers/api_example_com/src/tools/post_taskcreate/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "completed": {
+      "type": "boolean"
+    },
+    "due_date": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "name",
+    "slug",
+    "description",
+    "completed",
+    "due_date"
+  ]
+}

--- a/servers/api_example_com/src/tools/post_taskcreate/schema/root.ts
+++ b/servers/api_example_com/src/tools/post_taskcreate/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "name": z.string(),
+  "slug": z.string(),
+  "description": z.string(),
+  "completed": z.boolean(),
+  "due_date": z.string().datetime({ offset: true })
+}

--- a/servers/api_example_com/src/tools/put_taskupdate/index.ts
+++ b/servers/api_example_com/src/tools/put_taskupdate/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_taskupdate",
+  "toolDescription": "Update a Task",
+  "baseUrl": "https://api.example.com",
+  "path": "/tasks/{id}",
+  "method": "put",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "body": {
+      "name": "name",
+      "slug": "slug",
+      "description": "description",
+      "completed": "completed",
+      "due_date": "due_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/put_taskupdate/schema-json/root.json
+++ b/servers/api_example_com/src/tools/put_taskupdate/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "completed": {
+      "type": "boolean"
+    },
+    "due_date": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_example_com/src/tools/put_taskupdate/schema/root.ts
+++ b/servers/api_example_com/src/tools/put_taskupdate/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string(),
+  "name": z.string().optional(),
+  "slug": z.string().optional(),
+  "description": z.string().optional(),
+  "completed": z.boolean().optional(),
+  "due_date": z.string().datetime({ offset: true }).optional()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.