### PR TITLE
Add MCP server `virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0`

### DIFF
--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/.npmignore
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/README.md
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/README.md
@@ -1,0 +1,113 @@
+# @open-mcp/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+OAUTH2_TOKEN='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0 \
+  .cursor/mcp.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0 \
+  /path/to/client/config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `OAUTH2_TOKEN` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_kb_kb_uuid_search
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `kb_uuid` (string)
+- `q` (string)
+- `filter` (string)
+- `order` (string)
+- `v` (string)
+- `rid` (string)
+- `disable` (array)
+- `enable` (array)

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/package.json
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/constants.ts
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/constants.ts
@@ -1,0 +1,6 @@
+export const OPENAPI_URL = "https://raw.githubusercontent.com/nuclia/nucliadb/refs/heads/main/openapi.yaml"
+export const SERVER_NAME = "virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_kb_kb_uuid_search/index.js"
+]

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/index.ts
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/server.ts
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/tools/get_kb_kb_uuid_search/index.ts
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/tools/get_kb_kb_uuid_search/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_kb_kb_uuid_search",
+  "toolDescription": "Main search query",
+  "baseUrl": "https://virtserver.swaggerhub.com/nuclia/nucliadb/1.0.0",
+  "path": "/kb/{kb_uuid}/search",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "kb_uuid": "kb_uuid"
+    },
+    "query": {
+      "q": "q",
+      "filter": "filter",
+      "order": "order",
+      "v": "v",
+      "rid": "rid",
+      "disable": "disable",
+      "enable": "enable"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/tools/get_kb_kb_uuid_search/schema-json/root.json
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/tools/get_kb_kb_uuid_search/schema-json/root.json
@@ -1,0 +1,55 @@
+{
+  "type": "object",
+  "properties": {
+    "kb_uuid": {
+      "description": "UUID of the knowledgebox",
+      "type": "string"
+    },
+    "q": {
+      "description": "Text query. It can be with quotes to force keyword search on that elements.",
+      "type": "string"
+    },
+    "filter": {
+      "description": "Filter query. It should be a list of tags to filter. It can be a range query.",
+      "type": "string"
+    },
+    "order": {
+      "description": "Order query",
+      "type": "string"
+    },
+    "v": {
+      "description": "BASE64 vector encoding",
+      "type": "string"
+    },
+    "rid": {
+      "description": "Resource search",
+      "type": "string"
+    },
+    "disable": {
+      "description": "Disable paragraph, semantic, document, relations",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "paragraph",
+          "semantic",
+          "document",
+          "relations"
+        ]
+      }
+    },
+    "enable": {
+      "description": "Disable paragraph, semantic, document, relations",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "ask"
+        ]
+      }
+    }
+  },
+  "required": [
+    "kb_uuid"
+  ]
+}

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/tools/get_kb_kb_uuid_search/schema/root.ts
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/src/tools/get_kb_kb_uuid_search/schema/root.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "kb_uuid": z.string().describe("UUID of the knowledgebox"),
+  "q": z.string().describe("Text query. It can be with quotes to force keyword search on that elements.").optional(),
+  "filter": z.string().describe("Filter query. It should be a list of tags to filter. It can be a range query.").optional(),
+  "order": z.string().describe("Order query").optional(),
+  "v": z.string().describe("BASE64 vector encoding").optional(),
+  "rid": z.string().describe("Resource search").optional(),
+  "disable": z.array(z.enum(["paragraph","semantic","document","relations"])).describe("Disable paragraph, semantic, document, relations").optional(),
+  "enable": z.array(z.literal("ask")).describe("Disable paragraph, semantic, document, relations").optional()
+}

--- a/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/tsconfig.json
+++ b/servers/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0": {
      "command": "npx",
      "args": ["-y", "@open-mcp/virtserver_swaggerhub_com_nuclia_nucliadb_1_0_0"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.