### PR TITLE
Add MCP server `api_pixalate_com_api_v2`

### DIFF
--- a/servers/api_pixalate_com_api_v2/.npmignore
+++ b/servers/api_pixalate_com_api_v2/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_pixalate_com_api_v2/README.md
+++ b/servers/api_pixalate_com_api_v2/README.md
@@ -1,0 +1,130 @@
+# @open-mcp/api_pixalate_com_api_v2
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_pixalate_com_api_v2": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_pixalate_com_api_v2@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_pixalate_com_api_v2@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+X_API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_pixalate_com_api_v2 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_pixalate_com_api_v2 \
+  .cursor/mcp.json \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_pixalate_com_api_v2 \
+  /path/to/client/config.json \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_pixalate_com_api_v2": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_pixalate_com_api_v2"],
+      "env": {"X_API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `X_API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_mobile_apps_metadata
+
+**Environment variables**
+
+- `X_API_KEY`
+
+**Input schema**
+
+- `pretty` (boolean)
+
+### batch_get_mobile_apps_data
+
+**Environment variables**
+
+- `X_API_KEY`
+
+**Input schema**
+
+- `pretty` (boolean)
+
+### get_mobile_app_data
+
+**Environment variables**
+
+- `X_API_KEY`
+
+**Input schema**
+
+- `appId` (string)
+- `widget` (array)
+- `region` (string)
+- `device` (string)
+- `pretty` (boolean)

--- a/servers/api_pixalate_com_api_v2/package.json
+++ b/servers/api_pixalate_com_api_v2/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_pixalate_com_api_v2",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_pixalate_com_api_v2": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_pixalate_com_api_v2/src/constants.ts
+++ b/servers/api_pixalate_com_api_v2/src/constants.ts
@@ -1,0 +1,8 @@
+export const OPENAPI_URL = "https://api.pixalate.com/.well-known/api/v2/mrt/apps/apps.yml"
+export const SERVER_NAME = "api_pixalate_com_api_v2"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_mobile_apps_metadata/index.js",
+  "./tools/batch_get_mobile_apps_data/index.js",
+  "./tools/get_mobile_app_data/index.js"
+]

--- a/servers/api_pixalate_com_api_v2/src/index.ts
+++ b/servers/api_pixalate_com_api_v2/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_pixalate_com_api_v2/src/server.ts
+++ b/servers/api_pixalate_com_api_v2/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_pixalate_com_api_v2/src/tools/batch_get_mobile_apps_data/index.ts
+++ b/servers/api_pixalate_com_api_v2/src/tools/batch_get_mobile_apps_data/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "batch_get_mobile_apps_data",
+  "toolDescription": "<p>The purpose of this API is to provide risk ratings and reputational data across thousands of mobile applications in a batch mode.</p> <p>Posted data should be in CSV format where each line consists of a single field which is the Bundle I",
+  "baseUrl": "https://api.pixalate.com/api/v2",
+  "path": "/mrt/apps",
+  "method": "post",
+  "security": [
+    {
+      "key": "x-api-key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "pretty": "pretty"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_pixalate_com_api_v2/src/tools/batch_get_mobile_apps_data/schema-json/root.json
+++ b/servers/api_pixalate_com_api_v2/src/tools/batch_get_mobile_apps_data/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "pretty": {
+      "description": "If true, return pretty JSON. Default is false.",
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/api_pixalate_com_api_v2/src/tools/batch_get_mobile_apps_data/schema/root.ts
+++ b/servers/api_pixalate_com_api_v2/src/tools/batch_get_mobile_apps_data/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pretty": z.boolean().describe("If true, return pretty JSON. Default is false.").optional()
+}

--- a/servers/api_pixalate_com_api_v2/src/tools/get_mobile_app_data/index.ts
+++ b/servers/api_pixalate_com_api_v2/src/tools/get_mobile_app_data/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_mobile_app_data",
+  "toolDescription": "The purpose of this API is to provide risk ratings and reputational data for mobile applications. The response is a JSON formatted object containing a list of app information partitioned by region and device.",
+  "baseUrl": "https://api.pixalate.com/api/v2",
+  "path": "/mrt/apps/{appId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "x-api-key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "appId": "appId"
+    },
+    "query": {
+      "widget": "widget",
+      "region": "region",
+      "device": "device",
+      "pretty": "pretty"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_pixalate_com_api_v2/src/tools/get_mobile_app_data/schema-json/root.json
+++ b/servers/api_pixalate_com_api_v2/src/tools/get_mobile_app_data/schema-json/root.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "properties": {
+    "appId": {
+      "description": "The app's unique identifier. This is a package name on Google Play or a track id on Apple app Store.",
+      "type": "string"
+    },
+    "widget": {
+      "description": "Filter by comma-separated list of widgets to return. All widgets are returned by default.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "description": "The identifier for a predefined subset of all the app information available. *If not supplied, usually indicates all widgets.*",
+        "enum": [
+          "appOverview",
+          "appDetails",
+          "pixalateAdvisories",
+          "appAdvisories",
+          "riskOverview",
+          "developerOverview",
+          "trafficOverview",
+          "brandSafety",
+          "appPermissions",
+          "trafficOverlap",
+          "authorizedSellers",
+          "invalidTraffic",
+          "viewability",
+          "inventory",
+          "ctr",
+          "availableCountries",
+          "rankings",
+          "rankingsByCountry",
+          "coppa"
+        ],
+        "example": "appOverview"
+      }
+    },
+    "region": {
+      "description": "A geographic region. *GLOBAL* indicates an aggregate of all regions.",
+      "type": "string",
+      "enum": [
+        "GLOBAL",
+        "NA",
+        "EMEA",
+        "LATAM",
+        "APAC"
+      ],
+      "example": "APAC"
+    },
+    "device": {
+      "description": "The device. *GLOBAL* indicates an aggregate of all devices.",
+      "type": "string",
+      "enum": [
+        "GLOBAL",
+        "smartphone",
+        "tablet"
+      ],
+      "example": "smartphone"
+    },
+    "pretty": {
+      "description": "If true, return pretty JSON. Default is false.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "appId"
+  ]
+}

--- a/servers/api_pixalate_com_api_v2/src/tools/get_mobile_app_data/schema/root.ts
+++ b/servers/api_pixalate_com_api_v2/src/tools/get_mobile_app_data/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "appId": z.string().describe("The app's unique identifier. This is a package name on Google Play or a track id on Apple app Store."),
+  "widget": z.array(z.enum(["appOverview","appDetails","pixalateAdvisories","appAdvisories","riskOverview","developerOverview","trafficOverview","brandSafety","appPermissions","trafficOverlap","authorizedSellers","invalidTraffic","viewability","inventory","ctr","availableCountries","rankings","rankingsByCountry","coppa"]).describe("The identifier for a predefined subset of all the app information available. *If not supplied, usually indicates all widgets.*")).min(1).describe("Filter by comma-separated list of widgets to return. All widgets are returned by default.").optional(),
+  "region": z.enum(["GLOBAL","NA","EMEA","LATAM","APAC"]).describe("A geographic region. *GLOBAL* indicates an aggregate of all regions.").optional(),
+  "device": z.enum(["GLOBAL","smartphone","tablet"]).describe("The device. *GLOBAL* indicates an aggregate of all devices.").optional(),
+  "pretty": z.boolean().describe("If true, return pretty JSON. Default is false.").optional()
+}

--- a/servers/api_pixalate_com_api_v2/src/tools/get_mobile_apps_metadata/index.ts
+++ b/servers/api_pixalate_com_api_v2/src/tools/get_mobile_apps_metadata/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_mobile_apps_metadata",
+  "toolDescription": "The purpose of this API is to provide metadata information for mobile applications in general. The response is a JSON formatted object containing the current user's quota state and the date the mobile applications database was last updated.",
+  "baseUrl": "https://api.pixalate.com/api/v2",
+  "path": "/mrt/apps",
+  "method": "get",
+  "security": [
+    {
+      "key": "x-api-key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "pretty": "pretty"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_pixalate_com_api_v2/src/tools/get_mobile_apps_metadata/schema-json/root.json
+++ b/servers/api_pixalate_com_api_v2/src/tools/get_mobile_apps_metadata/schema-json/root.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "pretty": {
+      "description": "If true, return pretty JSON. Default is false.",
+      "type": "boolean"
+    }
+  },
+  "required": []
+}

--- a/servers/api_pixalate_com_api_v2/src/tools/get_mobile_apps_metadata/schema/root.ts
+++ b/servers/api_pixalate_com_api_v2/src/tools/get_mobile_apps_metadata/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pretty": z.boolean().describe("If true, return pretty JSON. Default is false.").optional()
+}

--- a/servers/api_pixalate_com_api_v2/tsconfig.json
+++ b/servers/api_pixalate_com_api_v2/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_pixalate_com_api_v2`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_pixalate_com_api_v2`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_pixalate_com_api_v2": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_pixalate_com_api_v2"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.