### PR TITLE
Add MCP server `api_demo_ecommerce_com_v1`

### DIFF
--- a/servers/api_demo_ecommerce_com_v1/.npmignore
+++ b/servers/api_demo_ecommerce_com_v1/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_demo_ecommerce_com_v1/README.md
+++ b/servers/api_demo_ecommerce_com_v1/README.md
@@ -1,0 +1,219 @@
+# @open-mcp/api_demo_ecommerce_com_v1
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_demo_ecommerce_com_v1": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_demo_ecommerce_com_v1@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_demo_ecommerce_com_v1@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_demo_ecommerce_com_v1 \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_demo_ecommerce_com_v1 \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_demo_ecommerce_com_v1 \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_demo_ecommerce_com_v1": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_demo_ecommerce_com_v1"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### post_auth_register
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `email` (string)
+- `password` (string)
+- `name` (string)
+
+### post_auth_login
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `email` (string)
+- `password` (string)
+
+### get_products
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `category` (string)
+- `search` (string)
+- `min_price` (number)
+- `max_price` (number)
+
+### get_products_id_
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `id` (string)
+
+### get_cart
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### post_cart_items
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `product_id` (string)
+- `quantity` (integer)
+
+### post_checkout
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `address_id` (string)
+- `payment_method_id` (string)
+
+### get_orders
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_orders_orderid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `orderId` (string)
+
+### get_addresses
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### post_addresses
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `line1` (string)
+- `line2` (string)
+- `city` (string)
+- `state` (string)
+- `postal_code` (string)
+- `country` (string)

--- a/servers/api_demo_ecommerce_com_v1/package.json
+++ b/servers/api_demo_ecommerce_com_v1/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_demo_ecommerce_com_v1",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_demo_ecommerce_com_v1": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_demo_ecommerce_com_v1/src/constants.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/constants.ts
@@ -1,0 +1,16 @@
+export const OPENAPI_URL = "https://beeceptor.com/docs/storefront-sample.json"
+export const SERVER_NAME = "api_demo_ecommerce_com_v1"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/post_auth_register/index.js",
+  "./tools/post_auth_login/index.js",
+  "./tools/get_products/index.js",
+  "./tools/get_products_id_/index.js",
+  "./tools/get_cart/index.js",
+  "./tools/post_cart_items/index.js",
+  "./tools/post_checkout/index.js",
+  "./tools/get_orders/index.js",
+  "./tools/get_orders_orderid_/index.js",
+  "./tools/get_addresses/index.js",
+  "./tools/post_addresses/index.js"
+]

--- a/servers/api_demo_ecommerce_com_v1/src/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_demo_ecommerce_com_v1/src/server.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_addresses/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_addresses/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_addresses",
+  "toolDescription": "Get your saved addresses",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/addresses",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_addresses/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_addresses/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_addresses/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_addresses/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_cart/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_cart/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_cart",
+  "toolDescription": "Get current user's cart",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/cart",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_cart/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_cart/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_cart/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_cart/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_orders/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_orders/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_orders",
+  "toolDescription": "List your past orders",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/orders",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_orders/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_orders/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_orders/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_orders/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_orders_orderid_/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_orders_orderid_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_orders_orderid_",
+  "toolDescription": "Get order details",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/orders/{orderId}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "orderId": "orderId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_orders_orderid_/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_orders_orderid_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "orderId"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_orders_orderid_/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_orders_orderid_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "orderId": z.string().uuid()
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_products/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_products/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_products",
+  "toolDescription": "List all products with filters",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/products",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "category": "category",
+      "search": "search",
+      "min_price": "min_price",
+      "max_price": "max_price"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_products/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_products/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "category": {
+      "type": "string"
+    },
+    "search": {
+      "type": "string"
+    },
+    "min_price": {
+      "type": "number"
+    },
+    "max_price": {
+      "type": "number"
+    }
+  },
+  "required": []
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_products/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_products/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "category": z.string().optional(),
+  "search": z.string().optional(),
+  "min_price": z.number().optional(),
+  "max_price": z.number().optional()
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_products_id_/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_products_id_/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_products_id_",
+  "toolDescription": "Get product details by ID",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/products/{id}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_products_id_/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_products_id_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/get_products_id_/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/get_products_id_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid()
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_addresses/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_addresses/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_addresses",
+  "toolDescription": "Add a new address",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/addresses",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "line1": "line1",
+      "line2": "line2",
+      "city": "city",
+      "state": "state",
+      "postal_code": "postal_code",
+      "country": "country"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_addresses/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_addresses/schema-json/root.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "properties": {
+    "line1": {
+      "type": "string"
+    },
+    "line2": {
+      "type": "string"
+    },
+    "city": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "postal_code": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "line1",
+    "city",
+    "state",
+    "postal_code",
+    "country"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_addresses/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_addresses/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "line1": z.string(),
+  "line2": z.string().optional(),
+  "city": z.string(),
+  "state": z.string(),
+  "postal_code": z.string(),
+  "country": z.string()
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_login/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_login/index.ts
@@ -1,0 +1,20 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_auth_login",
+  "toolDescription": "Login and get access token",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/auth/login",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "email": "email",
+      "password": "password"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_login/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_login/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "email",
+    "password"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_login/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_login/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email": z.string(),
+  "password": z.string()
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_register/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_register/index.ts
@@ -1,0 +1,21 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_auth_register",
+  "toolDescription": "Create a new user account",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/auth/register",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "email": "email",
+      "password": "password",
+      "name": "name"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_register/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_register/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "password": {
+      "type": "string",
+      "format": "password"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "email",
+    "password"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_register/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_auth_register/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "email": z.string().email(),
+  "password": z.string(),
+  "name": z.string().optional()
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_cart_items/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_cart_items/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_cart_items",
+  "toolDescription": "Add item to cart",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/cart/items",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "product_id": "product_id",
+      "quantity": "quantity"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_cart_items/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_cart_items/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "product_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 1
+    }
+  },
+  "required": [
+    "product_id",
+    "quantity"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_cart_items/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_cart_items/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "product_id": z.string().uuid(),
+  "quantity": z.number().int().gte(1)
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_checkout/index.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_checkout/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_checkout",
+  "toolDescription": "Checkout and place order",
+  "baseUrl": "https://api.demo-ecommerce.com/v1",
+  "path": "/checkout",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "address_id": "address_id",
+      "payment_method_id": "payment_method_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_checkout/schema-json/root.json
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_checkout/schema-json/root.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "address_id": {
+      "type": "string"
+    },
+    "payment_method_id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "address_id",
+    "payment_method_id"
+  ]
+}

--- a/servers/api_demo_ecommerce_com_v1/src/tools/post_checkout/schema/root.ts
+++ b/servers/api_demo_ecommerce_com_v1/src/tools/post_checkout/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "address_id": z.string(),
+  "payment_method_id": z.string()
+}

--- a/servers/api_demo_ecommerce_com_v1/tsconfig.json
+++ b/servers/api_demo_ecommerce_com_v1/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_demo_ecommerce_com_v1`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_demo_ecommerce_com_v1`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_demo_ecommerce_com_v1": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_demo_ecommerce_com_v1"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.