### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,198 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+USERNAME_PASSWORD_BASE64='...'
+X_API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --USERNAME_PASSWORD_BASE64=$USERNAME_PASSWORD_BASE64 \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json \
+  --USERNAME_PASSWORD_BASE64=$USERNAME_PASSWORD_BASE64 \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json \
+  --USERNAME_PASSWORD_BASE64=$USERNAME_PASSWORD_BASE64 \
+  --X_API_KEY=$X_API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {"USERNAME_PASSWORD_BASE64":"...","X_API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `USERNAME_PASSWORD_BASE64` - gets sent to the API provider
+- `X_API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### generate_resume_generate_resume_post
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `role` (string)
+- `job_description` (string)
+- `format` (string)
+- `original_resume` (other)
+- `enable_thinking` (boolean)
+
+### download_file_download_filename_get
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+
+### get_resume_resume_resume_id_get
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `resume_id` (integer)
+
+### evaluate_resume_evaluate_resume_post
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `pdf_url` (string)
+- `job_description` (string)
+
+### create_resume_from_content_create_resume_from_content_post
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `role` (string)
+- `profile_summary` (string)
+- `key_achievements` (array)
+- `areas_of_expertise` (array)
+- `format` (string)
+
+### compile_typ_compile_typ_post
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `typ_file` (string)
+- `output_filename` (other)
+
+### generate_download_link_generate_link_filename_get
+
+**Environment variables**
+
+- `USERNAME_PASSWORD_BASE64`
+- `X_API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+
+### health_check_health_get
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,13 @@
+export const OPENAPI_URL = "https://rxapi.peerapat.cv/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/generate_resume_generate_resume_post/index.js",
+  "./tools/download_file_download_filename_get/index.js",
+  "./tools/get_resume_resume_resume_id_get/index.js",
+  "./tools/evaluate_resume_evaluate_resume_post/index.js",
+  "./tools/create_resume_from_content_create_resume_from_content_post/index.js",
+  "./tools/compile_typ_compile_typ_post/index.js",
+  "./tools/generate_download_link_generate_link_filename_get/index.js",
+  "./tools/health_check_health_get/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/compile_typ_compile_typ_post/index.ts
+++ b/servers/api_example_com/src/tools/compile_typ_compile_typ_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "compile_typ_compile_typ_post",
+  "toolDescription": "Compile Typ",
+  "baseUrl": "https://api.example.com",
+  "path": "/compile_typ",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "typ_file": "typ_file",
+      "output_filename": "output_filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/compile_typ_compile_typ_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/compile_typ_compile_typ_post/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "typ_file": {
+      "type": "string",
+      "title": "Typ File"
+    },
+    "output_filename": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Output Filename"
+    }
+  },
+  "required": [
+    "typ_file"
+  ]
+}

--- a/servers/api_example_com/src/tools/compile_typ_compile_typ_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/compile_typ_compile_typ_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "typ_file": z.string(),
+  "output_filename": z.union([z.string(), z.null()]).optional()
+}

--- a/servers/api_example_com/src/tools/create_resume_from_content_create_resume_from_content_post/index.ts
+++ b/servers/api_example_com/src/tools/create_resume_from_content_create_resume_from_content_post/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "create_resume_from_content_create_resume_from_content_post",
+  "toolDescription": "Create Resume From Content",
+  "baseUrl": "https://api.example.com",
+  "path": "/create_resume_from_content",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "role": "role",
+      "profile_summary": "profile_summary",
+      "key_achievements": "key_achievements",
+      "areas_of_expertise": "areas_of_expertise",
+      "format": "format"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/create_resume_from_content_create_resume_from_content_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/create_resume_from_content_create_resume_from_content_post/schema-json/root.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string",
+      "maxLength": 100,
+      "minLength": 2,
+      "title": "Role"
+    },
+    "profile_summary": {
+      "type": "string",
+      "maxLength": 1000,
+      "minLength": 10,
+      "title": "Profile Summary"
+    },
+    "key_achievements": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "maxItems": 10,
+      "minItems": 1,
+      "title": "Key Achievements"
+    },
+    "areas_of_expertise": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "maxItems": 20,
+      "minItems": 1,
+      "title": "Areas Of Expertise"
+    },
+    "format": {
+      "type": "string",
+      "pattern": "^(pdf|typ)$",
+      "title": "Format",
+      "default": "pdf"
+    }
+  },
+  "required": [
+    "role",
+    "profile_summary",
+    "key_achievements",
+    "areas_of_expertise"
+  ]
+}

--- a/servers/api_example_com/src/tools/create_resume_from_content_create_resume_from_content_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/create_resume_from_content_create_resume_from_content_post/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "role": z.string().min(2).max(100),
+  "profile_summary": z.string().min(10).max(1000),
+  "key_achievements": z.array(z.string()).min(1).max(10),
+  "areas_of_expertise": z.array(z.string()).min(1).max(20),
+  "format": z.string().regex(new RegExp("^(pdf|typ)$")).optional()
+}

--- a/servers/api_example_com/src/tools/download_file_download_filename_get/index.ts
+++ b/servers/api_example_com/src/tools/download_file_download_filename_get/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "download_file_download_filename_get",
+  "toolDescription": "Download File",
+  "baseUrl": "https://api.example.com",
+  "path": "/download/{filename}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/download_file_download_filename_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/download_file_download_filename_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "type": "string",
+      "title": "Filename"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/api_example_com/src/tools/download_file_download_filename_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/download_file_download_filename_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string()
+}

--- a/servers/api_example_com/src/tools/evaluate_resume_evaluate_resume_post/index.ts
+++ b/servers/api_example_com/src/tools/evaluate_resume_evaluate_resume_post/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "evaluate_resume_evaluate_resume_post",
+  "toolDescription": "Evaluate Resume",
+  "baseUrl": "https://api.example.com",
+  "path": "/evaluate_resume",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "pdf_url": "pdf_url",
+      "job_description": "job_description"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/evaluate_resume_evaluate_resume_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/evaluate_resume_evaluate_resume_post/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "pdf_url": {
+      "type": "string",
+      "maxLength": 2083,
+      "minLength": 1,
+      "format": "uri",
+      "title": "Pdf Url"
+    },
+    "job_description": {
+      "type": "string",
+      "maxLength": 5000,
+      "minLength": 10,
+      "title": "Job Description"
+    }
+  },
+  "required": [
+    "pdf_url",
+    "job_description"
+  ]
+}

--- a/servers/api_example_com/src/tools/evaluate_resume_evaluate_resume_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/evaluate_resume_evaluate_resume_post/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pdf_url": z.string().url().min(1).max(2083),
+  "job_description": z.string().min(10).max(5000)
+}

--- a/servers/api_example_com/src/tools/generate_download_link_generate_link_filename_get/index.ts
+++ b/servers/api_example_com/src/tools/generate_download_link_generate_link_filename_get/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "generate_download_link_generate_link_filename_get",
+  "toolDescription": "Generate Download Link",
+  "baseUrl": "https://api.example.com",
+  "path": "/generate-link/{filename}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/generate_download_link_generate_link_filename_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/generate_download_link_generate_link_filename_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "type": "string",
+      "title": "Filename"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/api_example_com/src/tools/generate_download_link_generate_link_filename_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/generate_download_link_generate_link_filename_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string()
+}

--- a/servers/api_example_com/src/tools/generate_resume_generate_resume_post/index.ts
+++ b/servers/api_example_com/src/tools/generate_resume_generate_resume_post/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "generate_resume_generate_resume_post",
+  "toolDescription": "Generate Resume",
+  "baseUrl": "https://api.example.com",
+  "path": "/generate_resume",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "body": {
+      "role": "role",
+      "job_description": "job_description",
+      "format": "format",
+      "original_resume": "original_resume",
+      "enable_thinking": "enable_thinking"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/generate_resume_generate_resume_post/schema-json/root.json
+++ b/servers/api_example_com/src/tools/generate_resume_generate_resume_post/schema-json/root.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string",
+      "maxLength": 100,
+      "minLength": 2,
+      "title": "Role"
+    },
+    "job_description": {
+      "type": "string",
+      "maxLength": 5000,
+      "minLength": 10,
+      "title": "Job Description"
+    },
+    "format": {
+      "type": "string",
+      "pattern": "^(pdf|typ)$",
+      "title": "Format",
+      "default": "pdf"
+    },
+    "original_resume": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Original Resume"
+    },
+    "enable_thinking": {
+      "type": "boolean",
+      "title": "Enable Thinking",
+      "default": false
+    }
+  },
+  "required": [
+    "role",
+    "job_description"
+  ]
+}

--- a/servers/api_example_com/src/tools/generate_resume_generate_resume_post/schema/root.ts
+++ b/servers/api_example_com/src/tools/generate_resume_generate_resume_post/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "role": z.string().min(2).max(100),
+  "job_description": z.string().min(10).max(5000),
+  "format": z.string().regex(new RegExp("^(pdf|typ)$")).optional(),
+  "original_resume": z.union([z.string(), z.null()]).optional(),
+  "enable_thinking": z.boolean().optional()
+}

--- a/servers/api_example_com/src/tools/get_resume_resume_resume_id_get/index.ts
+++ b/servers/api_example_com/src/tools/get_resume_resume_resume_id_get/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_resume_resume_resume_id_get",
+  "toolDescription": "Get Resume",
+  "baseUrl": "https://api.example.com",
+  "path": "/resume/{resume_id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Basic <mcp-env-var>USERNAME_PASSWORD_BASE64</mcp-env-var>",
+      "in": "header",
+      "envVarName": "USERNAME_PASSWORD_BASE64"
+    },
+    {
+      "key": "X-API-Key",
+      "value": "<mcp-env-var>X_API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "X_API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "resume_id": "resume_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_resume_resume_resume_id_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_resume_resume_resume_id_get/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "resume_id": {
+      "type": "integer",
+      "title": "Resume Id"
+    }
+  },
+  "required": [
+    "resume_id"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_resume_resume_resume_id_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_resume_resume_resume_id_get/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "resume_id": z.number().int()
+}

--- a/servers/api_example_com/src/tools/health_check_health_get/index.ts
+++ b/servers/api_example_com/src/tools/health_check_health_get/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "health_check_health_get",
+  "toolDescription": "Health Check",
+  "baseUrl": "https://api.example.com",
+  "path": "/health",
+  "method": "get",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/health_check_health_get/schema-json/root.json
+++ b/servers/api_example_com/src/tools/health_check_health_get/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_example_com/src/tools/health_check_health_get/schema/root.ts
+++ b/servers/api_example_com/src/tools/health_check_health_get/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.