### PR TITLE
Add MCP server `api_bnkbl_com`

### DIFF
--- a/servers/api_bnkbl_com/.npmignore
+++ b/servers/api_bnkbl_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_bnkbl_com/README.md
+++ b/servers/api_bnkbl_com/README.md
@@ -1,0 +1,512 @@
+# @open-mcp/api_bnkbl_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_bnkbl_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_bnkbl_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_bnkbl_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+OAUTH2_TOKEN='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_bnkbl_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_bnkbl_com \
+  .cursor/mcp.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_bnkbl_com \
+  /path/to/client/config.json \
+  --OAUTH2_TOKEN=$OAUTH2_TOKEN
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_bnkbl_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_bnkbl_com"],
+      "env": {"OAUTH2_TOKEN":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `OAUTH2_TOKEN` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### gettoken
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+No input parameters
+
+### createclient
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### requestcontract
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `client_id` (string)
+- `product` (string)
+- `signers` (array)
+
+### uploadproofofaddress
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `client_id` (string)
+- `product` (string)
+
+### submitkyb
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `client_id` (string)
+- `product` (string)
+- `annual_revenue` (number)
+- `incorporation_date` (string)
+- `financial_institution` (boolean)
+- `income_source` (string)
+- `trading_name` (string)
+- `industry` (string)
+- `financing_frequency` (string)
+- `financing_needed` (number)
+- `comments` (string)
+- `ultimate_beneficial_owners` (array)
+- `directors` (array)
+- `corporate_structure` (array)
+
+### submitbankdata
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### getcontractsigners
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `client_id` (string)
+- `product` (string)
+
+### findclient
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `limit` (integer)
+- `offset` (integer)
+- `id` (string)
+- `state` (string)
+- `missing_bank_details` (boolean)
+- `crn` (string)
+- `product_id` (string)
+
+### getclient
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+- `product_id` (string)
+
+### importfinancial
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `client_id` (string)
+
+### getfinancingindicator
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `client_id` (string)
+
+### getpricebreakdown
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `debtor_country_code` (string)
+- `debtor_crn` (string)
+- `issuer_country_code` (string)
+- `issuer_crn` (string)
+- `face_value` (number)
+- `due_date` (string)
+
+### createinvoice
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### findinvoices
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `limit` (string)
+- `offset` (string)
+- `sort_by` (string)
+- `descending` (string)
+- `invoice_number` (string)
+- `invoice_number[]` (string)
+- `payment_reference` (string)
+- `payment_reference[]` (string)
+- `face_value_from` (string)
+- `face_value_to` (string)
+- `currency` (string)
+- `currency[]` (string)
+- `issuer_name_like` (string)
+- `issuer_country[]` (string)
+- `issuer_registration_number` (string)
+- `issuer_registration_number[]` (string)
+- `debtor_name_like` (string)
+- `debtor_country[]` (string)
+- `debtor_registration_number` (string)
+- `debtor_registration_number[]` (string)
+
+### getinvoice
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### cancelinvoice
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### getcreditpricebreakdown
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `country` (string)
+- `registration_number` (string)
+
+### createcredit
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### findcredits
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `limit` (string)
+- `offset` (string)
+- `sort_by` (string)
+- `descending` (string)
+- `id[]` (string)
+- `number[]` (string)
+- `state[]` (string)
+- `amount_from` (string)
+- `amount_to` (string)
+- `currency[]` (string)
+- `installments` (string)
+- `client_id[]` (string)
+
+### getcredit
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### cancelcredit
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### getpayablespricebreakdown
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+- `financing_amount` (number)
+- `repayment_method` (string)
+
+### submitpayables
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### findpayables
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `limit` (string)
+- `offset` (string)
+- `sort_by` (string)
+- `descending` (string)
+- `id[]` (string)
+- `state[]` (string)
+- `client_id[]` (string)
+- `total_requested_amount_from` (string)
+- `total_requested_amount_to` (string)
+- `currency[]` (string)
+
+### getpayabledetails
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### uploadinvoicepayablefile
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+No input parameters
+
+### approverepaymentplan
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+
+### declinerepaymentplan
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `id` (string)
+- `decline_reason` (string)
+
+### getbalances
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `account_id` (string)
+
+### findcashtransactions
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `account_id` (string)
+- `start_date` (string)
+- `end_date` (string)
+
+### findtrades
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `account_id` (string)
+- `limit` (string)
+- `offset` (string)
+- `start_date` (string)
+- `end_date` (string)
+
+### findpositions
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `account_id` (string)
+- `limit` (string)
+- `offset` (string)
+- `start_date` (string)
+- `end_date` (string)
+
+### findoverdue
+
+**Environment variables**
+
+- `OAUTH2_TOKEN`
+
+**Input schema**
+
+- `account_id` (string)
+- `limit` (string)
+- `offset` (string)
+- `start_date` (string)
+- `end_date` (string)

--- a/servers/api_bnkbl_com/package.json
+++ b/servers/api_bnkbl_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_bnkbl_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_bnkbl_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_bnkbl_com/src/constants.ts
+++ b/servers/api_bnkbl_com/src/constants.ts
@@ -1,0 +1,38 @@
+export const OPENAPI_URL = "https://developers.bnkbl.com/openapi/openapi.yaml"
+export const SERVER_NAME = "api_bnkbl_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/gettoken/index.js",
+  "./tools/createclient/index.js",
+  "./tools/requestcontract/index.js",
+  "./tools/uploadproofofaddress/index.js",
+  "./tools/submitkyb/index.js",
+  "./tools/submitbankdata/index.js",
+  "./tools/getcontractsigners/index.js",
+  "./tools/findclient/index.js",
+  "./tools/getclient/index.js",
+  "./tools/importfinancial/index.js",
+  "./tools/getfinancingindicator/index.js",
+  "./tools/getpricebreakdown/index.js",
+  "./tools/createinvoice/index.js",
+  "./tools/findinvoices/index.js",
+  "./tools/getinvoice/index.js",
+  "./tools/cancelinvoice/index.js",
+  "./tools/getcreditpricebreakdown/index.js",
+  "./tools/createcredit/index.js",
+  "./tools/findcredits/index.js",
+  "./tools/getcredit/index.js",
+  "./tools/cancelcredit/index.js",
+  "./tools/getpayablespricebreakdown/index.js",
+  "./tools/submitpayables/index.js",
+  "./tools/findpayables/index.js",
+  "./tools/getpayabledetails/index.js",
+  "./tools/uploadinvoicepayablefile/index.js",
+  "./tools/approverepaymentplan/index.js",
+  "./tools/declinerepaymentplan/index.js",
+  "./tools/getbalances/index.js",
+  "./tools/findcashtransactions/index.js",
+  "./tools/findtrades/index.js",
+  "./tools/findpositions/index.js",
+  "./tools/findoverdue/index.js"
+]

--- a/servers/api_bnkbl_com/src/index.ts
+++ b/servers/api_bnkbl_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_bnkbl_com/src/server.ts
+++ b/servers/api_bnkbl_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_bnkbl_com/src/tools/approverepaymentplan/index.ts
+++ b/servers/api_bnkbl_com/src/tools/approverepaymentplan/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "approverepaymentplan",
+  "toolDescription": "Approve repayment plan",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables/{id}/approve",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/approverepaymentplan/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/approverepaymentplan/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the payable financing request ID provided by Bankable when the payables were submitted",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/approverepaymentplan/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/approverepaymentplan/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("This is the payable financing request ID provided by Bankable when the payables were submitted")
+}

--- a/servers/api_bnkbl_com/src/tools/cancelcredit/index.ts
+++ b/servers/api_bnkbl_com/src/tools/cancelcredit/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cancelcredit",
+  "toolDescription": "Cancel credit",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/credit/{id}/cancel",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/cancelcredit/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/cancelcredit/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the credit ID provided by Bankable when the credit was created (see the \"Create Credit\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/cancelcredit/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/cancelcredit/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("This is the credit ID provided by Bankable when the credit was created (see the \"Create Credit\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/cancelinvoice/index.ts
+++ b/servers/api_bnkbl_com/src/tools/cancelinvoice/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "cancelinvoice",
+  "toolDescription": "Cancel invoice finance",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/invoice/{id}/cancel",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/cancelinvoice/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/cancelinvoice/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the Invoice ID provided by Bankable when the invoice was created (see the \"Create invoice\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/cancelinvoice/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/cancelinvoice/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("This is the Invoice ID provided by Bankable when the invoice was created (see the \"Create invoice\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/createclient/index.ts
+++ b/servers/api_bnkbl_com/src/tools/createclient/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createclient",
+  "toolDescription": "Create client",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/createclient/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/createclient/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/createclient/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/createclient/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_bnkbl_com/src/tools/createcredit/index.ts
+++ b/servers/api_bnkbl_com/src/tools/createcredit/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createcredit",
+  "toolDescription": "Submit credit",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/credit",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/createcredit/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/createcredit/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/createcredit/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/createcredit/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_bnkbl_com/src/tools/createinvoice/index.ts
+++ b/servers/api_bnkbl_com/src/tools/createinvoice/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "createinvoice",
+  "toolDescription": "Submit invoice",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/invoice",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/createinvoice/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/createinvoice/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/createinvoice/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/createinvoice/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_bnkbl_com/src/tools/declinerepaymentplan/index.ts
+++ b/servers/api_bnkbl_com/src/tools/declinerepaymentplan/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "declinerepaymentplan",
+  "toolDescription": "Decline repayment plan",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables/{id}/decline",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "query": {
+      "decline_reason": "decline_reason"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/declinerepaymentplan/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/declinerepaymentplan/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the payable financing request ID provided by Bankable when the payables were submitted",
+      "type": "string"
+    },
+    "decline_reason": {
+      "description": "The reason for declining the financing request",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "decline_reason"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/declinerepaymentplan/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/declinerepaymentplan/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("This is the payable financing request ID provided by Bankable when the payables were submitted"),
+  "decline_reason": z.string().describe("The reason for declining the financing request")
+}

--- a/servers/api_bnkbl_com/src/tools/findcashtransactions/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findcashtransactions/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findcashtransactions",
+  "toolDescription": "Find cash transactions",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/investor/{account_id}/cash-transactions",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "account_id": "account_id"
+    },
+    "query": {
+      "start_date": "start_date",
+      "end_date": "end_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findcashtransactions/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findcashtransactions/schema-json/root.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "account_id": {
+      "description": "The unique identifier of the investor account.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "start_date": {
+      "description": "Start date of the range for cash transactions (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    },
+    "end_date": {
+      "description": "End date of the range for cash transactions (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    }
+  },
+  "required": [
+    "account_id",
+    "start_date",
+    "end_date"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/findcashtransactions/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findcashtransactions/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account_id": z.string().uuid().describe("The unique identifier of the investor account."),
+  "start_date": z.string().date().describe("Start date of the range for cash transactions (must be less than 180 days)."),
+  "end_date": z.string().date().describe("End date of the range for cash transactions (must be less than 180 days).")
+}

--- a/servers/api_bnkbl_com/src/tools/findclient/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findclient/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findclient",
+  "toolDescription": "List clients",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/clients",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "id": "id",
+      "state": "state",
+      "missing_bank_details": "missing_bank_details",
+      "crn": "crn",
+      "product_id": "product_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findclient/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findclient/schema-json/root.json
@@ -1,0 +1,52 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "The number of items to obtain per response. The limit/offset schema is used for pagination. The maximum allowed value is 100.",
+      "type": "integer"
+    },
+    "offset": {
+      "description": "The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.",
+      "type": "integer"
+    },
+    "id": {
+      "description": "Use to filter the result using a client ID. Multiple IDs in the query are supported using `key=value` pairs.",
+      "type": "string"
+    },
+    "state": {
+      "description": "Use to filter the result using client state. Multiple states in the query are supported using `key=value` pairs.",
+      "type": "string",
+      "enum": [
+        "NEW_LEAD",
+        "LEAD_VERIFIED",
+        "LEAD_REJECTED",
+        "CONTRACT_SIGNED",
+        "COMPANY_CREATED",
+        "COMPANY_REQUESTED",
+        "CONTRACT_SENT",
+        "CONTRACT_GENERATED",
+        "LEAD_INVALID_SIGNERS"
+      ]
+    },
+    "missing_bank_details": {
+      "description": "Use to filter the results to show companies that are missing only the bank details to complete the onboarding.",
+      "type": "boolean"
+    },
+    "crn": {
+      "description": "Use to filter the result using CRN (country code + registration number). Multiple CRNs in the query are supported using `key=value` pairs.",
+      "type": "string"
+    },
+    "product_id": {
+      "description": "Use to filter the result using a product ID. Multiple product IDs in the query are supported using `key=value` pairs.",
+      "type": "string",
+      "enum": [
+        "ETR",
+        "ETC"
+      ]
+    }
+  },
+  "required": [
+    "limit",
+    "offset"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/findclient/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findclient/schema/root.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.number().int().describe("The number of items to obtain per response. The limit/offset schema is used for pagination. The maximum allowed value is 100."),
+  "offset": z.number().int().describe("The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0."),
+  "id": z.string().describe("Use to filter the result using a client ID. Multiple IDs in the query are supported using `key=value` pairs.").optional(),
+  "state": z.enum(["NEW_LEAD","LEAD_VERIFIED","LEAD_REJECTED","CONTRACT_SIGNED","COMPANY_CREATED","COMPANY_REQUESTED","CONTRACT_SENT","CONTRACT_GENERATED","LEAD_INVALID_SIGNERS"]).describe("Use to filter the result using client state. Multiple states in the query are supported using `key=value` pairs.").optional(),
+  "missing_bank_details": z.boolean().describe("Use to filter the results to show companies that are missing only the bank details to complete the onboarding.").optional(),
+  "crn": z.string().describe("Use to filter the result using CRN (country code + registration number). Multiple CRNs in the query are supported using `key=value` pairs.").optional(),
+  "product_id": z.enum(["ETR","ETC"]).describe("Use to filter the result using a product ID. Multiple product IDs in the query are supported using `key=value` pairs.").optional()
+}

--- a/servers/api_bnkbl_com/src/tools/findcredits/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findcredits/index.ts
@@ -1,0 +1,37 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findcredits",
+  "toolDescription": "List credits",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/credits",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "sort_by": "sort_by",
+      "descending": "descending",
+      "id[]": "id[]",
+      "number[]": "number[]",
+      "state[]": "state[]",
+      "amount_from": "amount_from",
+      "amount_to": "amount_to",
+      "currency[]": "currency[]",
+      "installments": "installments",
+      "client_id[]": "client_id[]"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findcredits/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findcredits/schema-json/root.json
@@ -1,0 +1,64 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "The number of items to obtain per response. The limit/offset schema is used for pagination. The default value is 10. The maximum allowed value is 100.",
+      "type": "string"
+    },
+    "offset": {
+      "description": "The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.",
+      "type": "string"
+    },
+    "sort_by": {
+      "description": "Use to determine which value to use to sort the paginated result. The default value is created_at.",
+      "type": "string",
+      "enum": [
+        "id",
+        "created_at",
+        "number",
+        "state",
+        "amount",
+        "currency",
+        "installments",
+        "client_id"
+      ]
+    },
+    "descending": {
+      "description": "Use to determine the sorting order as either descending or ascending. The default value is false, which corresponds to ascending order.",
+      "type": "string"
+    },
+    "id[]": {
+      "description": "Use to filter the credits list by a collection of credit IDs. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "number[]": {
+      "description": "Use to filter the credits list by a collection of credit number. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "state[]": {
+      "description": "Use to filter the credits list by a collection of credit states. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "amount_from": {
+      "description": "Use to filter the credits list by amount value above than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.",
+      "type": "string"
+    },
+    "amount_to": {
+      "description": "Use to filter the credits list by amount value below than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.",
+      "type": "string"
+    },
+    "currency[]": {
+      "description": "Use to filter the credits list by a collection of currencies. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.",
+      "type": "string"
+    },
+    "installments": {
+      "description": "Use to filter the credits list by the number of instalments given.",
+      "type": "string"
+    },
+    "client_id[]": {
+      "description": "Use to filter the credits list by a collection of client IDs. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/findcredits/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findcredits/schema/root.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.string().describe("The number of items to obtain per response. The limit/offset schema is used for pagination. The default value is 10. The maximum allowed value is 100.").optional(),
+  "offset": z.string().describe("The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.").optional(),
+  "sort_by": z.enum(["id","created_at","number","state","amount","currency","installments","client_id"]).describe("Use to determine which value to use to sort the paginated result. The default value is created_at.").optional(),
+  "descending": z.string().describe("Use to determine the sorting order as either descending or ascending. The default value is false, which corresponds to ascending order.").optional(),
+  "id[]": z.string().describe("Use to filter the credits list by a collection of credit IDs. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "number[]": z.string().describe("Use to filter the credits list by a collection of credit number. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "state[]": z.string().describe("Use to filter the credits list by a collection of credit states. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "amount_from": z.string().describe("Use to filter the credits list by amount value above than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.").optional(),
+  "amount_to": z.string().describe("Use to filter the credits list by amount value below than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.").optional(),
+  "currency[]": z.string().describe("Use to filter the credits list by a collection of currencies. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.").optional(),
+  "installments": z.string().describe("Use to filter the credits list by the number of instalments given.").optional(),
+  "client_id[]": z.string().describe("Use to filter the credits list by a collection of client IDs. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.").optional()
+}

--- a/servers/api_bnkbl_com/src/tools/findinvoices/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findinvoices/index.ts
@@ -1,0 +1,45 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findinvoices",
+  "toolDescription": "List invoices",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/invoices",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "sort_by": "sort_by",
+      "descending": "descending",
+      "invoice_number": "invoice_number",
+      "invoice_number[]": "invoice_number[]",
+      "payment_reference": "payment_reference",
+      "payment_reference[]": "payment_reference[]",
+      "face_value_from": "face_value_from",
+      "face_value_to": "face_value_to",
+      "currency": "currency",
+      "currency[]": "currency[]",
+      "issuer_name_like": "issuer_name_like",
+      "issuer_country[]": "issuer_country[]",
+      "issuer_registration_number": "issuer_registration_number",
+      "issuer_registration_number[]": "issuer_registration_number[]",
+      "debtor_name_like": "debtor_name_like",
+      "debtor_country[]": "debtor_country[]",
+      "debtor_registration_number": "debtor_registration_number",
+      "debtor_registration_number[]": "debtor_registration_number[]"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findinvoices/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findinvoices/schema-json/root.json
@@ -1,0 +1,98 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "The number of items to obtain per response. The limit/offset schema is used for pagination. The default value is 10. The maximum allowed value is 100.",
+      "type": "string"
+    },
+    "offset": {
+      "description": "The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.",
+      "type": "string"
+    },
+    "sort_by": {
+      "description": "Use to determine which value to use to sort the paginated result. The default value is created_at.",
+      "type": "string",
+      "enum": [
+        "created_at",
+        "invoice_number",
+        "payment_reference",
+        "face_value",
+        "currency",
+        "debtor_registration_number",
+        "debtor_country",
+        "issuer_registration_number",
+        "issuer_country",
+        "issuer_name"
+      ]
+    },
+    "descending": {
+      "description": "Use to determine the sorting order as either descending or ascending. The default value is false, which corresponds to ascending order.",
+      "type": "string"
+    },
+    "invoice_number": {
+      "description": "Use to filter the invoice list by the invoice number given.",
+      "type": "string"
+    },
+    "invoice_number[]": {
+      "description": "Use to filter the invoice list by a collection of invoice number. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "payment_reference": {
+      "description": "Use to filter the invoice list by the payment reference given.",
+      "type": "string"
+    },
+    "payment_reference[]": {
+      "description": "Use to filter the invoice list by a collection of payment references. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "face_value_from": {
+      "description": "Use to filter the invoice list by face value above than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.",
+      "type": "string"
+    },
+    "face_value_to": {
+      "description": "Use to filter the invoice list by face value below than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.",
+      "type": "string"
+    },
+    "currency": {
+      "description": "Use to filter the invoice list by the currency code given. The format is ISO 4217.",
+      "type": "string"
+    },
+    "currency[]": {
+      "description": "Use to filter the invoice list by a collection of currencies. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.",
+      "type": "string"
+    },
+    "issuer_name_like": {
+      "description": "Use to filter the invoice list by the given issuer name. The like suffix determines that the query we end up doing is a LIKE %VALUE%.",
+      "type": "string"
+    },
+    "issuer_country[]": {
+      "description": "Use to filter the invoice list by a collection of issuer country codes in ISO 3166 format. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "issuer_registration_number": {
+      "description": "Use to filter the invoice list by the issuer registration number given.",
+      "type": "string"
+    },
+    "issuer_registration_number[]": {
+      "description": "Use to filter the invoice list by a collection of issuer registration numbers. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "debtor_name_like": {
+      "description": "Use to filter the invoice list by the given debtor name. The like suffix determines that the query we end up doing is a LIKE %VALUE%.",
+      "type": "string"
+    },
+    "debtor_country[]": {
+      "description": "Use to filter the invoice list by a collection of debtor countries in ISO 3166 format. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "debtor_registration_number": {
+      "description": "Use to filter the invoice list by the debtor registration number given.",
+      "type": "string"
+    },
+    "debtor_registration_number[]": {
+      "description": "Use to filter the invoice list by a collection of debtor registration numbers. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/findinvoices/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findinvoices/schema/root.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.string().describe("The number of items to obtain per response. The limit/offset schema is used for pagination. The default value is 10. The maximum allowed value is 100.").optional(),
+  "offset": z.string().describe("The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.").optional(),
+  "sort_by": z.enum(["created_at","invoice_number","payment_reference","face_value","currency","debtor_registration_number","debtor_country","issuer_registration_number","issuer_country","issuer_name"]).describe("Use to determine which value to use to sort the paginated result. The default value is created_at.").optional(),
+  "descending": z.string().describe("Use to determine the sorting order as either descending or ascending. The default value is false, which corresponds to ascending order.").optional(),
+  "invoice_number": z.string().describe("Use to filter the invoice list by the invoice number given.").optional(),
+  "invoice_number[]": z.string().describe("Use to filter the invoice list by a collection of invoice number. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "payment_reference": z.string().describe("Use to filter the invoice list by the payment reference given.").optional(),
+  "payment_reference[]": z.string().describe("Use to filter the invoice list by a collection of payment references. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "face_value_from": z.string().describe("Use to filter the invoice list by face value above than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.").optional(),
+  "face_value_to": z.string().describe("Use to filter the invoice list by face value below than the given one. It must be sent as cents. For example, the value 191.95 has to be sent as 19195.").optional(),
+  "currency": z.string().describe("Use to filter the invoice list by the currency code given. The format is ISO 4217.").optional(),
+  "currency[]": z.string().describe("Use to filter the invoice list by a collection of currencies. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.").optional(),
+  "issuer_name_like": z.string().describe("Use to filter the invoice list by the given issuer name. The like suffix determines that the query we end up doing is a LIKE %VALUE%.").optional(),
+  "issuer_country[]": z.string().describe("Use to filter the invoice list by a collection of issuer country codes in ISO 3166 format. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "issuer_registration_number": z.string().describe("Use to filter the invoice list by the issuer registration number given.").optional(),
+  "issuer_registration_number[]": z.string().describe("Use to filter the invoice list by a collection of issuer registration numbers. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "debtor_name_like": z.string().describe("Use to filter the invoice list by the given debtor name. The like suffix determines that the query we end up doing is a LIKE %VALUE%.").optional(),
+  "debtor_country[]": z.string().describe("Use to filter the invoice list by a collection of debtor countries in ISO 3166 format. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "debtor_registration_number": z.string().describe("Use to filter the invoice list by the debtor registration number given.").optional(),
+  "debtor_registration_number[]": z.string().describe("Use to filter the invoice list by a collection of debtor registration numbers. You must use this filter by adding multiple times this query parameter with different values.").optional()
+}

--- a/servers/api_bnkbl_com/src/tools/findoverdue/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findoverdue/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findoverdue",
+  "toolDescription": "Find overdue",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/investor/{account_id}/overdue",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "account_id": "account_id"
+    },
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "start_date": "start_date",
+      "end_date": "end_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findoverdue/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findoverdue/schema-json/root.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "account_id": {
+      "description": "The unique identifier of the investor account.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "limit": {
+      "description": "Number of items to return per response (pagination). Default is 10, maximum is 100.",
+      "type": "string"
+    },
+    "offset": {
+      "description": "Number of items to skip in the response (pagination). Default is 0.",
+      "type": "string"
+    },
+    "start_date": {
+      "description": "Start date for the range of trades (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    },
+    "end_date": {
+      "description": "End date for the range of trades (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    }
+  },
+  "required": [
+    "account_id",
+    "start_date",
+    "end_date"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/findoverdue/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findoverdue/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account_id": z.string().uuid().describe("The unique identifier of the investor account."),
+  "limit": z.string().describe("Number of items to return per response (pagination). Default is 10, maximum is 100.").optional(),
+  "offset": z.string().describe("Number of items to skip in the response (pagination). Default is 0.").optional(),
+  "start_date": z.string().date().describe("Start date for the range of trades (must be less than 180 days)."),
+  "end_date": z.string().date().describe("End date for the range of trades (must be less than 180 days).")
+}

--- a/servers/api_bnkbl_com/src/tools/findpayables/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findpayables/index.ts
@@ -1,0 +1,35 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findpayables",
+  "toolDescription": "List payables",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "sort_by": "sort_by",
+      "descending": "descending",
+      "id[]": "id[]",
+      "state[]": "state[]",
+      "client_id[]": "client_id[]",
+      "total_requested_amount_from": "total_requested_amount_from",
+      "total_requested_amount_to": "total_requested_amount_to",
+      "currency[]": "currency[]"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findpayables/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findpayables/schema-json/root.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "limit": {
+      "description": "The number of items to obtain per response. The limit/offset schema is used for pagination. The default value is 10. The maximum allowed value is 100.",
+      "type": "string"
+    },
+    "offset": {
+      "description": "The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.",
+      "type": "string"
+    },
+    "sort_by": {
+      "description": "Use to determine which value to use to sort the paginated result. The default value is created_at.",
+      "type": "string",
+      "enum": [
+        "created_at",
+        "state",
+        "amount",
+        "currency"
+      ]
+    },
+    "descending": {
+      "description": "Use to determine the sorting order as either descending or ascending. The default value is false, which corresponds to ascending order.",
+      "type": "string",
+      "enum": [
+        "true",
+        "false"
+      ]
+    },
+    "id[]": {
+      "description": "Use to filter the payable list by a collection of payable financing request IDs. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string"
+    },
+    "state[]": {
+      "description": "Use to filter the payable request list by a collection of payable financing request states. You must use this filter by adding multiple times this query parameter with different values.",
+      "type": "string",
+      "example": "APPROVED&state[]=REJECTED"
+    },
+    "client_id[]": {
+      "description": "Use to filter the payable request list by a collection of client IDs. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.",
+      "type": "string",
+      "example": "9d4153a3-f708-4e47-967e-bebd619a76a4&client_id[]=db9beb15-ec04-4ff5-9f3f-0f00fd03a9d3"
+    },
+    "total_requested_amount_from": {
+      "description": "Use to filter the payable request list by amount value greater than the given one. The amount can only include numbers and dot (.), and it must be presented in (EUR) or pence (GBP). For example, 100.00.",
+      "type": "string",
+      "example": "100.00"
+    },
+    "total_requested_amount_to": {
+      "description": "Use to filter the payable request list by amount value less than the given one. The amount can only include numbers and dot (.), and it must be presented in (EUR) or pence (GBP). For example, 200.00.",
+      "type": "string",
+      "example": "200.00"
+    },
+    "currency[]": {
+      "description": "Use to filter the payable request list by a collection of currencies. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/findpayables/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findpayables/schema/root.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "limit": z.string().describe("The number of items to obtain per response. The limit/offset schema is used for pagination. The default value is 10. The maximum allowed value is 100.").optional(),
+  "offset": z.string().describe("The number of items to skip in the response. The limit/offset schema is used for pagination. The default value is 0.").optional(),
+  "sort_by": z.enum(["created_at","state","amount","currency"]).describe("Use to determine which value to use to sort the paginated result. The default value is created_at.").optional(),
+  "descending": z.enum(["true","false"]).describe("Use to determine the sorting order as either descending or ascending. The default value is false, which corresponds to ascending order.").optional(),
+  "id[]": z.string().describe("Use to filter the payable list by a collection of payable financing request IDs. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "state[]": z.string().describe("Use to filter the payable request list by a collection of payable financing request states. You must use this filter by adding multiple times this query parameter with different values.").optional(),
+  "client_id[]": z.string().describe("Use to filter the payable request list by a collection of client IDs. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.").optional(),
+  "total_requested_amount_from": z.string().describe("Use to filter the payable request list by amount value greater than the given one. The amount can only include numbers and dot (.), and it must be presented in (EUR) or pence (GBP). For example, 100.00.").optional(),
+  "total_requested_amount_to": z.string().describe("Use to filter the payable request list by amount value less than the given one. The amount can only include numbers and dot (.), and it must be presented in (EUR) or pence (GBP). For example, 200.00.").optional(),
+  "currency[]": z.string().describe("Use to filter the payable request list by a collection of currencies. You must use this filter by adding multiple times this query parameter with different values. The format is ISO 4217.").optional()
+}

--- a/servers/api_bnkbl_com/src/tools/findpositions/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findpositions/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findpositions",
+  "toolDescription": "Find positions",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/investor/{account_id}/positions",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "account_id": "account_id"
+    },
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "start_date": "start_date",
+      "end_date": "end_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findpositions/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findpositions/schema-json/root.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "account_id": {
+      "description": "The unique identifier of the investor account.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "limit": {
+      "description": "Number of items to return per response (pagination). Default is 10, maximum is 100.",
+      "type": "string"
+    },
+    "offset": {
+      "description": "Number of items to skip in the response (pagination). Default is 0.",
+      "type": "string"
+    },
+    "start_date": {
+      "description": "Start date for the range of trades (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    },
+    "end_date": {
+      "description": "End date for the range of trades (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    }
+  },
+  "required": [
+    "account_id",
+    "start_date",
+    "end_date"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/findpositions/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findpositions/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account_id": z.string().uuid().describe("The unique identifier of the investor account."),
+  "limit": z.string().describe("Number of items to return per response (pagination). Default is 10, maximum is 100.").optional(),
+  "offset": z.string().describe("Number of items to skip in the response (pagination). Default is 0.").optional(),
+  "start_date": z.string().date().describe("Start date for the range of trades (must be less than 180 days)."),
+  "end_date": z.string().date().describe("End date for the range of trades (must be less than 180 days).")
+}

--- a/servers/api_bnkbl_com/src/tools/findtrades/index.ts
+++ b/servers/api_bnkbl_com/src/tools/findtrades/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "findtrades",
+  "toolDescription": "Find trades",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/investor/{account_id}/trades",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "account_id": "account_id"
+    },
+    "query": {
+      "limit": "limit",
+      "offset": "offset",
+      "start_date": "start_date",
+      "end_date": "end_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/findtrades/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/findtrades/schema-json/root.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "account_id": {
+      "description": "The unique identifier of the investor account.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "limit": {
+      "description": "Number of items to return per response (pagination). Default is 10, maximum is 100.",
+      "type": "string"
+    },
+    "offset": {
+      "description": "Number of items to skip in the response (pagination). Default is 0.",
+      "type": "string"
+    },
+    "start_date": {
+      "description": "Start date for the range of trades (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    },
+    "end_date": {
+      "description": "End date for the range of trades (must be less than 180 days).",
+      "type": "string",
+      "format": "date"
+    }
+  },
+  "required": [
+    "account_id",
+    "start_date",
+    "end_date"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/findtrades/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/findtrades/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account_id": z.string().uuid().describe("The unique identifier of the investor account."),
+  "limit": z.string().describe("Number of items to return per response (pagination). Default is 10, maximum is 100.").optional(),
+  "offset": z.string().describe("Number of items to skip in the response (pagination). Default is 0.").optional(),
+  "start_date": z.string().date().describe("Start date for the range of trades (must be less than 180 days)."),
+  "end_date": z.string().date().describe("End date for the range of trades (must be less than 180 days).")
+}

--- a/servers/api_bnkbl_com/src/tools/getbalances/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getbalances/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getbalances",
+  "toolDescription": "Get account balance",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/investor/{account_id}/balances",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "account_id": "account_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getbalances/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getbalances/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "account_id": {
+      "description": "The unique identifier of the investor account.",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "account_id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getbalances/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getbalances/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "account_id": z.string().uuid().describe("The unique identifier of the investor account.")
+}

--- a/servers/api_bnkbl_com/src/tools/getclient/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getclient/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getclient",
+  "toolDescription": "Get client details",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    },
+    "query": {
+      "product_id": "product_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getclient/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getclient/schema-json/root.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the Credit Client ID provided by Bankable. when the client was created (see the \"Create Client\" response).",
+      "type": "string",
+      "format": "uuid"
+    },
+    "product_id": {
+      "description": "Product identifier. The current options are **ETR** and **ETC**.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "product_id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getclient/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getclient/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("This is the Credit Client ID provided by Bankable. when the client was created (see the \"Create Client\" response)."),
+  "product_id": z.string().describe("Product identifier. The current options are **ETR** and **ETC**.")
+}

--- a/servers/api_bnkbl_com/src/tools/getcontractsigners/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getcontractsigners/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcontractsigners",
+  "toolDescription": "Get contract signers",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{client_id}/product/{product}/contract/signers",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "client_id": "client_id",
+      "product": "product"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getcontractsigners/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getcontractsigners/schema-json/root.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "description": "Unique identifier for the client.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "product": {
+      "description": "Product identifier.",
+      "type": "string",
+      "enum": [
+        "credit-line",
+        "payables",
+        "receivables",
+        "revolving-credit"
+      ]
+    }
+  },
+  "required": [
+    "client_id",
+    "product"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getcontractsigners/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getcontractsigners/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().uuid().describe("Unique identifier for the client."),
+  "product": z.enum(["credit-line","payables","receivables","revolving-credit"]).describe("Product identifier.")
+}

--- a/servers/api_bnkbl_com/src/tools/getcredit/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getcredit/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcredit",
+  "toolDescription": "Get credit details",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/credit/{id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getcredit/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getcredit/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the credit ID provided by Bankable when the credit was created (see the \"Create Credit\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getcredit/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getcredit/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("This is the credit ID provided by Bankable when the credit was created (see the \"Create Credit\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/getcreditpricebreakdown/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getcreditpricebreakdown/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getcreditpricebreakdown",
+  "toolDescription": "Get credit price breakdown",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/credit/price-breakdown",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "country": "country",
+      "registration_number": "registration_number"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getcreditpricebreakdown/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getcreditpricebreakdown/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "country": {
+      "description": "ISO Country Code (two letter country code from ISO 3166).",
+      "type": "string"
+    },
+    "registration_number": {
+      "description": "Company registration number.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "country",
+    "registration_number"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getcreditpricebreakdown/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getcreditpricebreakdown/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "country": z.string().describe("ISO Country Code (two letter country code from ISO 3166)."),
+  "registration_number": z.string().describe("Company registration number.")
+}

--- a/servers/api_bnkbl_com/src/tools/getfinancingindicator/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getfinancingindicator/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getfinancingindicator",
+  "toolDescription": "Get financing indicator",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{client_id}/financial-status",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "client_id": "client_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getfinancingindicator/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getfinancingindicator/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "description": "This is the credit client ID provided by Bankable. when the client was created (see the \"Create Client\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "client_id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getfinancingindicator/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getfinancingindicator/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().uuid().describe("This is the credit client ID provided by Bankable. when the client was created (see the \"Create Client\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/getinvoice/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getinvoice/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getinvoice",
+  "toolDescription": "Get invoice details",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/invoice/{id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getinvoice/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getinvoice/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the Invoice ID provided by Bankable when the invoice was created (see the \"Create invoice\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getinvoice/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getinvoice/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("This is the Invoice ID provided by Bankable when the invoice was created (see the \"Create invoice\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/getpayabledetails/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getpayabledetails/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpayabledetails",
+  "toolDescription": "Get payable details",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables/{id}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getpayabledetails/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getpayabledetails/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "This is the ID provided by Bankable when the payable was created (see the \"Submit Payables\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getpayabledetails/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getpayabledetails/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("This is the ID provided by Bankable when the payable was created (see the \"Submit Payables\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/getpayablespricebreakdown/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getpayablespricebreakdown/index.ts
@@ -1,0 +1,28 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpayablespricebreakdown",
+  "toolDescription": "Get payables finance price breakdown",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables/price-breakdown",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "id": "id",
+      "financing_amount": "financing_amount",
+      "repayment_method": "repayment_method"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getpayablespricebreakdown/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getpayablespricebreakdown/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique identifier for the client provided by Bankable.",
+      "type": "string"
+    },
+    "financing_amount": {
+      "description": "The total amount that a Client desires to finance (1 or more payables).",
+      "type": "number",
+      "format": "float"
+    },
+    "repayment_method": {
+      "description": "Whether a Client wants to repay the financing in weekly or monthly instalments.",
+      "type": "string",
+      "enum": [
+        "weekly_instalments",
+        "monthly_instalments"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "financing_amount",
+    "repayment_method"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getpayablespricebreakdown/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getpayablespricebreakdown/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().describe("The unique identifier for the client provided by Bankable."),
+  "financing_amount": z.number().describe("The total amount that a Client desires to finance (1 or more payables)."),
+  "repayment_method": z.enum(["weekly_instalments","monthly_instalments"]).describe("Whether a Client wants to repay the financing in weekly or monthly instalments.")
+}

--- a/servers/api_bnkbl_com/src/tools/getpricebreakdown/index.ts
+++ b/servers/api_bnkbl_com/src/tools/getpricebreakdown/index.ts
@@ -1,0 +1,31 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "getpricebreakdown",
+  "toolDescription": "Get invoice finance price breakdown",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/invoice/price-breakdown",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "debtor_country_code": "debtor_country_code",
+      "debtor_crn": "debtor_crn",
+      "issuer_country_code": "issuer_country_code",
+      "issuer_crn": "issuer_crn",
+      "face_value": "face_value",
+      "due_date": "due_date"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/getpricebreakdown/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/getpricebreakdown/schema-json/root.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "debtor_country_code": {
+      "description": "The debtor's two-letter country code in ISO 3166 format.",
+      "type": "string"
+    },
+    "debtor_crn": {
+      "description": "The debtor's Company Registration Number.",
+      "type": "string"
+    },
+    "issuer_country_code": {
+      "description": "The issuer's two-letter country code in ISO 3166 format.",
+      "type": "string"
+    },
+    "issuer_crn": {
+      "description": "The issuer's Company Registration Number.",
+      "type": "string"
+    },
+    "face_value": {
+      "description": "The invoice face value can only include numbers and dot (.) must be presented in (EUR) or pence (GBP). For example, 100.00 EUR .",
+      "type": "number",
+      "format": "float"
+    },
+    "due_date": {
+      "description": "The due date as shown on the potential invoice to be financed. Should be in format YYYY-MM-DD, for example, 2022-01-01.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "debtor_country_code",
+    "debtor_crn",
+    "issuer_country_code",
+    "issuer_crn",
+    "face_value",
+    "due_date"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/getpricebreakdown/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/getpricebreakdown/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "debtor_country_code": z.string().describe("The debtor's two-letter country code in ISO 3166 format."),
+  "debtor_crn": z.string().describe("The debtor's Company Registration Number."),
+  "issuer_country_code": z.string().describe("The issuer's two-letter country code in ISO 3166 format."),
+  "issuer_crn": z.string().describe("The issuer's Company Registration Number."),
+  "face_value": z.number().describe("The invoice face value can only include numbers and dot (.) must be presented in (EUR) or pence (GBP). For example, 100.00 EUR ."),
+  "due_date": z.string().describe("The due date as shown on the potential invoice to be financed. Should be in format YYYY-MM-DD, for example, 2022-01-01.")
+}

--- a/servers/api_bnkbl_com/src/tools/gettoken/index.ts
+++ b/servers/api_bnkbl_com/src/tools/gettoken/index.ts
@@ -1,0 +1,15 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "gettoken",
+  "toolDescription": "Get authentication token",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/oauth/token",
+  "method": "post",
+  "security": [],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/gettoken/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/gettoken/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/gettoken/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/gettoken/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_bnkbl_com/src/tools/importfinancial/index.ts
+++ b/servers/api_bnkbl_com/src/tools/importfinancial/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "importfinancial",
+  "toolDescription": "Submit financial data",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{client_id}/financial",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "client_id": "client_id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/importfinancial/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/importfinancial/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "description": "This is the credit client ID provided by Bankable. when the client was created (see the \"Create Client\" response).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "client_id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/importfinancial/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/importfinancial/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().uuid().describe("This is the credit client ID provided by Bankable. when the client was created (see the \"Create Client\" response).")
+}

--- a/servers/api_bnkbl_com/src/tools/requestcontract/index.ts
+++ b/servers/api_bnkbl_com/src/tools/requestcontract/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "requestcontract",
+  "toolDescription": "Request contract",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{client_id}/product/{product}/contract/request",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "client_id": "client_id",
+      "product": "product"
+    },
+    "body": {
+      "signers": "signers"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/requestcontract/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/requestcontract/schema-json/root.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "description": "Unique identifier for the client.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "product": {
+      "description": "Product identifier.",
+      "type": "string",
+      "enum": [
+        "credit-line",
+        "payables",
+        "receivables",
+        "revolving-credit"
+      ]
+    },
+    "signers": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "description": "List of signing parties.",
+      "items": {
+        "type": "object",
+        "required": [
+          "email",
+          "first_name",
+          "last_name"
+        ],
+        "properties": {
+          "email": {
+            "description": "Signer email.",
+            "type": "string",
+            "example": "john.doe@bnkbl.com"
+          },
+          "first_name": {
+            "description": "Signer first name.",
+            "type": "string",
+            "example": "John"
+          },
+          "last_name": {
+            "description": "Signer last name.",
+            "type": "string",
+            "example": "Doe"
+          },
+          "address": {
+            "type": "string",
+            "description": "Address of the signer, mandatory for UK companies.",
+            "example": "New Broad Street House, 35 New Broad Street, London, United Kingdom, EC2M 1NH"
+          },
+          "proof_of_address": {
+            "type": "string",
+            "description": "Unique identifier of the file returned by the Upload Proof of Address endpoint. Mandatory for companies in the UK.",
+            "example": "fc46b7de-a9f6-4398-8448-bfe665d25d02"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "client_id",
+    "product",
+    "signers"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/requestcontract/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/requestcontract/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().uuid().describe("Unique identifier for the client."),
+  "product": z.enum(["credit-line","payables","receivables","revolving-credit"]).describe("Product identifier."),
+  "signers": z.array(z.object({ "email": z.string().describe("Signer email."), "first_name": z.string().describe("Signer first name."), "last_name": z.string().describe("Signer last name."), "address": z.string().describe("Address of the signer, mandatory for UK companies.").optional(), "proof_of_address": z.string().describe("Unique identifier of the file returned by the Upload Proof of Address endpoint. Mandatory for companies in the UK.").optional() })).min(1).max(3).describe("List of signing parties.")
+}

--- a/servers/api_bnkbl_com/src/tools/submitbankdata/index.ts
+++ b/servers/api_bnkbl_com/src/tools/submitbankdata/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "submitbankdata",
+  "toolDescription": "Submit bank data",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{id}/bankdata",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "id": "id"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/submitbankdata/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/submitbankdata/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Unique identifier for the client.",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/submitbankdata/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/submitbankdata/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "id": z.string().uuid().describe("Unique identifier for the client.")
+}

--- a/servers/api_bnkbl_com/src/tools/submitkyb/index.ts
+++ b/servers/api_bnkbl_com/src/tools/submitkyb/index.ts
@@ -1,0 +1,41 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "submitkyb",
+  "toolDescription": "Submit KYB form",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{client_id}/product/{product}/kyb",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "client_id": "client_id",
+      "product": "product"
+    },
+    "body": {
+      "annual_revenue": "annual_revenue",
+      "incorporation_date": "incorporation_date",
+      "financial_institution": "financial_institution",
+      "income_source": "income_source",
+      "trading_name": "trading_name",
+      "industry": "industry",
+      "financing_frequency": "financing_frequency",
+      "financing_needed": "financing_needed",
+      "comments": "comments",
+      "ultimate_beneficial_owners": "ultimate_beneficial_owners",
+      "directors": "directors",
+      "corporate_structure": "corporate_structure"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/submitkyb/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/submitkyb/schema-json/root.json
@@ -1,0 +1,210 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "description": "Unique identifier for the client.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "product": {
+      "description": "Product identifier.",
+      "type": "string",
+      "enum": [
+        "credit-line",
+        "payables",
+        "receivables",
+        "revolving-credit"
+      ]
+    },
+    "annual_revenue": {
+      "description": "Annual revenue of the company",
+      "type": "number",
+      "format": "float",
+      "example": 10000
+    },
+    "incorporation_date": {
+      "type": "string",
+      "description": "The incorporation date of the company",
+      "format": "date",
+      "example": "2006-01-02"
+    },
+    "financial_institution": {
+      "type": "boolean",
+      "description": "The company is a financial institution. False is obligatory to be able to onboard. We give out an error if true."
+    },
+    "income_source": {
+      "type": "string",
+      "description": "Source of income.",
+      "enum": [
+        "business_activities",
+        "investment_activities",
+        "royalties"
+      ]
+    },
+    "trading_name": {
+      "type": "string",
+      "description": "The trading name of the company if different from the legal name.",
+      "example": "Bankable"
+    },
+    "industry": {
+      "type": "string",
+      "description": "Standard Industrial Classification code.",
+      "format": "SIC"
+    },
+    "financing_frequency": {
+      "type": "string",
+      "description": "The financing frequency.",
+      "enum": [
+        "regular",
+        "sporadic",
+        "season"
+      ]
+    },
+    "financing_needed": {
+      "type": "number",
+      "format": "float",
+      "description": "Amount of financing needed.",
+      "example": 100.5
+    },
+    "comments": {
+      "type": "string",
+      "description": "Extra comment.",
+      "example": "Ipsum deserunt ad ipsum ad commodo."
+    },
+    "ultimate_beneficial_owners": {
+      "type": "array",
+      "maxItems": 4,
+      "description": "Array of objects where each object is an owner with at least 25% ownership. 0-4 people.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the owner.",
+            "example": "John Doe"
+          },
+          "nationality": {
+            "type": "string",
+            "example": "GB",
+            "description": "Nationality of the owner.",
+            "maxLength": 2,
+            "minLength": 2
+          },
+          "share": {
+            "type": "number",
+            "format": "float",
+            "description": "Share of the owner.",
+            "example": 100
+          },
+          "date_of_birth": {
+            "type": "string",
+            "description": "Birth data of the owner.",
+            "format": "date",
+            "example": "2006-01-02"
+          },
+          "personal_id": {
+            "type": "string",
+            "description": "Personal ID number of the owner, optional for UK nationals."
+          },
+          "address": {
+            "type": "string",
+            "description": "Address of the owner, mandatory for UK company or people with different nationality from company."
+          },
+          "sanctioned": {
+            "description": "Whether the owner is sanctioned or not",
+            "type": "boolean"
+          },
+          "pep": {
+            "description": "Whether the owner is a Politically Exposed Person or not.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "nationality",
+          "share",
+          "date_of_birth",
+          "personal_id",
+          "address",
+          "sanctioned",
+          "pep"
+        ]
+      }
+    },
+    "directors": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Array of objects where each object is a director of the company.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the director.",
+            "example": "John Doe"
+          },
+          "nationality": {
+            "type": "string",
+            "description": "Nationality of the director.",
+            "maxLength": 2,
+            "minLength": 2
+          },
+          "position": {
+            "type": "string",
+            "description": "Position in the company.",
+            "example": "CEO"
+          },
+          "date_of_birth": {
+            "type": "string",
+            "description": "Birth data of the director.",
+            "format": "date",
+            "example": "2006-01-02"
+          },
+          "personal_id": {
+            "type": "string",
+            "description": "Personal ID number of the director, optional for UK nationals."
+          },
+          "address": {
+            "type": "string",
+            "description": "Address of the director, mandatory for UK company or people with different nationality from company."
+          },
+          "sanctioned": {
+            "description": "Whether the director is sanctioned or not",
+            "type": "boolean"
+          },
+          "pep": {
+            "description": "Whether the director is a Politically Exposed Person or not.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "nationality",
+          "position",
+          "date_of_birth",
+          "personal_id",
+          "address",
+          "sanctioned",
+          "pep"
+        ]
+      }
+    },
+    "corporate_structure": {
+      "type": "array",
+      "description": "Array of objects where each object is a company with at least 25% ownership. Unlimited companies.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "client_id",
+    "product",
+    "annual_revenue",
+    "incorporation_date",
+    "financial_institution",
+    "income_source",
+    "financing_frequency",
+    "directors"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/submitkyb/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/submitkyb/schema/root.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().uuid().describe("Unique identifier for the client."),
+  "product": z.enum(["credit-line","payables","receivables","revolving-credit"]).describe("Product identifier."),
+  "annual_revenue": z.number().describe("Annual revenue of the company"),
+  "incorporation_date": z.string().date().describe("The incorporation date of the company"),
+  "financial_institution": z.boolean().describe("The company is a financial institution. False is obligatory to be able to onboard. We give out an error if true."),
+  "income_source": z.enum(["business_activities","investment_activities","royalties"]).describe("Source of income."),
+  "trading_name": z.string().describe("The trading name of the company if different from the legal name.").optional(),
+  "industry": z.string().describe("Standard Industrial Classification code.").optional(),
+  "financing_frequency": z.enum(["regular","sporadic","season"]).describe("The financing frequency."),
+  "financing_needed": z.number().describe("Amount of financing needed.").optional(),
+  "comments": z.string().describe("Extra comment.").optional(),
+  "ultimate_beneficial_owners": z.array(z.object({ "name": z.string().describe("Name of the owner."), "nationality": z.string().min(2).max(2).describe("Nationality of the owner."), "share": z.number().describe("Share of the owner."), "date_of_birth": z.string().date().describe("Birth data of the owner."), "personal_id": z.string().describe("Personal ID number of the owner, optional for UK nationals."), "address": z.string().describe("Address of the owner, mandatory for UK company or people with different nationality from company."), "sanctioned": z.boolean().describe("Whether the owner is sanctioned or not"), "pep": z.boolean().describe("Whether the owner is a Politically Exposed Person or not.") })).max(4).describe("Array of objects where each object is an owner with at least 25% ownership. 0-4 people.").optional(),
+  "directors": z.array(z.object({ "name": z.string().describe("Name of the director."), "nationality": z.string().min(2).max(2).describe("Nationality of the director."), "position": z.string().describe("Position in the company."), "date_of_birth": z.string().date().describe("Birth data of the director."), "personal_id": z.string().describe("Personal ID number of the director, optional for UK nationals."), "address": z.string().describe("Address of the director, mandatory for UK company or people with different nationality from company."), "sanctioned": z.boolean().describe("Whether the director is sanctioned or not"), "pep": z.boolean().describe("Whether the director is a Politically Exposed Person or not.") })).min(1).describe("Array of objects where each object is a director of the company."),
+  "corporate_structure": z.array(z.string()).describe("Array of objects where each object is a company with at least 25% ownership. Unlimited companies.").optional()
+}

--- a/servers/api_bnkbl_com/src/tools/submitpayables/index.ts
+++ b/servers/api_bnkbl_com/src/tools/submitpayables/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "submitpayables",
+  "toolDescription": "Submit payables",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/submitpayables/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/submitpayables/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/submitpayables/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/submitpayables/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_bnkbl_com/src/tools/uploadinvoicepayablefile/index.ts
+++ b/servers/api_bnkbl_com/src/tools/uploadinvoicepayablefile/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "uploadinvoicepayablefile",
+  "toolDescription": "Upload invoice PDF",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/payables/file",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/uploadinvoicepayablefile/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/uploadinvoicepayablefile/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/api_bnkbl_com/src/tools/uploadinvoicepayablefile/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/uploadinvoicepayablefile/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/api_bnkbl_com/src/tools/uploadproofofaddress/index.ts
+++ b/servers/api_bnkbl_com/src/tools/uploadproofofaddress/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "uploadproofofaddress",
+  "toolDescription": "Upload proof of address",
+  "baseUrl": "https://api.bnkbl.com",
+  "path": "/partner/client/{client_id}/product/{product}/contract/signers/proof-of-address",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>OAUTH2_TOKEN</mcp-env-var>",
+      "in": "header",
+      "envVarName": "OAUTH2_TOKEN"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "client_id": "client_id",
+      "product": "product"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_bnkbl_com/src/tools/uploadproofofaddress/schema-json/root.json
+++ b/servers/api_bnkbl_com/src/tools/uploadproofofaddress/schema-json/root.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "description": "Unique identifier for the client.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "product": {
+      "description": "Product identifier.",
+      "type": "string",
+      "enum": [
+        "credit-line",
+        "payables",
+        "receivables",
+        "revolving-credit"
+      ]
+    }
+  },
+  "required": [
+    "client_id",
+    "product"
+  ]
+}

--- a/servers/api_bnkbl_com/src/tools/uploadproofofaddress/schema/root.ts
+++ b/servers/api_bnkbl_com/src/tools/uploadproofofaddress/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().uuid().describe("Unique identifier for the client."),
+  "product": z.enum(["credit-line","payables","receivables","revolving-credit"]).describe("Product identifier.")
+}

--- a/servers/api_bnkbl_com/tsconfig.json
+++ b/servers/api_bnkbl_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_bnkbl_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_bnkbl_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_bnkbl_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_bnkbl_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.