### PR TITLE
Add MCP server `_external_api`

### DIFF
--- a/servers/_external_api/.npmignore
+++ b/servers/_external_api/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_external_api/README.md
+++ b/servers/_external_api/README.md
@@ -1,0 +1,193 @@
+# @open-mcp/_external_api
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "_external_api": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/_external_api@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/_external_api@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+AUTHORIZATION='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add _external_api \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --AUTHORIZATION=$AUTHORIZATION
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add _external_api \
+  .cursor/mcp.json \
+  --AUTHORIZATION=$AUTHORIZATION
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add _external_api \
+  /path/to/client/config.json \
+  --AUTHORIZATION=$AUTHORIZATION
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_external_api": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_external_api"],
+      "env": {"AUTHORIZATION":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `AUTHORIZATION` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### post_oauth_token
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `client_id` (string)
+- `client_secret` (string)
+- `audience` (string)
+- `grant_type` (string)
+
+### post_v1_direct_message
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `data` (object)
+
+### post_v1_trigger_message_campaignid_
+
+**Environment variables**
+
+- `AUTHORIZATION`
+
+**Input schema**
+
+- `campaignId` (string)
+- `numberLookup` (string)
+- `data` (object)
+
+### triggermessages
+
+**Environment variables**
+
+- `AUTHORIZATION`
+
+**Input schema**
+
+- `campaignId` (string)
+- `action` (string)
+- `data` (object)
+
+### bulktriggermessages
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `campaignId` (string)
+- `action` (string)
+- `sendAt` (string)
+- `shouldResumeAfterQuietHours` (string)
+- `data` (object)
+
+### post_v1_bulk_contacts_create
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `action` (string)
+- `listIds` (string)
+- `shouldNumberLookup` (boolean)
+- `delimiter` (string)
+
+### post_v1_contact_create
+
+**Environment variables**
+
+- `AUTHORIZATION`
+
+**Input schema**
+
+- `existingContact` (string)
+- `shouldNumberLookup` (string)
+- `data` (object)
+
+### post_v1_contact_update
+
+**Environment variables**
+
+- `AUTHORIZATION`
+
+**Input schema**
+
+- `shouldNumberLookup` (string)
+- `data` (object)

--- a/servers/_external_api/package.json
+++ b/servers/_external_api/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/_external_api",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "_external_api": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/_external_api/src/constants.ts
+++ b/servers/_external_api/src/constants.ts
@@ -1,0 +1,13 @@
+export const OPENAPI_URL = "https://smart-api.getmobiz.com/external-api/client-specs"
+export const SERVER_NAME = "_external_api"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/post_oauth_token/index.js",
+  "./tools/post_v1_direct_message/index.js",
+  "./tools/post_v1_trigger_message_campaignid_/index.js",
+  "./tools/triggermessages/index.js",
+  "./tools/bulktriggermessages/index.js",
+  "./tools/post_v1_bulk_contacts_create/index.js",
+  "./tools/post_v1_contact_create/index.js",
+  "./tools/post_v1_contact_update/index.js"
+]

--- a/servers/_external_api/src/index.ts
+++ b/servers/_external_api/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/_external_api/src/server.ts
+++ b/servers/_external_api/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_external_api/src/tools/bulktriggermessages/index.ts
+++ b/servers/_external_api/src/tools/bulktriggermessages/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "bulktriggermessages",
+  "toolDescription": "Trigger a batch of distributed messages",
+  "baseUrl": "/external-api",
+  "path": "/v1/bulk-trigger-messages/{campaignId}",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "campaignId": "campaignId"
+    },
+    "query": {
+      "action": "action",
+      "sendAt": "sendAt",
+      "shouldResumeAfterQuietHours": "shouldResumeAfterQuietHours"
+    },
+    "body": {
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/bulktriggermessages/schema-json/properties/data.json
+++ b/servers/_external_api/src/tools/bulktriggermessages/schema-json/properties/data.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "triggerCampaigns"
+      ]
+    },
+    "attributes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "description": "The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.",
+            "minLength": 8,
+            "maxLength": 15,
+            "example": "+18005551234"
+          }
+        },
+        "additionalProperties": {
+          "type": "string"
+        },
+        "required": [
+          "phone"
+        ]
+      }
+    }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
+}

--- a/servers/_external_api/src/tools/bulktriggermessages/schema-json/root.json
+++ b/servers/_external_api/src/tools/bulktriggermessages/schema-json/root.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "properties": {
+    "campaignId": {
+      "description": "campaignId",
+      "type": "string",
+      "format": "uuid"
+    },
+    "action": {
+      "description": "Work only with contacts that exist in your base, or also add new ones.",
+      "type": "string",
+      "enum": [
+        "update",
+        "createAndUpdate"
+      ],
+      "default": "update"
+    },
+    "sendAt": {
+      "description": "Moment the messages should be set, in Unix epoch timestamp. If not provided, messages are sent right away.",
+      "type": "string"
+    },
+    "shouldResumeAfterQuietHours": {
+      "description": "Whether to cancel sending messages which would fall within quiet hours, or let the system resume sending after quiet hours.",
+      "type": "string",
+      "enum": [
+        "true",
+        "false"
+      ]
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "campaignId",
+    "data"
+  ]
+}

--- a/servers/_external_api/src/tools/bulktriggermessages/schema/properties/data.ts
+++ b/servers/_external_api/src/tools/bulktriggermessages/schema/properties/data.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.literal("triggerCampaigns"),
+  "attributes": z.array(z.object({ "phone": z.string().min(8).max(15).describe("The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.") }).catchall(z.string()))
+}

--- a/servers/_external_api/src/tools/bulktriggermessages/schema/root.ts
+++ b/servers/_external_api/src/tools/bulktriggermessages/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "campaignId": z.string().uuid().describe("campaignId"),
+  "action": z.enum(["update","createAndUpdate"]).describe("Work only with contacts that exist in your base, or also add new ones.").optional(),
+  "sendAt": z.string().describe("Moment the messages should be set, in Unix epoch timestamp. If not provided, messages are sent right away.").optional(),
+  "shouldResumeAfterQuietHours": z.enum(["true","false"]).describe("Whether to cancel sending messages which would fall within quiet hours, or let the system resume sending after quiet hours.").optional(),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/_external_api/src/tools/post_oauth_token/index.ts
+++ b/servers/_external_api/src/tools/post_oauth_token/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_oauth_token",
+  "toolDescription": "Get access token",
+  "baseUrl": "https://auth.mobiz.co",
+  "path": "/oauth/token",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "client_id": "client_id",
+      "client_secret": "client_secret",
+      "audience": "audience",
+      "grant_type": "grant_type"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/post_oauth_token/schema-json/root.json
+++ b/servers/_external_api/src/tools/post_oauth_token/schema-json/root.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "client_id": {
+      "type": "string"
+    },
+    "client_secret": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string",
+      "description": "audience should always be:  'api-mobiz-smart'",
+      "default": "api-mobiz-smart"
+    },
+    "grant_type": {
+      "type": "string",
+      "description": "grant_type should always be:  'client_credentials'",
+      "default": "client_credentials"
+    }
+  },
+  "required": []
+}

--- a/servers/_external_api/src/tools/post_oauth_token/schema/root.ts
+++ b/servers/_external_api/src/tools/post_oauth_token/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "client_id": z.string().optional(),
+  "client_secret": z.string().optional(),
+  "audience": z.string().describe("audience should always be:  'api-mobiz-smart'").optional(),
+  "grant_type": z.string().describe("grant_type should always be:  'client_credentials'").optional()
+}

--- a/servers/_external_api/src/tools/post_v1_bulk_contacts_create/index.ts
+++ b/servers/_external_api/src/tools/post_v1_bulk_contacts_create/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_bulk_contacts_create",
+  "toolDescription": "Import contacts",
+  "baseUrl": "/external-api",
+  "path": "/v1/bulk-contacts-create",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "action": "action",
+      "listIds": "listIds",
+      "shouldNumberLookup": "shouldNumberLookup",
+      "delimiter": "delimiter"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/post_v1_bulk_contacts_create/schema-json/root.json
+++ b/servers/_external_api/src/tools/post_v1_bulk_contacts_create/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "action": {
+      "description": "Accepts create OR createAndUpdate. Defaults to createAndUpdate",
+      "type": "string",
+      "enum": [
+        "create",
+        "createAndUpdate"
+      ]
+    },
+    "listIds": {
+      "description": "Accepts uuids, comma separated, of existing listIds. Defaults to empty",
+      "type": "string",
+      "format": "uuid"
+    },
+    "shouldNumberLookup": {
+      "description": "Should run number lookups billable to the account. *Minimum charge applies. Defaults to false",
+      "type": "boolean"
+    },
+    "delimiter": {
+      "description": "Csv contents delimiter. Must be single character. Defaults to ','",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/_external_api/src/tools/post_v1_bulk_contacts_create/schema/root.ts
+++ b/servers/_external_api/src/tools/post_v1_bulk_contacts_create/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "action": z.enum(["create","createAndUpdate"]).describe("Accepts create OR createAndUpdate. Defaults to createAndUpdate").optional(),
+  "listIds": z.string().uuid().describe("Accepts uuids, comma separated, of existing listIds. Defaults to empty").optional(),
+  "shouldNumberLookup": z.boolean().describe("Should run number lookups billable to the account. *Minimum charge applies. Defaults to false").optional(),
+  "delimiter": z.string().describe("Csv contents delimiter. Must be single character. Defaults to ','").optional()
+}

--- a/servers/_external_api/src/tools/post_v1_contact_create/index.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_create/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_contact_create",
+  "toolDescription": "Create a contact",
+  "baseUrl": "/external-api",
+  "path": "/v1/contact-create",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "<mcp-env-var>AUTHORIZATION</mcp-env-var>",
+      "in": "header",
+      "envVarName": "AUTHORIZATION"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "existingContact": "existingContact",
+      "shouldNumberLookup": "shouldNumberLookup"
+    },
+    "body": {
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/post_v1_contact_create/schema-json/properties/data.json
+++ b/servers/_external_api/src/tools/post_v1_contact_create/schema-json/properties/data.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "manageContacts"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_contact_create/schema-json/properties/data/properties/attributes.json
+++ b/servers/_external_api/src/tools/post_v1_contact_create/schema-json/properties/data/properties/attributes.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "phone": {
+      "type": "string",
+      "description": "The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.",
+      "minLength": 8,
+      "maxLength": 20
+    },
+    "listIds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      }
+    }
+  },
+  "additionalProperties": {
+    "type": "string"
+  },
+  "required": [
+    "phone"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_contact_create/schema-json/root.json
+++ b/servers/_external_api/src/tools/post_v1_contact_create/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "existingContact": {
+      "description": "ignore or update already existing contact",
+      "type": "string",
+      "enum": [
+        "ignore",
+        "update"
+      ],
+      "default": "update"
+    },
+    "shouldNumberLookup": {
+      "description": "Should run number lookups billable to the account. *Minimum charge applies. Defaults to false",
+      "type": "string",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "default": "false"
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": []
+}

--- a/servers/_external_api/src/tools/post_v1_contact_create/schema/properties/data.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_create/schema/properties/data.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.literal("manageContacts"),
+  "attributes": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/_external_api/src/tools/post_v1_contact_create/schema/properties/data/properties/attributes.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_create/schema/properties/data/properties/attributes.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "phone": z.string().min(8).max(20).describe("The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region."),
+  "listIds": z.array(z.string().uuid()).optional()
+}

--- a/servers/_external_api/src/tools/post_v1_contact_create/schema/root.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_create/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "existingContact": z.enum(["ignore","update"]).describe("ignore or update already existing contact").optional(),
+  "shouldNumberLookup": z.enum(["true","false"]).describe("Should run number lookups billable to the account. *Minimum charge applies. Defaults to false").optional(),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/_external_api/src/tools/post_v1_contact_update/index.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_update/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_contact_update",
+  "toolDescription": "Updates a contact",
+  "baseUrl": "/external-api",
+  "path": "/v1/contact-update",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "<mcp-env-var>AUTHORIZATION</mcp-env-var>",
+      "in": "header",
+      "envVarName": "AUTHORIZATION"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "shouldNumberLookup": "shouldNumberLookup"
+    },
+    "body": {
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/post_v1_contact_update/schema-json/properties/data.json
+++ b/servers/_external_api/src/tools/post_v1_contact_update/schema-json/properties/data.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "manageContacts"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_contact_update/schema-json/properties/data/properties/attributes.json
+++ b/servers/_external_api/src/tools/post_v1_contact_update/schema-json/properties/data/properties/attributes.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "phone": {
+      "type": "string",
+      "description": "The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.",
+      "minLength": 8,
+      "maxLength": 20
+    },
+    "listIds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      }
+    }
+  },
+  "additionalProperties": {
+    "type": "string"
+  },
+  "required": [
+    "phone"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_contact_update/schema-json/root.json
+++ b/servers/_external_api/src/tools/post_v1_contact_update/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "shouldNumberLookup": {
+      "description": "Should run number lookups billable to the account. *Minimum charge applies. Defaults to false",
+      "type": "string",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "default": "false"
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": []
+}

--- a/servers/_external_api/src/tools/post_v1_contact_update/schema/properties/data.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_update/schema/properties/data.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.literal("manageContacts"),
+  "attributes": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/_external_api/src/tools/post_v1_contact_update/schema/properties/data/properties/attributes.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_update/schema/properties/data/properties/attributes.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "phone": z.string().min(8).max(20).describe("The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region."),
+  "listIds": z.array(z.string().uuid()).optional()
+}

--- a/servers/_external_api/src/tools/post_v1_contact_update/schema/root.ts
+++ b/servers/_external_api/src/tools/post_v1_contact_update/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "shouldNumberLookup": z.enum(["true","false"]).describe("Should run number lookups billable to the account. *Minimum charge applies. Defaults to false").optional(),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>").optional()
+}

--- a/servers/_external_api/src/tools/post_v1_direct_message/index.ts
+++ b/servers/_external_api/src/tools/post_v1_direct_message/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_direct_message",
+  "toolDescription": "Send message",
+  "baseUrl": "/external-api",
+  "path": "/v1/direct-message",
+  "method": "post",
+  "security": [],
+  "paramsMap": {
+    "body": {
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/post_v1_direct_message/schema-json/properties/data.json
+++ b/servers/_external_api/src/tools/post_v1_direct_message/schema-json/properties/data.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "directMessages"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_direct_message/schema-json/properties/data/properties/attributes.json
+++ b/servers/_external_api/src/tools/post_v1_direct_message/schema-json/properties/data/properties/attributes.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "phone": {
+      "type": "string",
+      "description": "The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.",
+      "minLength": 8,
+      "maxLength": 15,
+      "example": "+18005551234"
+    },
+    "message": {
+      "type": "string",
+      "example": "You're my favorite customer"
+    }
+  },
+  "required": [
+    "phone",
+    "message"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_direct_message/schema-json/root.json
+++ b/servers/_external_api/src/tools/post_v1_direct_message/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_direct_message/schema/properties/data.ts
+++ b/servers/_external_api/src/tools/post_v1_direct_message/schema/properties/data.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.literal("directMessages"),
+  "attributes": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/_external_api/src/tools/post_v1_direct_message/schema/properties/data/properties/attributes.ts
+++ b/servers/_external_api/src/tools/post_v1_direct_message/schema/properties/data/properties/attributes.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "phone": z.string().min(8).max(15).describe("The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region."),
+  "message": z.string()
+}

--- a/servers/_external_api/src/tools/post_v1_direct_message/schema/root.ts
+++ b/servers/_external_api/src/tools/post_v1_direct_message/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/index.ts
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_v1_trigger_message_campaignid_",
+  "toolDescription": "Trigger an instant message",
+  "baseUrl": "/external-api",
+  "path": "/v1/trigger-message/{campaignId}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "<mcp-env-var>AUTHORIZATION</mcp-env-var>",
+      "in": "header",
+      "envVarName": "AUTHORIZATION"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "campaignId": "campaignId"
+    },
+    "query": {
+      "numberLookup": "numberLookup"
+    },
+    "body": {
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema-json/properties/data.json
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema-json/properties/data.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "triggerCampaigns"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema-json/properties/data/properties/attributes.json
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema-json/properties/data/properties/attributes.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "phone": {
+      "type": "string",
+      "description": "The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.",
+      "minLength": 8,
+      "maxLength": 15,
+      "example": "+18005551234"
+    }
+  },
+  "additionalProperties": {
+    "type": "string"
+  },
+  "required": [
+    "phone"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema-json/root.json
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema-json/root.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "campaignId": {
+      "description": "An ID of the automated campaign you want to trigger",
+      "type": "string",
+      "format": "uuid"
+    },
+    "numberLookup": {
+      "description": "Should run number lookups billable to the account. *Minimum charge applies. Defaults to false",
+      "type": "string"
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "campaignId",
+    "data"
+  ]
+}

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema/properties/data.ts
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema/properties/data.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.literal("triggerCampaigns"),
+  "attributes": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `attributes` to the tool, first call the tool `expandSchema` with \"/properties/data/properties/attributes\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema/properties/data/properties/attributes.ts
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema/properties/data/properties/attributes.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "phone": z.string().min(8).max(15).describe("The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.")
+}

--- a/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema/root.ts
+++ b/servers/_external_api/src/tools/post_v1_trigger_message_campaignid_/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "campaignId": z.string().uuid().describe("An ID of the automated campaign you want to trigger"),
+  "numberLookup": z.string().describe("Should run number lookups billable to the account. *Minimum charge applies. Defaults to false").optional(),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/_external_api/src/tools/triggermessages/index.ts
+++ b/servers/_external_api/src/tools/triggermessages/index.ts
@@ -1,0 +1,32 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "triggermessages",
+  "toolDescription": "Trigger a batch of instant messages",
+  "baseUrl": "/external-api",
+  "path": "/v1/trigger-messages/{campaignId}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "<mcp-env-var>AUTHORIZATION</mcp-env-var>",
+      "in": "header",
+      "envVarName": "AUTHORIZATION"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "campaignId": "campaignId"
+    },
+    "query": {
+      "action": "action"
+    },
+    "body": {
+      "data": "data"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_external_api/src/tools/triggermessages/schema-json/properties/data.json
+++ b/servers/_external_api/src/tools/triggermessages/schema-json/properties/data.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "triggerCampaigns"
+      ]
+    },
+    "attributes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "description": "The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.",
+            "minLength": 8,
+            "maxLength": 15,
+            "example": "+18005551234"
+          }
+        },
+        "additionalProperties": {
+          "type": "string"
+        },
+        "required": [
+          "phone"
+        ]
+      }
+    }
+  },
+  "required": [
+    "type",
+    "attributes"
+  ]
+}

--- a/servers/_external_api/src/tools/triggermessages/schema-json/root.json
+++ b/servers/_external_api/src/tools/triggermessages/schema-json/root.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "campaignId": {
+      "description": "campaignId",
+      "type": "string",
+      "format": "uuid"
+    },
+    "action": {
+      "description": "Work only with contacts that exist in your base, or also add new ones.",
+      "type": "string",
+      "enum": [
+        "update",
+        "createAndUpdate"
+      ],
+      "default": "update"
+    },
+    "data": {
+      "type": "object",
+      "description": "<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "campaignId",
+    "data"
+  ]
+}

--- a/servers/_external_api/src/tools/triggermessages/schema/properties/data.ts
+++ b/servers/_external_api/src/tools/triggermessages/schema/properties/data.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "type": z.literal("triggerCampaigns"),
+  "attributes": z.array(z.object({ "phone": z.string().min(8).max(15).describe("The ideal format is the E164 format; otherwise the number will be parsed with best attempt while using using the International Dialing Code of the account's business region.") }).catchall(z.string()))
+}

--- a/servers/_external_api/src/tools/triggermessages/schema/root.ts
+++ b/servers/_external_api/src/tools/triggermessages/schema/root.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "campaignId": z.string().uuid().describe("campaignId"),
+  "action": z.enum(["update","createAndUpdate"]).describe("Work only with contacts that exist in your base, or also add new ones.").optional(),
+  "data": z.record(z.any()).describe("<llm-instruction>This part of the input schema is truncated. If you want to pass the property `data` to the tool, first call the tool `expandSchema` with \"/properties/data\" in the list of pointers. This will return the expanded input schema which you can then use in the tool call. You may have to call `expandSchema` multiple times if the schema is nested.</llm-instruction>")
+}

--- a/servers/_external_api/tsconfig.json
+++ b/servers/_external_api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_external_api`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_external_api`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_external_api": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_external_api"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.