### PR TITLE
Add MCP server `_host_port_`

### DIFF
--- a/servers/_host_port_/.npmignore
+++ b/servers/_host_port_/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/_host_port_/README.md
+++ b/servers/_host_port_/README.md
@@ -1,0 +1,432 @@
+# @open-mcp/_host_port_
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "_host_port_": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/_host_port_@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/_host_port_@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+API_KEY='...'
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add _host_port_ \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json \
+  --API_KEY=$API_KEY
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add _host_port_ \
+  .cursor/mcp.json \
+  --API_KEY=$API_KEY
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add _host_port_ \
+  /path/to/client/config.json \
+  --API_KEY=$API_KEY
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "_host_port_": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/_host_port_"],
+      "env": {"API_KEY":"..."}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+- `API_KEY` - gets sent to the API provider
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### delete_active_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_active_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### patch_active_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `Operation` (string)
+- `Target-Type` (string)
+- `Target-Delimiter` (string)
+- `Target` (string)
+- `Trim-Target-Whitespace` (string)
+
+### post_active_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### put_active_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### get_commands_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### post_commands_commandid_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `commandId` (string)
+
+### get_obsidian_local_rest_api_crt
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### post_open_filename_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+- `newLeaf` (boolean)
+
+### get_openapi_yaml
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### delete_periodic_period_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `period` (string)
+
+### get_periodic_period_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `period` (string)
+
+### patch_periodic_period_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `period` (string)
+- `Operation` (string)
+- `Target-Type` (string)
+- `Target-Delimiter` (string)
+- `Target` (string)
+- `Trim-Target-Whitespace` (string)
+
+### post_periodic_period_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `period` (string)
+
+### put_periodic_period_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `period` (string)
+
+### delete_periodic_period_year_month_day_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `year` (number)
+- `month` (number)
+- `day` (number)
+- `period` (string)
+
+### get_periodic_period_year_month_day_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `year` (number)
+- `month` (number)
+- `day` (number)
+- `period` (string)
+
+### patch_periodic_period_year_month_day_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `year` (number)
+- `month` (number)
+- `day` (number)
+- `period` (string)
+- `Operation` (string)
+- `Target-Type` (string)
+- `Target-Delimiter` (string)
+- `Target` (string)
+- `Trim-Target-Whitespace` (string)
+
+### post_periodic_period_year_month_day_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `year` (number)
+- `month` (number)
+- `day` (number)
+- `period` (string)
+
+### put_periodic_period_year_month_day_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `year` (number)
+- `month` (number)
+- `day` (number)
+- `period` (string)
+
+### post_search_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### post_search_simple_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `query` (string)
+- `contextLength` (number)
+
+### get_vault_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+No input parameters
+
+### delete_vault_filename_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+
+### get_vault_filename_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+
+### patch_vault_filename_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+- `Operation` (string)
+- `Target-Type` (string)
+- `Target-Delimiter` (string)
+- `Target` (string)
+- `Trim-Target-Whitespace` (string)
+
+### post_vault_filename_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+
+### put_vault_filename_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `filename` (string)
+
+### get_vault_pathtodirectory_
+
+**Environment variables**
+
+- `API_KEY`
+
+**Input schema**
+
+- `pathToDirectory` (string)

--- a/servers/_host_port_/package.json
+++ b/servers/_host_port_/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/_host_port_",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "_host_port_": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/_host_port_/src/constants.ts
+++ b/servers/_host_port_/src/constants.ts
@@ -1,0 +1,35 @@
+export const OPENAPI_URL = "https://coddingtonbear.github.io/obsidian-local-rest-api/openapi.yaml"
+export const SERVER_NAME = "_host_port_"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_/index.js",
+  "./tools/delete_active_/index.js",
+  "./tools/get_active_/index.js",
+  "./tools/patch_active_/index.js",
+  "./tools/post_active_/index.js",
+  "./tools/put_active_/index.js",
+  "./tools/get_commands_/index.js",
+  "./tools/post_commands_commandid_/index.js",
+  "./tools/get_obsidian_local_rest_api_crt/index.js",
+  "./tools/post_open_filename_/index.js",
+  "./tools/get_openapi_yaml/index.js",
+  "./tools/delete_periodic_period_/index.js",
+  "./tools/get_periodic_period_/index.js",
+  "./tools/patch_periodic_period_/index.js",
+  "./tools/post_periodic_period_/index.js",
+  "./tools/put_periodic_period_/index.js",
+  "./tools/delete_periodic_period_year_month_day_/index.js",
+  "./tools/get_periodic_period_year_month_day_/index.js",
+  "./tools/patch_periodic_period_year_month_day_/index.js",
+  "./tools/post_periodic_period_year_month_day_/index.js",
+  "./tools/put_periodic_period_year_month_day_/index.js",
+  "./tools/post_search_/index.js",
+  "./tools/post_search_simple_/index.js",
+  "./tools/get_vault_/index.js",
+  "./tools/delete_vault_filename_/index.js",
+  "./tools/get_vault_filename_/index.js",
+  "./tools/patch_vault_filename_/index.js",
+  "./tools/post_vault_filename_/index.js",
+  "./tools/put_vault_filename_/index.js",
+  "./tools/get_vault_pathtodirectory_/index.js"
+]

--- a/servers/_host_port_/src/index.ts
+++ b/servers/_host_port_/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/_host_port_/src/server.ts
+++ b/servers/_host_port_/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/_host_port_/src/tools/delete_active_/index.ts
+++ b/servers/_host_port_/src/tools/delete_active_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_active_",
+  "toolDescription": "Deletes the currently-active file in Obsidian.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/active/",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/delete_active_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/delete_active_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/delete_active_/schema/root.ts
+++ b/servers/_host_port_/src/tools/delete_active_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/delete_periodic_period_/index.ts
+++ b/servers/_host_port_/src/tools/delete_periodic_period_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_periodic_period_",
+  "toolDescription": "Delete the current periodic note for the specified period.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/delete_periodic_period_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/delete_periodic_period_/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/delete_periodic_period_/schema/root.ts
+++ b/servers/_host_port_/src/tools/delete_periodic_period_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/delete_periodic_period_year_month_day_/index.ts
+++ b/servers/_host_port_/src/tools/delete_periodic_period_year_month_day_/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_periodic_period_year_month_day_",
+  "toolDescription": "Delete the periodic note for the specified period and date.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/{year}/{month}/{day}/",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "year": "year",
+      "month": "month",
+      "day": "day",
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/delete_periodic_period_year_month_day_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/delete_periodic_period_year_month_day_/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "year": {
+      "description": "The year of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "month": {
+      "description": "The month (1-12) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "day": {
+      "description": "The day (1-31) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "month",
+    "day",
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/delete_periodic_period_year_month_day_/schema/root.ts
+++ b/servers/_host_port_/src/tools/delete_periodic_period_year_month_day_/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "year": z.number().describe("The year of the date for which you would like to grab a periodic note."),
+  "month": z.number().describe("The month (1-12) of the date for which you would like to grab a periodic note."),
+  "day": z.number().describe("The day (1-31) of the date for which you would like to grab a periodic note."),
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/delete_vault_filename_/index.ts
+++ b/servers/_host_port_/src/tools/delete_vault_filename_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "delete_vault_filename_",
+  "toolDescription": "Delete a particular file in your vault.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/{filename}",
+  "method": "delete",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/delete_vault_filename_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/delete_vault_filename_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "description": "Path to the relevant file (relative to your vault root).\n",
+      "format": "path",
+      "type": "string"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/_host_port_/src/tools/delete_vault_filename_/schema/root.ts
+++ b/servers/_host_port_/src/tools/delete_vault_filename_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string().describe("Path to the relevant file (relative to your vault root).\n")
+}

--- a/servers/_host_port_/src/tools/get_/index.ts
+++ b/servers/_host_port_/src/tools/get_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_",
+  "toolDescription": "Returns basic details about the server.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/get_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/get_active_/index.ts
+++ b/servers/_host_port_/src/tools/get_active_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_active_",
+  "toolDescription": "Return the content of the active file open in Obsidian.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/active/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_active_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_active_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/get_active_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_active_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/get_commands_/index.ts
+++ b/servers/_host_port_/src/tools/get_commands_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_commands_",
+  "toolDescription": "Get a list of available commands.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/commands/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_commands_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_commands_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/get_commands_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_commands_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/get_obsidian_local_rest_api_crt/index.ts
+++ b/servers/_host_port_/src/tools/get_obsidian_local_rest_api_crt/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_obsidian_local_rest_api_crt",
+  "toolDescription": "Returns the certificate in use by this API.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/obsidian-local-rest-api.crt",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_obsidian_local_rest_api_crt/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_obsidian_local_rest_api_crt/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/get_obsidian_local_rest_api_crt/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_obsidian_local_rest_api_crt/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/get_openapi_yaml/index.ts
+++ b/servers/_host_port_/src/tools/get_openapi_yaml/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_openapi_yaml",
+  "toolDescription": "Returns OpenAPI YAML document describing the capabilities of this API.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/openapi.yaml",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_openapi_yaml/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_openapi_yaml/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/get_openapi_yaml/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_openapi_yaml/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/get_periodic_period_/index.ts
+++ b/servers/_host_port_/src/tools/get_periodic_period_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_periodic_period_",
+  "toolDescription": "Get current periodic note for the specified period.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_periodic_period_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_periodic_period_/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/get_periodic_period_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_periodic_period_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/get_periodic_period_year_month_day_/index.ts
+++ b/servers/_host_port_/src/tools/get_periodic_period_year_month_day_/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_periodic_period_year_month_day_",
+  "toolDescription": "Get the periodic note for the specified period and date.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/{year}/{month}/{day}/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "year": "year",
+      "month": "month",
+      "day": "day",
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_periodic_period_year_month_day_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_periodic_period_year_month_day_/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "year": {
+      "description": "The year of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "month": {
+      "description": "The month (1-12) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "day": {
+      "description": "The day (1-31) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "month",
+    "day",
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/get_periodic_period_year_month_day_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_periodic_period_year_month_day_/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "year": z.number().describe("The year of the date for which you would like to grab a periodic note."),
+  "month": z.number().describe("The month (1-12) of the date for which you would like to grab a periodic note."),
+  "day": z.number().describe("The day (1-31) of the date for which you would like to grab a periodic note."),
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/get_vault_/index.ts
+++ b/servers/_host_port_/src/tools/get_vault_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_vault_",
+  "toolDescription": "List files that exist in the root of your vault.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_vault_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_vault_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/get_vault_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_vault_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/get_vault_filename_/index.ts
+++ b/servers/_host_port_/src/tools/get_vault_filename_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_vault_filename_",
+  "toolDescription": "Return the content of a single file in your vault.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/{filename}",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_vault_filename_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_vault_filename_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "description": "Path to the relevant file (relative to your vault root).\n",
+      "format": "path",
+      "type": "string"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/_host_port_/src/tools/get_vault_filename_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_vault_filename_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string().describe("Path to the relevant file (relative to your vault root).\n")
+}

--- a/servers/_host_port_/src/tools/get_vault_pathtodirectory_/index.ts
+++ b/servers/_host_port_/src/tools/get_vault_pathtodirectory_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_vault_pathtodirectory_",
+  "toolDescription": "List files that exist in the specified directory.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/{pathToDirectory}/",
+  "method": "get",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "pathToDirectory": "pathToDirectory"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/get_vault_pathtodirectory_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/get_vault_pathtodirectory_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "pathToDirectory": {
+      "description": "Path to list files from (relative to your vault root).  Note that empty directories will not be returned.\n\nNote: this particular interactive tool requires that you provide an argument for this field, but the API itself will allow you to list the root folder of your vault. If you would like to try listing content in the root of your vault using this interactive tool, use the above \"List files that exist in the root of your vault\" form above.\n",
+      "format": "path",
+      "type": "string"
+    }
+  },
+  "required": [
+    "pathToDirectory"
+  ]
+}

--- a/servers/_host_port_/src/tools/get_vault_pathtodirectory_/schema/root.ts
+++ b/servers/_host_port_/src/tools/get_vault_pathtodirectory_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "pathToDirectory": z.string().describe("Path to list files from (relative to your vault root).  Note that empty directories will not be returned.\n\nNote: this particular interactive tool requires that you provide an argument for this field, but the API itself will allow you to list the root folder of your vault. If you would like to try listing content in the root of your vault using this interactive tool, use the above \"List files that exist in the root of your vault\" form above.\n")
+}

--- a/servers/_host_port_/src/tools/patch_active_/index.ts
+++ b/servers/_host_port_/src/tools/patch_active_/index.ts
@@ -1,0 +1,30 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "patch_active_",
+  "toolDescription": "Partially update content in the currently open note.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/active/",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "header": {
+      "Operation": "Operation",
+      "Target-Type": "Target-Type",
+      "Target-Delimiter": "Target-Delimiter",
+      "Target": "Target",
+      "Trim-Target-Whitespace": "Trim-Target-Whitespace"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/patch_active_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/patch_active_/schema-json/root.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "properties": {
+    "Operation": {
+      "description": "Patch operation to perform",
+      "enum": [
+        "append",
+        "prepend",
+        "replace"
+      ],
+      "type": "string"
+    },
+    "Target-Type": {
+      "description": "Type of target to patch",
+      "enum": [
+        "heading",
+        "block",
+        "frontmatter"
+      ],
+      "type": "string"
+    },
+    "Target-Delimiter": {
+      "description": "Delimiter to use for nested targets (i.e. Headings)",
+      "default": "::",
+      "type": "string"
+    },
+    "Target": {
+      "description": "Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n",
+      "type": "string"
+    },
+    "Trim-Target-Whitespace": {
+      "description": "Trim whitespace from Target before applying patch?",
+      "default": "false",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "Operation",
+    "Target-Type",
+    "Target"
+  ]
+}

--- a/servers/_host_port_/src/tools/patch_active_/schema/root.ts
+++ b/servers/_host_port_/src/tools/patch_active_/schema/root.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "Operation": z.enum(["append","prepend","replace"]).describe("Patch operation to perform"),
+  "Target-Type": z.enum(["heading","block","frontmatter"]).describe("Type of target to patch"),
+  "Target-Delimiter": z.string().describe("Delimiter to use for nested targets (i.e. Headings)").optional(),
+  "Target": z.string().describe("Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n"),
+  "Trim-Target-Whitespace": z.enum(["true","false"]).describe("Trim whitespace from Target before applying patch?").optional()
+}

--- a/servers/_host_port_/src/tools/patch_periodic_period_/index.ts
+++ b/servers/_host_port_/src/tools/patch_periodic_period_/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "patch_periodic_period_",
+  "toolDescription": "Partially update content in the current periodic note for the specified period.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "period": "period"
+    },
+    "header": {
+      "Operation": "Operation",
+      "Target-Type": "Target-Type",
+      "Target-Delimiter": "Target-Delimiter",
+      "Target": "Target",
+      "Trim-Target-Whitespace": "Trim-Target-Whitespace"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/patch_periodic_period_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/patch_periodic_period_/schema-json/root.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    },
+    "Operation": {
+      "description": "Patch operation to perform",
+      "enum": [
+        "append",
+        "prepend",
+        "replace"
+      ],
+      "type": "string"
+    },
+    "Target-Type": {
+      "description": "Type of target to patch",
+      "enum": [
+        "heading",
+        "block",
+        "frontmatter"
+      ],
+      "type": "string"
+    },
+    "Target-Delimiter": {
+      "description": "Delimiter to use for nested targets (i.e. Headings)",
+      "default": "::",
+      "type": "string"
+    },
+    "Target": {
+      "description": "Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n",
+      "type": "string"
+    },
+    "Trim-Target-Whitespace": {
+      "description": "Trim whitespace from Target before applying patch?",
+      "default": "false",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "period",
+    "Operation",
+    "Target-Type",
+    "Target"
+  ]
+}

--- a/servers/_host_port_/src/tools/patch_periodic_period_/schema/root.ts
+++ b/servers/_host_port_/src/tools/patch_periodic_period_/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note."),
+  "Operation": z.enum(["append","prepend","replace"]).describe("Patch operation to perform"),
+  "Target-Type": z.enum(["heading","block","frontmatter"]).describe("Type of target to patch"),
+  "Target-Delimiter": z.string().describe("Delimiter to use for nested targets (i.e. Headings)").optional(),
+  "Target": z.string().describe("Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n"),
+  "Trim-Target-Whitespace": z.enum(["true","false"]).describe("Trim whitespace from Target before applying patch?").optional()
+}

--- a/servers/_host_port_/src/tools/patch_periodic_period_year_month_day_/index.ts
+++ b/servers/_host_port_/src/tools/patch_periodic_period_year_month_day_/index.ts
@@ -1,0 +1,36 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "patch_periodic_period_year_month_day_",
+  "toolDescription": "Partially update content in the periodic note for the specified period and date.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/{year}/{month}/{day}/",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "year": "year",
+      "month": "month",
+      "day": "day",
+      "period": "period"
+    },
+    "header": {
+      "Operation": "Operation",
+      "Target-Type": "Target-Type",
+      "Target-Delimiter": "Target-Delimiter",
+      "Target": "Target",
+      "Trim-Target-Whitespace": "Trim-Target-Whitespace"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/patch_periodic_period_year_month_day_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/patch_periodic_period_year_month_day_/schema-json/root.json
@@ -1,0 +1,74 @@
+{
+  "type": "object",
+  "properties": {
+    "year": {
+      "description": "The year of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "month": {
+      "description": "The month (1-12) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "day": {
+      "description": "The day (1-31) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    },
+    "Operation": {
+      "description": "Patch operation to perform",
+      "enum": [
+        "append",
+        "prepend",
+        "replace"
+      ],
+      "type": "string"
+    },
+    "Target-Type": {
+      "description": "Type of target to patch",
+      "enum": [
+        "heading",
+        "block",
+        "frontmatter"
+      ],
+      "type": "string"
+    },
+    "Target-Delimiter": {
+      "description": "Delimiter to use for nested targets (i.e. Headings)",
+      "default": "::",
+      "type": "string"
+    },
+    "Target": {
+      "description": "Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n",
+      "type": "string"
+    },
+    "Trim-Target-Whitespace": {
+      "description": "Trim whitespace from Target before applying patch?",
+      "default": "false",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "month",
+    "day",
+    "period",
+    "Operation",
+    "Target-Type",
+    "Target"
+  ]
+}

--- a/servers/_host_port_/src/tools/patch_periodic_period_year_month_day_/schema/root.ts
+++ b/servers/_host_port_/src/tools/patch_periodic_period_year_month_day_/schema/root.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "year": z.number().describe("The year of the date for which you would like to grab a periodic note."),
+  "month": z.number().describe("The month (1-12) of the date for which you would like to grab a periodic note."),
+  "day": z.number().describe("The day (1-31) of the date for which you would like to grab a periodic note."),
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note."),
+  "Operation": z.enum(["append","prepend","replace"]).describe("Patch operation to perform"),
+  "Target-Type": z.enum(["heading","block","frontmatter"]).describe("Type of target to patch"),
+  "Target-Delimiter": z.string().describe("Delimiter to use for nested targets (i.e. Headings)").optional(),
+  "Target": z.string().describe("Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n"),
+  "Trim-Target-Whitespace": z.enum(["true","false"]).describe("Trim whitespace from Target before applying patch?").optional()
+}

--- a/servers/_host_port_/src/tools/patch_vault_filename_/index.ts
+++ b/servers/_host_port_/src/tools/patch_vault_filename_/index.ts
@@ -1,0 +1,33 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "patch_vault_filename_",
+  "toolDescription": "Partially update content in an existing note.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/{filename}",
+  "method": "patch",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    },
+    "header": {
+      "Operation": "Operation",
+      "Target-Type": "Target-Type",
+      "Target-Delimiter": "Target-Delimiter",
+      "Target": "Target",
+      "Trim-Target-Whitespace": "Trim-Target-Whitespace"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/patch_vault_filename_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/patch_vault_filename_/schema-json/root.json
@@ -1,0 +1,52 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "description": "Path to the relevant file (relative to your vault root).\n",
+      "format": "path",
+      "type": "string"
+    },
+    "Operation": {
+      "description": "Patch operation to perform",
+      "enum": [
+        "append",
+        "prepend",
+        "replace"
+      ],
+      "type": "string"
+    },
+    "Target-Type": {
+      "description": "Type of target to patch",
+      "enum": [
+        "heading",
+        "block",
+        "frontmatter"
+      ],
+      "type": "string"
+    },
+    "Target-Delimiter": {
+      "description": "Delimiter to use for nested targets (i.e. Headings)",
+      "default": "::",
+      "type": "string"
+    },
+    "Target": {
+      "description": "Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n",
+      "type": "string"
+    },
+    "Trim-Target-Whitespace": {
+      "description": "Trim whitespace from Target before applying patch?",
+      "default": "false",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "filename",
+    "Operation",
+    "Target-Type",
+    "Target"
+  ]
+}

--- a/servers/_host_port_/src/tools/patch_vault_filename_/schema/root.ts
+++ b/servers/_host_port_/src/tools/patch_vault_filename_/schema/root.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string().describe("Path to the relevant file (relative to your vault root).\n"),
+  "Operation": z.enum(["append","prepend","replace"]).describe("Patch operation to perform"),
+  "Target-Type": z.enum(["heading","block","frontmatter"]).describe("Type of target to patch"),
+  "Target-Delimiter": z.string().describe("Delimiter to use for nested targets (i.e. Headings)").optional(),
+  "Target": z.string().describe("Target to patch; this value can be URL-Encoded and *must*\nbe URL-Encoded if it includes non-ASCII characters.\n"),
+  "Trim-Target-Whitespace": z.enum(["true","false"]).describe("Trim whitespace from Target before applying patch?").optional()
+}

--- a/servers/_host_port_/src/tools/post_active_/index.ts
+++ b/servers/_host_port_/src/tools/post_active_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_active_",
+  "toolDescription": "Append content to the active file open in Obsidian.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/active/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_active_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_active_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/post_active_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_active_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/post_commands_commandid_/index.ts
+++ b/servers/_host_port_/src/tools/post_commands_commandid_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_commands_commandid_",
+  "toolDescription": "Execute a command.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/commands/{commandId}/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "commandId": "commandId"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_commands_commandid_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_commands_commandid_/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "commandId": {
+      "description": "The id of the command to execute",
+      "type": "string"
+    }
+  },
+  "required": [
+    "commandId"
+  ]
+}

--- a/servers/_host_port_/src/tools/post_commands_commandid_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_commands_commandid_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "commandId": z.string().describe("The id of the command to execute")
+}

--- a/servers/_host_port_/src/tools/post_open_filename_/index.ts
+++ b/servers/_host_port_/src/tools/post_open_filename_/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_open_filename_",
+  "toolDescription": "Open the specified document in the Obsidian user interface.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/open/{filename}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    },
+    "query": {
+      "newLeaf": "newLeaf"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_open_filename_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_open_filename_/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "description": "Path to the file to return (relative to your vault root).\n",
+      "format": "path",
+      "type": "string"
+    },
+    "newLeaf": {
+      "description": "Open this as a new leaf?",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/_host_port_/src/tools/post_open_filename_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_open_filename_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string().describe("Path to the file to return (relative to your vault root).\n"),
+  "newLeaf": z.boolean().describe("Open this as a new leaf?").optional()
+}

--- a/servers/_host_port_/src/tools/post_periodic_period_/index.ts
+++ b/servers/_host_port_/src/tools/post_periodic_period_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_periodic_period_",
+  "toolDescription": "Append content to the current periodic note for the specified period.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_periodic_period_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_periodic_period_/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/post_periodic_period_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_periodic_period_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/post_periodic_period_year_month_day_/index.ts
+++ b/servers/_host_port_/src/tools/post_periodic_period_year_month_day_/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_periodic_period_year_month_day_",
+  "toolDescription": "Append content to the periodic note for the specified period and date.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/{year}/{month}/{day}/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "year": "year",
+      "month": "month",
+      "day": "day",
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_periodic_period_year_month_day_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_periodic_period_year_month_day_/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "year": {
+      "description": "The year of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "month": {
+      "description": "The month (1-12) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "day": {
+      "description": "The day (1-31) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "month",
+    "day",
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/post_periodic_period_year_month_day_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_periodic_period_year_month_day_/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "year": z.number().describe("The year of the date for which you would like to grab a periodic note."),
+  "month": z.number().describe("The month (1-12) of the date for which you would like to grab a periodic note."),
+  "day": z.number().describe("The day (1-31) of the date for which you would like to grab a periodic note."),
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/post_search_/index.ts
+++ b/servers/_host_port_/src/tools/post_search_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_search_",
+  "toolDescription": "Search for documents matching a specified search query",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/search/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_search_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_search_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/post_search_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_search_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/post_search_simple_/index.ts
+++ b/servers/_host_port_/src/tools/post_search_simple_/index.ts
@@ -1,0 +1,27 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_search_simple_",
+  "toolDescription": "Search for documents matching a specified text query",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/search/simple/",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "query": {
+      "query": "query",
+      "contextLength": "contextLength"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_search_simple_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_search_simple_/schema-json/root.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "description": "Your search query",
+      "type": "string"
+    },
+    "contextLength": {
+      "description": "How much context to return around the matching string",
+      "default": 100,
+      "type": "number"
+    }
+  },
+  "required": [
+    "query"
+  ]
+}

--- a/servers/_host_port_/src/tools/post_search_simple_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_search_simple_/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "query": z.string().describe("Your search query"),
+  "contextLength": z.number().describe("How much context to return around the matching string").optional()
+}

--- a/servers/_host_port_/src/tools/post_vault_filename_/index.ts
+++ b/servers/_host_port_/src/tools/post_vault_filename_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "post_vault_filename_",
+  "toolDescription": "Append content to a new or existing file.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/{filename}",
+  "method": "post",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/post_vault_filename_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/post_vault_filename_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "description": "Path to the relevant file (relative to your vault root).\n",
+      "format": "path",
+      "type": "string"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/_host_port_/src/tools/post_vault_filename_/schema/root.ts
+++ b/servers/_host_port_/src/tools/post_vault_filename_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string().describe("Path to the relevant file (relative to your vault root).\n")
+}

--- a/servers/_host_port_/src/tools/put_active_/index.ts
+++ b/servers/_host_port_/src/tools/put_active_/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_active_",
+  "toolDescription": "Update the content of the active file open in Obsidian.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/active/",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {},
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/put_active_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/put_active_/schema-json/root.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/servers/_host_port_/src/tools/put_active_/schema/root.ts
+++ b/servers/_host_port_/src/tools/put_active_/schema/root.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {}

--- a/servers/_host_port_/src/tools/put_periodic_period_/index.ts
+++ b/servers/_host_port_/src/tools/put_periodic_period_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_periodic_period_",
+  "toolDescription": "Update the content of the current periodic note for the specified period.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/put_periodic_period_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/put_periodic_period_/schema-json/root.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/put_periodic_period_/schema/root.ts
+++ b/servers/_host_port_/src/tools/put_periodic_period_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/put_periodic_period_year_month_day_/index.ts
+++ b/servers/_host_port_/src/tools/put_periodic_period_year_month_day_/index.ts
@@ -1,0 +1,29 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_periodic_period_year_month_day_",
+  "toolDescription": "Update the content of the periodic note for the specified period and date.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/periodic/{period}/{year}/{month}/{day}/",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "year": "year",
+      "month": "month",
+      "day": "day",
+      "period": "period"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/put_periodic_period_year_month_day_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/put_periodic_period_year_month_day_/schema-json/root.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "year": {
+      "description": "The year of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "month": {
+      "description": "The month (1-12) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "day": {
+      "description": "The day (1-31) of the date for which you would like to grab a periodic note.",
+      "type": "number"
+    },
+    "period": {
+      "description": "The name of the period for which you would like to grab a periodic note.",
+      "default": "daily",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "yearly"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "month",
+    "day",
+    "period"
+  ]
+}

--- a/servers/_host_port_/src/tools/put_periodic_period_year_month_day_/schema/root.ts
+++ b/servers/_host_port_/src/tools/put_periodic_period_year_month_day_/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "year": z.number().describe("The year of the date for which you would like to grab a periodic note."),
+  "month": z.number().describe("The month (1-12) of the date for which you would like to grab a periodic note."),
+  "day": z.number().describe("The day (1-31) of the date for which you would like to grab a periodic note."),
+  "period": z.enum(["daily","weekly","monthly","quarterly","yearly"]).describe("The name of the period for which you would like to grab a periodic note.")
+}

--- a/servers/_host_port_/src/tools/put_vault_filename_/index.ts
+++ b/servers/_host_port_/src/tools/put_vault_filename_/index.ts
@@ -1,0 +1,26 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "put_vault_filename_",
+  "toolDescription": "Create a new file in your vault or update the content of an existing one.",
+  "baseUrl": "https://{host}:{port}",
+  "path": "/vault/{filename}",
+  "method": "put",
+  "security": [
+    {
+      "key": "Authorization",
+      "value": "Bearer <mcp-env-var>API_KEY</mcp-env-var>",
+      "in": "header",
+      "envVarName": "API_KEY"
+    }
+  ],
+  "paramsMap": {
+    "path": {
+      "filename": "filename"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/_host_port_/src/tools/put_vault_filename_/schema-json/root.json
+++ b/servers/_host_port_/src/tools/put_vault_filename_/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "filename": {
+      "description": "Path to the relevant file (relative to your vault root).\n",
+      "format": "path",
+      "type": "string"
+    }
+  },
+  "required": [
+    "filename"
+  ]
+}

--- a/servers/_host_port_/src/tools/put_vault_filename_/schema/root.ts
+++ b/servers/_host_port_/src/tools/put_vault_filename_/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "filename": z.string().describe("Path to the relevant file (relative to your vault root).\n")
+}

--- a/servers/_host_port_/tsconfig.json
+++ b/servers/_host_port_/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `_host_port_`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/_host_port_`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "_host_port_": {
      "command": "npx",
      "args": ["-y", "@open-mcp/_host_port_"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.