### PR TITLE
Add MCP server `api_example_com`

### DIFF
--- a/servers/api_example_com/.npmignore
+++ b/servers/api_example_com/.npmignore
@@ -1,0 +1,4 @@
+src/
+node_modules/
+.gitignore
+tsconfig.json

--- a/servers/api_example_com/README.md
+++ b/servers/api_example_com/README.md
@@ -1,0 +1,235 @@
+# @open-mcp/api_example_com
+
+## Using the remote server
+
+To use the hosted Streamable HTTP server, add the following to your client config:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "transport": "streamableHttp",
+      "url": "https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp"
+    }
+  }
+}
+```
+
+#### Forwarding variables
+
+You can forward "environment" variables to the remote server by including them in the request headers or URL query string (headers take precedence). Just prefix the variable name with `FORWARD_VAR_` like so:
+
+```ini
+https://mcp.open-mcp.org/api/server/api_example_com@latest/mcp?FORWARD_VAR_OPEN_MCP_BASE_URL=https%3A%2F%2Fapi.example.com
+```
+
+<Callout title="Security" type="warn">
+  Sending authentication tokens as forwarded variables is not recommended
+</Callout>
+
+## Installing locally
+
+If you want to run the server locally on your own machine instead of using the remote server, first set the environment variables as shell variables:
+
+```bash
+# No environment variables required for this server
+```
+
+Then use the OpenMCP config CLI to add the server to your MCP client:
+
+### Claude desktop
+
+```bash
+npx @open-mcp/config add api_example_com \
+  ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+### Cursor
+
+Run this from the root of your project directory or, to add to all cursor projects, run it from your home directory `~`.
+
+```bash
+npx @open-mcp/config add api_example_com \
+  .cursor/mcp.json
+```
+
+### Other
+
+```bash
+npx @open-mcp/config add api_example_com \
+  /path/to/client/config.json
+```
+
+### Manually
+
+If you don't want to use the helper above, add the following to your MCP client config manually:
+
+```json
+{
+  "mcpServers": {
+    "api_example_com": {
+      "command": "npx",
+      "args": ["-y", "@open-mcp/api_example_com"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Environment variables
+
+- `OPEN_MCP_BASE_URL` - overwrites the base URL of every tool's underlying API request
+
+
+## Tools
+
+### expandSchema
+
+Expand the input schema for a tool before calling the tool
+
+**Input schema**
+
+- `toolName` (string)
+- `jsonPointers` (array)
+
+### get_playtimeleaderboard
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `page` (number)
+- `limit` (number)
+- `sort` (string)
+- `search` (string)
+
+### get_playtimeleaderboardplayer
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `player` (string)
+- `sort` (string)
+
+### get_votesleaderboard
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `page` (number)
+- `limit` (number)
+- `sort` (string)
+- `search` (string)
+
+### get_votesleaderboardplayer
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `player` (string)
+- `sort` (string)
+
+### get_punishments
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `page` (number)
+- `limit` (number)
+- `sort` (string)
+- `search` (string)
+
+### get_punishmentsplayer
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `player` (string)
+- `page` (number)
+- `limit` (number)
+- `sort` (string)
+
+### get_discorduser
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `player` (string)
+
+### get_clans
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `page` (number)
+- `limit` (number)
+- `sort` (string)
+- `search` (string)
+
+### get_clanplayer
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `player` (string)
+
+### get_clansinfo
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `tag` (string)
+- `sort` (string)
+
+### get_players
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `page` (number)
+- `limit` (number)
+- `sort` (string)
+- `search` (string)
+
+### get_playersplayer
+
+**Environment variables**
+
+No environment variables required
+
+**Input schema**
+
+- `player` (string)
+- `sort` (string)

--- a/servers/api_example_com/package.json
+++ b/servers/api_example_com/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@open-mcp/api_example_com",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "api_example_com": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "copy-json-schema": "mkdir -p dist/tools && find src/tools -type d -name 'schema-json' -exec sh -c 'mkdir -p dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\") && cp -r {} dist/tools/$(dirname {} | sed \"s/src\\/tools\\///\")/' \\;",
+    "prebuild": "npm run clean && npm run copy-json-schema",
+    "build": "tsc && chmod 755 dist/index.js",
+    "test": "echo \"No test specified\"",
+    "prepublishOnly": "npm install && npm run build && npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@open-mcp/core": "latest",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/servers/api_example_com/src/constants.ts
+++ b/servers/api_example_com/src/constants.ts
@@ -1,0 +1,17 @@
+export const OPENAPI_URL = "https://apiv2.arcticbd.net/openapi.json"
+export const SERVER_NAME = "api_example_com"
+export const SERVER_VERSION = "0.0.1"
+export const OPERATION_FILES_RELATIVE = [
+  "./tools/get_playtimeleaderboard/index.js",
+  "./tools/get_playtimeleaderboardplayer/index.js",
+  "./tools/get_votesleaderboard/index.js",
+  "./tools/get_votesleaderboardplayer/index.js",
+  "./tools/get_punishments/index.js",
+  "./tools/get_punishmentsplayer/index.js",
+  "./tools/get_discorduser/index.js",
+  "./tools/get_clans/index.js",
+  "./tools/get_clanplayer/index.js",
+  "./tools/get_clansinfo/index.js",
+  "./tools/get_players/index.js",
+  "./tools/get_playersplayer/index.js"
+]

--- a/servers/api_example_com/src/index.ts
+++ b/servers/api_example_com/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const TOOLS_ARG_NAME = "--tools"
+
+function parseCSV(csv: string | undefined) {
+  if (!csv) {
+    return undefined
+  }
+  const arr = csv
+    .trim()
+    .split(",")
+    .filter((x) => x !== "")
+  return arr.length > 0 ? arr : undefined
+}
+
+import("./server.js").then((module) => {
+  const args = process.argv.slice(2)
+  const toolsCSV = args
+    .find((arg) => arg.startsWith(TOOLS_ARG_NAME))
+    ?.replace(TOOLS_ARG_NAME, "")
+
+  const toolNames = parseCSV(toolsCSV)
+
+  module.runServer({ toolNames }).catch((error) => {
+    console.error("Fatal error running server:", error)
+    process.exit(1)
+  })
+})

--- a/servers/api_example_com/src/server.ts
+++ b/servers/api_example_com/src/server.ts
@@ -1,0 +1,33 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { registerTools } from "@open-mcp/core"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  OPERATION_FILES_RELATIVE,
+} from "./constants.js"
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+})
+
+export async function runServer({ toolNames }: { toolNames?: string[] }) {
+  try {
+    const tools: OpenMCPServerTool[] = []
+    for (const file of OPERATION_FILES_RELATIVE) {
+      const tool = (await import(file)).default as OpenMCPServerTool
+      if (!toolNames || toolNames.includes(tool.toolName)) {
+        tools.push(tool)
+      }
+    }
+    await registerTools(server, tools)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    console.error("MCP Server running on stdio")
+  } catch (error) {
+    console.error("Error during initialization:", error)
+    process.exit(1)
+  }
+}

--- a/servers/api_example_com/src/tools/get_clanplayer/index.ts
+++ b/servers/api_example_com/src/tools/get_clanplayer/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_clanplayer",
+  "toolDescription": "Get player's clan information",
+  "baseUrl": "https://api.example.com",
+  "path": "/survival/clans/player/{player}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "player": "player"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_clanplayer/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_clanplayer/schema-json/root.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "player": {
+      "description": "Player name",
+      "type": "string",
+      "example": "Udoy"
+    }
+  },
+  "required": [
+    "player"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_clanplayer/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_clanplayer/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "player": z.string().describe("Player name")
+}

--- a/servers/api_example_com/src/tools/get_clans/index.ts
+++ b/servers/api_example_com/src/tools/get_clans/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_clans",
+  "toolDescription": "Get clans information the Survival server",
+  "baseUrl": "https://api.example.com",
+  "path": "/survival/clans",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "page": "page",
+      "limit": "limit",
+      "sort": "sort",
+      "search": "search"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_clans/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_clans/schema-json/root.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "description": "Page number",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of items per page",
+      "type": "number"
+    },
+    "sort": {
+      "description": "Sort by",
+      "type": "string",
+      "enum": [
+        "playtime",
+        "worth",
+        "balance",
+        "votes",
+        "kdr",
+        "deaths",
+        "kills"
+      ],
+      "default": "playtime"
+    },
+    "search": {
+      "description": "Search query for filtering",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_clans/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_clans/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().describe("Page number").optional(),
+  "limit": z.number().describe("Number of items per page").optional(),
+  "sort": z.enum(["playtime","worth","balance","votes","kdr","deaths","kills"]).describe("Sort by").optional(),
+  "search": z.string().describe("Search query for filtering").optional()
+}

--- a/servers/api_example_com/src/tools/get_clansinfo/index.ts
+++ b/servers/api_example_com/src/tools/get_clansinfo/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_clansinfo",
+  "toolDescription": "Get clan information",
+  "baseUrl": "https://api.example.com",
+  "path": "/survival/clans/{tag}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "tag": "tag"
+    },
+    "query": {
+      "sort": "sort"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_clansinfo/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_clansinfo/schema-json/root.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "tag": {
+      "description": "Clan tag",
+      "type": "string"
+    },
+    "sort": {
+      "description": "Sort by",
+      "type": "string",
+      "enum": [
+        "playtime",
+        "worth",
+        "balance",
+        "votes",
+        "kdr",
+        "deaths",
+        "kills"
+      ],
+      "default": "playtime"
+    }
+  },
+  "required": [
+    "tag"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_clansinfo/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_clansinfo/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "tag": z.string().describe("Clan tag"),
+  "sort": z.enum(["playtime","worth","balance","votes","kdr","deaths","kills"]).describe("Sort by").optional()
+}

--- a/servers/api_example_com/src/tools/get_discorduser/index.ts
+++ b/servers/api_example_com/src/tools/get_discorduser/index.ts
@@ -1,0 +1,19 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_discorduser",
+  "toolDescription": "Get discord user id from player name",
+  "baseUrl": "https://api.example.com",
+  "path": "/discord/{player}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "player": "player"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_discorduser/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_discorduser/schema-json/root.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "player": {
+      "description": "Player name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "player"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_discorduser/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_discorduser/schema/root.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "player": z.string().describe("Player name")
+}

--- a/servers/api_example_com/src/tools/get_players/index.ts
+++ b/servers/api_example_com/src/tools/get_players/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_players",
+  "toolDescription": "Get survival players information",
+  "baseUrl": "https://api.example.com",
+  "path": "/survival/players",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "page": "page",
+      "limit": "limit",
+      "sort": "sort",
+      "search": "search"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_players/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_players/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "description": "Page number",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of items per page",
+      "type": "number"
+    },
+    "sort": {
+      "description": "Sort by monthly or all time votes",
+      "type": "string",
+      "enum": [
+        "MonthTotal",
+        "AllTimeTotal"
+      ],
+      "default": "MonthTotal"
+    },
+    "search": {
+      "description": "Search query for filtering",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_players/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_players/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().describe("Page number").optional(),
+  "limit": z.number().describe("Number of items per page").optional(),
+  "sort": z.enum(["MonthTotal","AllTimeTotal"]).describe("Sort by monthly or all time votes").optional(),
+  "search": z.string().describe("Search query for filtering").optional()
+}

--- a/servers/api_example_com/src/tools/get_playersplayer/index.ts
+++ b/servers/api_example_com/src/tools/get_playersplayer/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_playersplayer",
+  "toolDescription": "Get player's survival server information",
+  "baseUrl": "https://api.example.com",
+  "path": "/survival/players/{player}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "player": "player"
+    },
+    "query": {
+      "sort": "sort"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_playersplayer/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_playersplayer/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "player": {
+      "description": "Player name",
+      "type": "string"
+    },
+    "sort": {
+      "description": "Sort by monthly or all time votes",
+      "type": "string",
+      "enum": [
+        "MonthTotal",
+        "AllTimeTotal"
+      ],
+      "default": "MonthTotal"
+    }
+  },
+  "required": [
+    "player"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_playersplayer/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_playersplayer/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "player": z.string().describe("Player name"),
+  "sort": z.enum(["MonthTotal","AllTimeTotal"]).describe("Sort by monthly or all time votes").optional()
+}

--- a/servers/api_example_com/src/tools/get_playtimeleaderboard/index.ts
+++ b/servers/api_example_com/src/tools/get_playtimeleaderboard/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_playtimeleaderboard",
+  "toolDescription": "Get lobby playtime leaderboard",
+  "baseUrl": "https://api.example.com",
+  "path": "/leaderboard/lobby/playtime",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "page": "page",
+      "limit": "limit",
+      "sort": "sort",
+      "search": "search"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_playtimeleaderboard/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_playtimeleaderboard/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "description": "Page number",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of items per page",
+      "type": "number"
+    },
+    "sort": {
+      "description": "Sort by ascending or descending",
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "DESC"
+    },
+    "search": {
+      "description": "Search query for filtering",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_playtimeleaderboard/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_playtimeleaderboard/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().describe("Page number").optional(),
+  "limit": z.number().describe("Number of items per page").optional(),
+  "sort": z.enum(["ASC","DESC"]).describe("Sort by ascending or descending").optional(),
+  "search": z.string().describe("Search query for filtering").optional()
+}

--- a/servers/api_example_com/src/tools/get_playtimeleaderboardplayer/index.ts
+++ b/servers/api_example_com/src/tools/get_playtimeleaderboardplayer/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_playtimeleaderboardplayer",
+  "toolDescription": "Get lobby playtime leaderboard data of a player",
+  "baseUrl": "https://api.example.com",
+  "path": "/leaderboard/lobby/playtime/{player}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "player": "player"
+    },
+    "query": {
+      "sort": "sort"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_playtimeleaderboardplayer/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_playtimeleaderboardplayer/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "player": {
+      "description": "Player name",
+      "type": "string"
+    },
+    "sort": {
+      "description": "Sort by ascending or descending",
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "DESC"
+    }
+  },
+  "required": [
+    "player"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_playtimeleaderboardplayer/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_playtimeleaderboardplayer/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "player": z.string().describe("Player name"),
+  "sort": z.enum(["ASC","DESC"]).describe("Sort by ascending or descending").optional()
+}

--- a/servers/api_example_com/src/tools/get_punishments/index.ts
+++ b/servers/api_example_com/src/tools/get_punishments/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_punishments",
+  "toolDescription": "Get latest punishments list",
+  "baseUrl": "https://api.example.com",
+  "path": "/punishments",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "page": "page",
+      "limit": "limit",
+      "sort": "sort",
+      "search": "search"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_punishments/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_punishments/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "description": "Page number",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of items per page",
+      "type": "number"
+    },
+    "sort": {
+      "description": "Sort by ascending or descending",
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "DESC"
+    },
+    "search": {
+      "description": "Search query for filtering",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_punishments/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_punishments/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().describe("Page number").optional(),
+  "limit": z.number().describe("Number of items per page").optional(),
+  "sort": z.enum(["ASC","DESC"]).describe("Sort by ascending or descending").optional(),
+  "search": z.string().describe("Search query for filtering").optional()
+}

--- a/servers/api_example_com/src/tools/get_punishmentsplayer/index.ts
+++ b/servers/api_example_com/src/tools/get_punishmentsplayer/index.ts
@@ -1,0 +1,24 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_punishmentsplayer",
+  "toolDescription": "Get punishments list of a player",
+  "baseUrl": "https://api.example.com",
+  "path": "/punishments/{player}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "player": "player"
+    },
+    "query": {
+      "page": "page",
+      "limit": "limit",
+      "sort": "sort"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_punishmentsplayer/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_punishmentsplayer/schema-json/root.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "player": {
+      "description": "Player name",
+      "type": "string"
+    },
+    "page": {
+      "description": "Page number",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of items per page",
+      "type": "number"
+    },
+    "sort": {
+      "description": "Sort by ascending or descending",
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "DESC"
+    }
+  },
+  "required": [
+    "player"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_punishmentsplayer/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_punishmentsplayer/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "player": z.string().describe("Player name"),
+  "page": z.number().describe("Page number").optional(),
+  "limit": z.number().describe("Number of items per page").optional(),
+  "sort": z.enum(["ASC","DESC"]).describe("Sort by ascending or descending").optional()
+}

--- a/servers/api_example_com/src/tools/get_votesleaderboard/index.ts
+++ b/servers/api_example_com/src/tools/get_votesleaderboard/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_votesleaderboard",
+  "toolDescription": "Get vote count leaderboard",
+  "baseUrl": "https://api.example.com",
+  "path": "/leaderboard/votes",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "query": {
+      "page": "page",
+      "limit": "limit",
+      "sort": "sort",
+      "search": "search"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_votesleaderboard/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_votesleaderboard/schema-json/root.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "description": "Page number",
+      "type": "number"
+    },
+    "limit": {
+      "description": "Number of items per page",
+      "type": "number"
+    },
+    "sort": {
+      "description": "Sort by monthly or all time votes",
+      "type": "string",
+      "enum": [
+        "MonthTotal",
+        "AllTimeTotal"
+      ],
+      "default": "MonthTotal"
+    },
+    "search": {
+      "description": "Search query for filtering",
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/servers/api_example_com/src/tools/get_votesleaderboard/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_votesleaderboard/schema/root.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "page": z.number().describe("Page number").optional(),
+  "limit": z.number().describe("Number of items per page").optional(),
+  "sort": z.enum(["MonthTotal","AllTimeTotal"]).describe("Sort by monthly or all time votes").optional(),
+  "search": z.string().describe("Search query for filtering").optional()
+}

--- a/servers/api_example_com/src/tools/get_votesleaderboardplayer/index.ts
+++ b/servers/api_example_com/src/tools/get_votesleaderboardplayer/index.ts
@@ -1,0 +1,22 @@
+import { inputParamsSchema } from "./schema/root.js"
+import type { OpenMCPServerTool } from "@open-mcp/core"
+
+const tool: OpenMCPServerTool = {
+  "toolName": "get_votesleaderboardplayer",
+  "toolDescription": "Get vote count leaderboard data of a player",
+  "baseUrl": "https://api.example.com",
+  "path": "/leaderboard/votes/{player}",
+  "method": "get",
+  "security": [],
+  "paramsMap": {
+    "path": {
+      "player": "player"
+    },
+    "query": {
+      "sort": "sort"
+    }
+  },
+  inputParamsSchema
+}
+
+export default tool

--- a/servers/api_example_com/src/tools/get_votesleaderboardplayer/schema-json/root.json
+++ b/servers/api_example_com/src/tools/get_votesleaderboardplayer/schema-json/root.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "player": {
+      "description": "Player name",
+      "type": "string"
+    },
+    "sort": {
+      "description": "Sort by monthly or all time votes",
+      "type": "string",
+      "enum": [
+        "MonthTotal",
+        "AllTimeTotal"
+      ],
+      "default": "MonthTotal"
+    }
+  },
+  "required": [
+    "player"
+  ]
+}

--- a/servers/api_example_com/src/tools/get_votesleaderboardplayer/schema/root.ts
+++ b/servers/api_example_com/src/tools/get_votesleaderboardplayer/schema/root.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const inputParamsSchema = {
+  "player": z.string().describe("Player name"),
+  "sort": z.enum(["MonthTotal","AllTimeTotal"]).describe("Sort by monthly or all time votes").optional()
+}

--- a/servers/api_example_com/tsconfig.json
+++ b/servers/api_example_com/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR was created automatically by the OpenMCP bot in response to someone submitting an OpenAPI spec on https://www.open-mcp.org/.

It adds support for a new MCP server `api_example_com`.

## Installing

Once this PR is merged the server will be available as an npm package called `@open-mcp/api_example_com`, which you'll be able to add to your MCP client config like this:

```json
{
  "mcpServers": {
    "api_example_com": {
      "command": "npx",
      "args": ["-y", "@open-mcp/api_example_com"],
    }
  }
}
```

In the meantime you can pull this branch to install and build the server manually.

## Beta warning

This is an early beta so some things won't work as expected, but we're working fast and confident that most edge cases will be ironed out soon.